### PR TITLE
feat: implement campus-based access control for admin and student routes

### DIFF
--- a/client-side-ts/src/components/common/AdminCampusRouteGuard.tsx
+++ b/client-side-ts/src/components/common/AdminCampusRouteGuard.tsx
@@ -1,0 +1,24 @@
+import ProtectedRoute from "@/components/common/ProtectedRoute";
+import type { Campus } from "@/features/auth/types/auth.types";
+
+interface CampusRouteGuardProps {
+  allowedCampuses: Campus[];
+}
+
+/**
+ * A route guard that requires the user to be an Admin and belong to one
+ * of the specified campuses.
+ *
+ * @example
+ * <Route Component={<AdminCampusRouteGuard allowedCampuses={["UC-Main"]} />}>
+ *   <Route path="some-uc-main-page" Component={SomeUcMainPage} />
+ * </Route>
+ */
+export function AdminCampusRouteGuard({ allowedCampuses }: CampusRouteGuardProps) {
+  return (
+    <ProtectedRoute
+      allowedRoles={["Admin"]}
+      allowedCampuses={allowedCampuses}
+    />
+  );
+}

--- a/client-side-ts/src/components/common/CampusView.tsx
+++ b/client-side-ts/src/components/common/CampusView.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { useCampusCheck } from "@/features/auth/hooks/useCampusCheck";
+import type { Campus } from "@/features/auth/types/auth.types";
+
+interface CampusViewProps {
+  /** The list of campuses that are allowed to see the content. */
+  allowedCampuses: Campus[];
+  /** The user role required to view the content. Defaults to "Admin". */
+  role?: "Admin" | "Student";
+  /** The content to render if the user's campus is in the allowed list. */
+  children: React.ReactNode;
+}
+
+/**
+ * A wrapper component that only renders its children if the authenticated
+ * user has the required role and belongs to one of the specified campuses.
+ *
+ * It renders nothing if the user does not have the required role or if
+ * their campus is not in the `allowedCampuses` list.
+ */
+export function CampusView({
+  allowedCampuses,
+  role = "Admin",
+  children,
+}: CampusViewProps) {
+  const canView = useCampusCheck(allowedCampuses, role);
+
+  return canView ? <>{children}</> : null;
+}

--- a/client-side-ts/src/components/common/ProtectedRoute.tsx
+++ b/client-side-ts/src/components/common/ProtectedRoute.tsx
@@ -1,9 +1,12 @@
-import { Navigate, Outlet } from "react-router";
+import { Navigate, Outlet } from "react-router-dom";
 import { useAuth } from "@/features/auth";
+import type { Campus } from "@/features/auth/types/auth.types";
 
 interface ProtectedRouteProps {
   /** Which roles are allowed through. Omit to allow any authenticated user. */
   allowedRoles?: Array<"Admin" | "Student">;
+  /** Which campuses are allowed. Only applies to Admins. Omit to allow all. */
+  allowedCampuses?: Campus[];
   /** Where to redirect unauthenticated users. Defaults to /auth/login. */
   redirectTo?: string;
 }
@@ -14,10 +17,12 @@ interface ProtectedRouteProps {
  * - While auth is loading (silent refresh), shows a centered spinner.
  * - Redirects unauthenticated users to the login page.
  * - If `allowedRoles` is set, redirects users whose role isn't in the list.
+ * - If `allowedCampuses` is set, redirects admins whose campus isn't in the list.
  * - Otherwise renders `<Outlet />` (child routes).
  */
 export default function ProtectedRoute({
   allowedRoles,
+  allowedCampuses,
   redirectTo = "/auth/login",
 }: ProtectedRouteProps) {
   const { user, isAuthenticated, isLoading } = useAuth();
@@ -37,6 +42,16 @@ export default function ProtectedRoute({
   if (allowedRoles && user && !allowedRoles.includes(user.role)) {
     // User is authenticated but lacks role — send to a safe landing page
     return <Navigate to="/" replace />;
+  }
+
+  if (
+    allowedCampuses &&
+    user &&
+    !allowedCampuses.includes(user.campus)
+  ) {
+    // User's campus is not allowed, send to a safe dashboard based on role
+    const fallback = user.role === "Admin" ? "/admin" : "/";
+    return <Navigate to={fallback} replace />;
   }
 
   return <Outlet />;

--- a/client-side-ts/src/components/common/StudentCampusRouteGuard.tsx
+++ b/client-side-ts/src/components/common/StudentCampusRouteGuard.tsx
@@ -1,0 +1,26 @@
+import ProtectedRoute from "@/components/common/ProtectedRoute";
+import type { Campus } from "@/features/auth/types/auth.types";
+
+interface CampusRouteGuardProps {
+  allowedCampuses: Campus[];
+}
+
+/**
+ * A route guard that requires the user to be a Student and belong to one
+ * of the specified campuses.
+ *
+ * @example
+ * <Route element={<StudentCampusRouteGuard allowedCampuses={["UC-Main"]} />}>
+ *   <Route path="student-uc-main-only" element={SomeStudentPage} />
+ * </Route>
+ */
+export function StudentCampusRouteGuard({
+  allowedCampuses,
+}: CampusRouteGuardProps) {
+  return (
+    <ProtectedRoute
+      allowedRoles={["Student"]}
+      allowedCampuses={allowedCampuses}
+    />
+  );
+}

--- a/client-side-ts/src/features/auth/hooks/useCampusCheck.ts
+++ b/client-side-ts/src/features/auth/hooks/useCampusCheck.ts
@@ -1,0 +1,22 @@
+import { useAuth } from "@/features/auth";
+import type { Campus } from "@/features/auth/types/auth.types";
+
+/**
+ * A hook to check if the current user belongs to one of the specified campuses.
+ *
+ * @param allowedCampuses An array of campuses that are allowed.
+ * @param requiredRole The role required to check against. Defaults to "Admin".
+ * @returns `true` if the user has the required role and their campus is in the list, otherwise `false`.
+ */
+export function useCampusCheck(
+  allowedCampuses: Campus[],
+  requiredRole: "Admin" | "Student" = "Admin"
+): boolean {
+  const { user } = useAuth();
+
+  if (!user || user.role !== requiredRole || !user.campus) {
+    return false;
+  }
+
+  return allowedCampuses.includes(user.campus);
+}

--- a/client-side-ts/src/features/auth/types/auth.types.ts
+++ b/client-side-ts/src/features/auth/types/auth.types.ts
@@ -1,9 +1,11 @@
+export type Campus = "UC-Main" | "UC-Banilad" | "UC-LM" | "UC-PT" | "UC-CS";
+
 /** User object returned by the backend on login/refresh. */
 export type User = {
   id: string;
   idNumber: string;
   role: "Admin" | "Student";
-  campus: string;
+  campus: Campus;
   name?: string;
   email?: string;
   course?: string;

--- a/client-side-ts/src/pages/admin/GeneralAdminPage.tsx
+++ b/client-side-ts/src/pages/admin/GeneralAdminPage.tsx
@@ -1,0 +1,23 @@
+import { CampusView } from "@/components/common/CampusView";
+
+export default function GeneralAdminPage() {
+  return (
+    <div className="p-4">
+      <h1 className="mb-4 text-2xl font-bold">General Admin Page</h1>
+      <p className="mb-4">
+        This is a general page accessible to all admins, regardless of campus.
+      </p>
+
+      {/* Conditional UI for UC-Main Admins */}
+      <CampusView allowedCampuses={["UC-Main"]} role="Admin">
+        <div className="relative rounded border border-green-400 bg-green-100 px-4 py-3 text-green-700">
+          <strong className="font-bold">UC-Main Specific Content:</strong>
+          <span className="block sm:inline">
+            {" "}
+            Welcome, Main Campus Admin! Here are your exclusive controls.
+          </span>
+        </div>
+      </CampusView>
+    </div>
+  );
+}

--- a/client-side-ts/src/pages/admin/MainCampusFinancePage.tsx
+++ b/client-side-ts/src/pages/admin/MainCampusFinancePage.tsx
@@ -1,0 +1,8 @@
+export function MainCampusFinancePage() {
+  return (
+    <div>
+      <h1 className="text-2xl font-bold">Main Campus Finances</h1>
+      <p>This page is only visible to admins from UC-Main.</p>
+    </div>
+  );
+}

--- a/client-side-ts/src/pages/student/GeneralStudentPage.tsx
+++ b/client-side-ts/src/pages/student/GeneralStudentPage.tsx
@@ -1,0 +1,23 @@
+import { CampusView } from "@/components/common/CampusView";
+
+export default function GeneralStudentPage() {
+  return (
+    <div className="p-4">
+      <h1 className="mb-4 text-2xl font-bold">General Student Page</h1>
+      <p className="mb-4">
+        This is a general page accessible to all students, regardless of campus.
+      </p>
+
+      {/* Conditional UI for UC-Main Students */}
+      <CampusView allowedCampuses={["UC-Main"]} role="Student">
+        <div className="relative rounded border border-blue-400 bg-blue-100 px-4 py-3 text-blue-700">
+          <strong className="font-bold">UC-Main Specific Content:</strong>
+          <span className="block sm:inline">
+            {" "}
+            Welcome, Main Campus Student! Here are your exclusive updates.
+          </span>
+        </div>
+      </CampusView>
+    </div>
+  );
+}

--- a/client-side-ts/src/pages/student/MainCampusStudentPage.tsx
+++ b/client-side-ts/src/pages/student/MainCampusStudentPage.tsx
@@ -1,0 +1,11 @@
+export default function MainCampusStudentPage() {
+  return (
+    <div className="p-4">
+      <h1 className="mb-4 text-2xl font-bold">Main Campus Student Page</h1>
+      <p>
+        This page is strictly restricted to students from the UC-Main campus. If
+        you are seeing this, you are a UC-Main student.
+      </p>
+    </div>
+  );
+}

--- a/client-side-ts/src/router.tsx
+++ b/client-side-ts/src/router.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter, Outlet } from "react-router";
+import { createBrowserRouter, Outlet } from "react-router-dom";
 import { MainLayout } from "./layouts/MainLayout";
 import { AdminLayout } from "./layouts/AdminLayout";
 import { Home } from "./pages/home";
@@ -11,7 +11,7 @@ import { Cart } from "./pages/orders/components/Cart";
 import OTPCode from "./pages/auth/OtpCode";
 import { PrivacyPolicy } from "./pages/PrivacyPolicy";
 import { TermsOfCondition } from "./pages/TermsOfCondition";
-import Dashboard  from "./pages/admin/Dashboard";
+import Dashboard from "./pages/admin/Dashboard";
 import EventManagement from "./pages/admin/EventManagement";
 import { ErrorPage } from "./pages/ErrorPage";
 import Login from "./pages/auth/Login";
@@ -23,8 +23,14 @@ import EventAttendance from "./pages/student/EventAttendance";
 import MyOrders from "./pages/student/MyOrders";
 import StudentLayout from "./layouts/StudentLayout";
 import { AdminRouteGuard } from "./components/common/RouteGuards";
+import { AdminCampusRouteGuard } from "./components/common/AdminCampusRouteGuard";
+import { StudentCampusRouteGuard } from "./components/common/StudentCampusRouteGuard";
+import { MainCampusFinancePage } from "./pages/admin/MainCampusFinancePage";
+import GeneralStudentPage from "./pages/student/GeneralStudentPage";
+import GeneralAdminPage from "./pages/admin/GeneralAdminPage";
+import MainCampusStudentPage from "./pages/student/MainCampusStudentPage";
 
-export default createBrowserRouter([
+const router = createBrowserRouter([
   {
     path: "/",
     Component: Outlet,
@@ -49,6 +55,18 @@ export default createBrowserRouter([
               { path: "event-attendance", Component: EventAttendance },
               { path: "my-orders", Component: MyOrders },
               { path: "account-settings", Component: AccountSettings },
+              // TODO: Remove this sample
+              // Example of a general student page with campus-specific component
+              { path: "general", Component: GeneralStudentPage },
+              // TODO: Remove this sample
+              // Example of a campus-specific student route
+              {
+                path: "main-campus",
+                element: (
+                  <StudentCampusRouteGuard allowedCampuses={["UC-Main"]} />
+                ),
+                children: [{ index: true, Component: MainCampusStudentPage }],
+              },
             ],
           },
         ],
@@ -78,10 +96,22 @@ export default createBrowserRouter([
               { index: true, Component: Dashboard },
               { path: "events", Component: EventManagement },
               { path: "events/:eventId", Component: EventManagement },
+              // TODO: Remove this sample
+              // Example of a general admin page with campus-specific component
+              { path: "general", Component: GeneralAdminPage },
             ],
+          },
+          // TODO: Remove this sample
+          // Example of a campus-specific route
+          {
+            path: "finances",
+            element: <AdminCampusRouteGuard allowedCampuses={["UC-Main"]} />,
+            children: [{ index: true, Component: MainCampusFinancePage }],
           },
         ],
       },
     ],
   },
 ]);
+
+export default router;


### PR DESCRIPTION
This pull request introduces campus-based access control for both admin and student users, allowing certain pages and components to be restricted based on a user's campus affiliation. It adds new route guards, a reusable campus-aware view component, and updates the user type to use a strongly-typed campus enum. Sample pages and routes demonstrate these features for both admin and student flows.

Campus-based access control:

* Added a `Campus` type to `auth.types.ts` and updated the `User` type to use it instead of a generic string, ensuring campus values are validated and consistent.
* Implemented new route guards: `AdminCampusRouteGuard` and `StudentCampusRouteGuard`, which restrict access to routes based on both role and campus. [[1]](diffhunk://#diff-3e21ce124573fa7b0864ab871e544b30c6a292533381c8921af3375c32d6fbb5R1-R24) [[2]](diffhunk://#diff-b3985e92a55c8b4476486253db2c8da039c30f7856132b9695ab89a8fec4b900R1-R26)
* Updated `ProtectedRoute` to support campus restrictions for admins, redirecting unauthorized users to appropriate dashboards. [[1]](diffhunk://#diff-66b5e620332fecb547d47ef07a13e701f992a4ca9f292ccded6fea2cb1b74033L1-R9) [[2]](diffhunk://#diff-66b5e620332fecb547d47ef07a13e701f992a4ca9f292ccded6fea2cb1b74033R20-R25) [[3]](diffhunk://#diff-66b5e620332fecb547d47ef07a13e701f992a4ca9f292ccded6fea2cb1b74033R47-R56)

Reusable campus-aware UI:

* Added a `CampusView` component and a `useCampusCheck` hook to conditionally render UI elements based on campus and role, used in both admin and student sample pages. [[1]](diffhunk://#diff-8b4162d4c88173934ff785a132eda9aaedf2f19e28b962f0d3d67275e9df250eR1-R29) [[2]](diffhunk://#diff-2dc4a833f7f1a5b26a064e06bad630ce34001c97d2e2370e08238e1a27fda4deR1-R22) [[3]](diffhunk://#diff-9661a0f6cda280dd8eab49e17e276a30a5f703ef71df5d03f91530f4d85e9c66R1-R23) [[4]](diffhunk://#diff-4ebeed73b9f668f935f8154b5ae0f3629d87f5bac16d9c6c29f146524bf54c5cR1-R23)

Sample campus-restricted routes and pages:

* Demonstrated campus-specific routing in `router.tsx`, including sample pages for UC-Main admins and students, and conditional UI in general admin/student pages. [[1]](diffhunk://#diff-a1ef1465fdb163f6f5c9a50c96e5e36eebfe88427384a16472e29f881dffb362R26-R33) [[2]](diffhunk://#diff-a1ef1465fdb163f6f5c9a50c96e5e36eebfe88427384a16472e29f881dffb362R58-R69) [[3]](diffhunk://#diff-a1ef1465fdb163f6f5c9a50c96e5e36eebfe88427384a16472e29f881dffb362R99-R117) [[4]](diffhunk://#diff-9f42723ece1ccb6e225f2af01977bfd1e1fd7ff1c178cbe907884efab2217ef3R1-R8) [[5]](diffhunk://#diff-f5ff328754d43bcc47a451da1ba576ab62ae05dd41e4678080aca92982daa0e6R1-R11)