### PR TITLE
fix [Adriane]: resolved deprecated mongodb warnings

### DIFF
--- a/server-side/server.js
+++ b/server-side/server.js
@@ -19,8 +19,6 @@ app.use(bodyParser.json());
 //Connection to Mongoose
 mongoose
   .connect(mongodbConnection(), {
-    useNewUrlParser: true,
-    useUnifiedTopology: true,
     dbName: "psits",
   })
   .then(() => console.log("MongoDB connected"))


### PR DESCRIPTION
Removed useNewUrlParser & useUnifiedTopology because they are deprecated. These options were introduced in previous versions of the MongoDB Node.js driver to address specific issues and provide better stability. However, the functionality they provided has since been integrated directly into the driver itself in version 4.0.0 and later.