### PR TITLE
fix [Adriane]: removed password in confirmation modal

### DIFF
--- a/client-side/src/components/common/ConfirmationModal.jsx
+++ b/client-side/src/components/common/ConfirmationModal.jsx
@@ -27,9 +27,6 @@ function ConfirmationModal({ formData, onSubmit, onCancel }) {
               <strong>Last Name:</strong> {formData.last_name}
             </p>
             <p>
-              <strong>Password:</strong> {formData.password}
-            </p>
-            <p>
               <strong>Email:</strong> {formData.email}
             </p>
             <p>


### PR DESCRIPTION
A fix to task: "Password must hidden, because confidential"