### PR TITLE
feat(pagination): centralized logic for pagination This commit adds a new Paginator class that can be reused throughout controllers that use Mongoose ORM.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
   "tailwindCSS.lint.invalidConfigPath": "error",
   "tailwindCSS.lint.invalidTailwindDirective": "error",
   "tailwindCSS.lint.invalidScreen": "error",
-  "tailwindCSS.lint.suggestCanonicalClasses": "ignore"
+  "tailwindCSS.lint.suggestCanonicalClasses": "ignore",
+  "editor.formatOnSave": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "psits-website",
+  "name": "psits-web-react",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -15,7 +15,6 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/server-side/src/custom_function/paginator.ts
+++ b/server-side/src/custom_function/paginator.ts
@@ -1,0 +1,47 @@
+import { Model, FilterQuery, ProjectionType, SortOrder } from 'mongoose';
+
+interface IPaginationQuery<T> {
+    model: Model<T>;
+    filter: FilterQuery<T>;
+    select: ProjectionType<T>;
+    sort: Record<string, SortOrder>;
+}
+
+class PaginatedList<T> {
+    public items: T[];
+    public totalCount: number;
+    public pageNumber: number;
+    public totalPages: number;
+
+    constructor(items: T[], count: number, pageNumber: number, pageSize: number) {
+        this.pageNumber = pageNumber;
+        this.totalCount = count;
+        this.totalPages = Math.ceil(count / pageSize);
+        this.items = items;
+    }
+
+    public get hasPreviousPage(): boolean {
+        return this.pageNumber > 1 && this.pageNumber <= this.totalPages + 1;
+    }
+
+    public get hasNextPage(): boolean {
+        return this.pageNumber < this.totalPages;
+    }
+
+    public static async createAsync<T>(query: IPaginationQuery<T>, pageNumber: number, pageSize: number): Promise<PaginatedList<T>> {
+        const { model, filter, select, sort } = query;
+
+        const [count, items] = await Promise.all([
+            model.countDocuments(filter),
+            model.find(filter)
+                .select(select)
+                .sort(sort)
+                .skip((pageNumber - 1) * pageSize)
+                .lean<T[]>()
+        ]);
+
+        return new PaginatedList<T>(items, count, pageNumber, pageSize);
+    }
+}
+
+export { PaginatedList, IPaginationQuery };

--- a/server-side/src/custom_function/paginator.ts
+++ b/server-side/src/custom_function/paginator.ts
@@ -1,4 +1,4 @@
-import { Model, FilterQuery, ProjectionType, SortOrder } from 'mongoose';
+import { Model, FilterQuery, ProjectionType, SortOrder } from "mongoose";
 
 /**
  * Query parameters used by `PaginatedList.createAsync` to load a page from a Mongoose model.
@@ -18,10 +18,13 @@ import { Model, FilterQuery, ProjectionType, SortOrder } from 'mongoose';
  * };
  */
 interface IPaginationQuery<T> {
-    model: Model<T>;
-    filter: FilterQuery<T>;
-    select: ProjectionType<T>;
-    sort: Record<string, SortOrder>;
+  model: Model<T>;
+  filter?: FilterQuery<T>;
+  select?:
+    | string
+    | string[]
+    | Record<string, string | number | boolean | object>;
+  sort?: Record<string, SortOrder>;
 }
 
 /**
@@ -39,77 +42,85 @@ interface IPaginationQuery<T> {
  * const page = new PaginatedList<User>(users, totalCount, 2, 20);
  */
 class PaginatedList<T> {
-    /** Page items (typed array). */
-    public items: T[];
-    /** Total number of items across all pages. */
-    public totalCount: number;
-    /** Current 1-based page number. */
-    public pageNumber: number;
-    /** Total computed pages for the supplied `pageSize`. */
-    public totalPages: number;
+  /** Page items (typed array). */
+  public items: T[];
+  /** Total number of items across all pages. */
+  public totalCount: number;
+  /** Current 1-based page number. */
+  public pageNumber: number;
+  /** Total computed pages for the supplied `pageSize`. */
+  public totalPages: number;
 
-    /**
-     * Construct a new paginated result.
-     *
-     * @param items - Array of page items (type `T[]`).
-     * @param count - Total number of matching items across all pages.
-     * @param pageNumber - Current 1-based page number.
-     * @param pageSize - Items per page (used to compute `totalPages`).
-     */
-    constructor(items: T[], count: number, pageNumber: number, pageSize: number) {
-        this.totalCount = count;
-        this.totalPages = pageSize > 0 ? Math.ceil(count / pageSize) : 0;
-        this.pageNumber = Math.min(Math.max(1, pageNumber), Math.max(1, this.totalPages));
-        this.items = items;
-    }
+  /**
+   * Construct a new paginated result.
+   *
+   * @param items - Array of page items (type `T[]`).
+   * @param count - Total number of matching items across all pages.
+   * @param pageNumber - Current 1-based page number.
+   * @param pageSize - Items per page (used to compute `totalPages`).
+   */
+  constructor(items: T[], count: number, pageNumber: number, pageSize: number) {
+    this.totalCount = count;
+    this.totalPages = pageSize > 0 ? Math.ceil(count / pageSize) : 0;
+    this.pageNumber = Math.min(
+      Math.max(1, pageNumber),
+      Math.max(1, this.totalPages)
+    );
+    this.items = items;
+  }
 
-    /**
-     * Indicates whether a previous page exists.
-     *
-     * @returns `true` when `pageNumber > 1` and `pageNumber <= totalPages + 1`.
-     *
-     */
-    public get hasPreviousPage(): boolean {
-        return this.pageNumber > 1;
-    }
+  /**
+   * Indicates whether a previous page exists.
+   *
+   * @returns `true` when `pageNumber > 1` and `pageNumber <= totalPages + 1`.
+   *
+   */
+  public get hasPreviousPage(): boolean {
+    return this.pageNumber > 1;
+  }
 
-    /**
-     * Indicates whether a next page exists.
-     *
-     * @returns `true` when `pageNumber < totalPages`.
-     */
-    public get hasNextPage(): boolean {
-        return this.pageNumber < this.totalPages;
-    }
+  /**
+   * Indicates whether a next page exists.
+   *
+   * @returns `true` when `pageNumber < totalPages`.
+   */
+  public get hasNextPage(): boolean {
+    return this.pageNumber < this.totalPages;
+  }
 
-    /**
-     * Load a page from the database and return a typed `PaginatedList<T>`.
-     *
-     * @typeParam T - The result type expected from the model query (use `lean<T>()` if you want POJOs).
-     * @param query - `IPaginationQuery<T>` describing `model`, `filter`, `select`, and `sort`.
-     * @param pageNumber - 1-based page number to load.
-     * @param pageSize - Number of items per page.
-     * @returns Promise resolving to `PaginatedList<T>` containing the loaded items and pagination metadata.
-     *
-     * @remarks
-     * - The method calls `model.countDocuments(filter)` and `model.find(filter).select(select).sort(sort).skip(...).limit(...).lean<T>()`.
-     * - Use `lean<T>()` when you only need plain objects (better performance). If you need Mongoose `Document` behavior, remove `lean()` and adjust types accordingly.
-     */
-    public static async createAsync<T>(query: IPaginationQuery<T>, pageNumber: number, pageSize: number): Promise<PaginatedList<T>> {
-        const { model, filter, select, sort } = query;
+  /**
+   * Load a page from the database and return a typed `PaginatedList<T>`.
+   *
+   * @typeParam T - The result type expected from the model query (use `lean<T>()` if you want POJOs).
+   * @param query - `IPaginationQuery<T>` describing `model`, `filter`, `select`, and `sort`.
+   * @param pageNumber - 1-based page number to load.
+   * @param pageSize - Number of items per page.
+   * @returns Promise resolving to `PaginatedList<T>` containing the loaded items and pagination metadata.
+   *
+   * @remarks
+   * - The method calls `model.countDocuments(filter)` and `model.find(filter).select(select).sort(sort).skip(...).limit(...).lean<T>()`.
+   * - Use `lean<T>()` when you only need plain objects (better performance). If you need Mongoose `Document` behavior, remove `lean()` and adjust types accordingly.
+   */
+  public static async createAsync<T>(
+    query: IPaginationQuery<T>,
+    pageNumber: number,
+    pageSize: number
+  ): Promise<PaginatedList<T>> {
+    const { model, filter, select, sort } = query;
 
-        const [count, items] = await Promise.all([
-            model.countDocuments(filter),
-            model.find(filter)
-                .select(select)
-                .sort(sort)
-                .skip((pageNumber - 1) * pageSize)
-                .limit(pageSize)
-                .lean<T[]>()
-        ]);
+    const [count, items] = await Promise.all([
+      model.countDocuments(filter),
+      model
+        .find(filter ?? {})
+        .select(select ?? [])
+        .sort(sort)
+        .skip((pageNumber - 1) * pageSize)
+        .limit(pageSize)
+        .lean<T[]>(),
+    ]);
 
-        return new PaginatedList<T>(items, count, pageNumber, pageSize);
-    }
+    return new PaginatedList<T>(items, count, pageNumber, pageSize);
+  }
 }
 
 export { PaginatedList, IPaginationQuery };

--- a/server-side/src/custom_function/paginator.ts
+++ b/server-side/src/custom_function/paginator.ts
@@ -59,9 +59,14 @@ class PaginatedList<T> {
    * @param pageNumber - Current 1-based page number.
    * @param pageSize - Items per page (used to compute `totalPages`).
    */
-  constructor(items: T[], count: number, pageNumber: number, pageSize: number) {
+  constructor(
+    items: T[] = [],
+    count: number = 0,
+    pageNumber: number = 1,
+    pageSize: number = 1
+  ) {
     this.totalCount = count;
-    this.totalPages = pageSize > 0 ? Math.ceil(count / pageSize) : 0;
+    this.totalPages = pageSize > 0 ? Math.ceil(count / pageSize) : 1;
     this.pageNumber = Math.min(
       Math.max(1, pageNumber),
       Math.max(1, this.totalPages)
@@ -103,8 +108,8 @@ class PaginatedList<T> {
    */
   public static async createAsync<T>(
     query: IPaginationQuery<T>,
-    pageNumber: number,
-    pageSize: number
+    pageNumber: number = 1,
+    pageSize: number = 50
   ): Promise<PaginatedList<T>> {
     const { model, filter, select, sort } = query;
 

--- a/server-side/src/custom_function/paginator.ts
+++ b/server-side/src/custom_function/paginator.ts
@@ -59,15 +59,8 @@ class PaginatedList<T> {
     constructor(items: T[], count: number, pageNumber: number, pageSize: number) {
         this.totalCount = count;
         this.totalPages = pageSize > 0 ? Math.ceil(count / pageSize) : 0;
-        this.pageNumber = Math.min(Math.max(1, pageNumber), PaginatedList.maxPageNumber(this.totalPages));
+        this.pageNumber = Math.min(Math.max(1, pageNumber), Math.max(1, this.totalPages));
         this.items = items;
-    }
-
-    /**
-     * Helper method for getting max page number.
-     */
-    private static maxPageNumber(totalPages: number): number {
-        return Math.max(1, totalPages);
     }
 
     /**

--- a/server-side/src/custom_function/paginator.ts
+++ b/server-side/src/custom_function/paginator.ts
@@ -1,5 +1,22 @@
 import { Model, FilterQuery, ProjectionType, SortOrder } from 'mongoose';
 
+/**
+ * Query parameters used by `PaginatedList.createAsync` to load a page from a Mongoose model.
+ *
+ * @typeParam T - The document/lean type for the Mongoose model (the item type returned).
+ * @property model - Mongoose `Model<T>` used to run the queries.
+ * @property filter - Mongo filter passed to `model.find(...)`.
+ * @property select - Projection applied via `.select(...)`.
+ * @property sort - Sort descriptor passed to `.sort(...)`.
+ *
+ * @example
+ * const q: IPaginationQuery<User> = {
+ *   model: UserModel,
+ *   filter: { active: true },
+ *   select: 'name email',
+ *   sort: { createdAt: -1 }
+ * };
+ */
 interface IPaginationQuery<T> {
     model: Model<T>;
     filter: FilterQuery<T>;
@@ -7,27 +24,84 @@ interface IPaginationQuery<T> {
     sort: Record<string, SortOrder>;
 }
 
+/**
+ * Generic container representing a single page of results.
+ *
+ * @typeParam T - Item type stored in `items`.
+ *
+ * @remarks
+ * - `items` contains the page items (type `T[]`).
+ * - `totalCount` is the total number of matching documents across all pages.
+ * - `pageNumber` is 1-based.
+ * - `totalPages` is computed as `Math.ceil(totalCount / pageSize)`.
+ *
+ * @example
+ * const page = new PaginatedList<User>(users, totalCount, 2, 20);
+ */
 class PaginatedList<T> {
+    /** Page items (typed array). */
     public items: T[];
+    /** Total number of items across all pages. */
     public totalCount: number;
+    /** Current 1-based page number. */
     public pageNumber: number;
+    /** Total computed pages for the supplied `pageSize`. */
     public totalPages: number;
 
+    /**
+     * Construct a new paginated result.
+     *
+     * @param items - Array of page items (type `T[]`).
+     * @param count - Total number of matching items across all pages.
+     * @param pageNumber - Current 1-based page number.
+     * @param pageSize - Items per page (used to compute `totalPages`).
+     */
     constructor(items: T[], count: number, pageNumber: number, pageSize: number) {
-        this.pageNumber = pageNumber;
         this.totalCount = count;
-        this.totalPages = Math.ceil(count / pageSize);
+        this.totalPages = pageSize > 0 ? Math.ceil(count / pageSize) : 0;
+        this.pageNumber = Math.min(Math.max(1, pageNumber), PaginatedList.maxPageNumber(this.totalPages));
         this.items = items;
     }
 
-    public get hasPreviousPage(): boolean {
-        return this.pageNumber > 1 && this.pageNumber <= this.totalPages + 1;
+    /**
+     * Helper method for getting max page number.
+     */
+    private static maxPageNumber(totalPages: number): number {
+        return Math.max(1, totalPages);
     }
 
+    /**
+     * Indicates whether a previous page exists.
+     *
+     * @returns `true` when `pageNumber > 1` and `pageNumber <= totalPages + 1`.
+     *
+     */
+    public get hasPreviousPage(): boolean {
+        return this.pageNumber > 1;
+    }
+
+    /**
+     * Indicates whether a next page exists.
+     *
+     * @returns `true` when `pageNumber < totalPages`.
+     */
     public get hasNextPage(): boolean {
         return this.pageNumber < this.totalPages;
     }
 
+    /**
+     * Load a page from the database and return a typed `PaginatedList<T>`.
+     *
+     * @typeParam T - The result type expected from the model query (use `lean<T>()` if you want POJOs).
+     * @param query - `IPaginationQuery<T>` describing `model`, `filter`, `select`, and `sort`.
+     * @param pageNumber - 1-based page number to load.
+     * @param pageSize - Number of items per page.
+     * @returns Promise resolving to `PaginatedList<T>` containing the loaded items and pagination metadata.
+     *
+     * @remarks
+     * - The method calls `model.countDocuments(filter)` and `model.find(filter).select(select).sort(sort).skip(...).limit(...).lean<T>()`.
+     * - Use `lean<T>()` when you only need plain objects (better performance). If you need Mongoose `Document` behavior, remove `lean()` and adjust types accordingly.
+     */
     public static async createAsync<T>(query: IPaginationQuery<T>, pageNumber: number, pageSize: number): Promise<PaginatedList<T>> {
         const { model, filter, select, sort } = query;
 
@@ -37,6 +111,7 @@ class PaginatedList<T> {
                 .select(select)
                 .sort(sort)
                 .skip((pageNumber - 1) * pageSize)
+                .limit(pageSize)
                 .lean<T[]>()
         ]);
 


### PR DESCRIPTION
This change introduces a centralized `paginator.ts` class that allows simplified pagination logic for controllers fetching batches or lists of data.

Example usage:
```typescript
type PaginatedResponse<T> = {
  data?: PaginatedList<T>;
  message?: string;
  error?: unknown;
};

export const getAllEventsController = async (
  req: Request,
  res: Response<PaginatedResponse<IEventDocument>>
) => {
  try {
    const { pageNumber, pageSize } = req.query;
    const results = await PaginatedList.createAsync<IEventDocument>(
      { model: Event },
      parseInt(pageNumber as string),
      parseInt(pageSize as string)
    );
    return res.status(200).json({ data: results });
  } catch (error) {
    console.error("An unhandled error has occurred: ", error);
    return res
      .status(500)
      .json({ message: "An unexpected error has occurred." });
  }
};
```
1. The `getAllEventsController` used to only do Event.find() and return everything at once.
2. This example also adds an optional Response structure `PaginatedResponse`. This is opinionated to me, but throughout the file, `data`, `message`, and `errors` are used commonly anyway.
3. I also thought about creating a Request structure, but it didn't work. Even when I tried to assign an interface to Request, I was prompted with error that req.query can only be string typed. Since this is a `GET` endpoint, there's almost no need to request body. PageNumber and PageSize is manually converted to int when passing to `PaginatedList()` class
  > A Request interface can certainly be made. But it involves other fields such as body, and etc which aren't needed for this demonstration.
4. The PaginatedList `query` argument needs to be passed a `Model` object (which is a Mongoose-related object). We pass here instead the Document type of the model / entity. In this case, `IEventDocument` instead of its model `IEvent`.
5. The original code originally had a *Not Found* check. This has been removed in this example (empty result can be checked in client easily). If there really is a need, then do not use the `createAsync()` method of `PaginatedList` class, handle the logic manually, and create a new PaginatedList instead and pass the values to its constructor. Example:
      ```typescript
      const totalCount = // ... handle manual counting
      const pNumber =  // ...
      const pSize =  // ...
      const results = new PaginatedList<IEventDocument>(
        items as IEventDocument[], 
        totalCount, 
        pNumber, 
        pSize
      ); 
      return res.status(200).json({ data: results })

6. You have to pass the Document type of the model to generic type `<T>`
7. Pagination defaults to pageSize = 50, pageNumber = 1 when the query params are not supplied.
8. Optionally, `sort` and `select` arguments can also be passed to IPaginationQuery query to selectively choose fields to include / exclude and/or sort multiple fields via SortOrder. These are mongoose methods within mongoose query.

Unrelated notes:
*Added formatOnSave for prettier in workspace settings ahaha*

Btw, ang PaginationList.createAsync() is only for most simple cases. Most of the time, if the data has already been queried, i manual nalng gamit ang PaginationList() nga constructor.
Maybe maghimo lng kog overload nga method muhandle ug Pagination bahalag na query na ang data ahaha tryan nako ugma