### PR TITLE
Fix Merchandise Filtering Bug/duplicate data

### DIFF
--- a/client-side-ts/src/features/admin/api/admin.ts
+++ b/client-side-ts/src/features/admin/api/admin.ts
@@ -123,23 +123,31 @@ interface MerchandiseReportOrderDetail {
   rfid?: string;
 }
 
-interface MerchandiseReportOrder {
-  _id: string;
-  order_details: MerchandiseReportOrderDetail[];
-}
-
-interface MerchandiseReportsResult {
+export interface MerchandiseReportsResult {
   data: MerchandiseReportOrderDetail[];
   total: number;
   page: number;
   limit: number;
   totalPages: number;
   message?: string;
+  summary: { unitsSold: number; totalRevenue: number };
+  productNames: string[];
 }
 
-interface MerchandiseReportsParams {
+export interface MerchandiseReportsParams {
   page?: number;
   limit?: number;
+  search?: string;
+  referenceCode?: string;
+  studentId?: string;
+  name?: string;
+  course?: string;
+  year?: string;
+  productName?: string;
+  size?: string;
+  color?: string;
+  dateFrom?: string;
+  dateTo?: string;
 }
 
 type DailySalesResponse = DailySalesData[] | { data: DailySalesData[] };
@@ -539,16 +547,40 @@ export const deleteMerchandise = async (
 export const merchandiseReports = async ({
   page = 1,
   limit = 10,
+  search,
+  referenceCode,
+  studentId,
+  name,
+  course,
+  year,
+  productName,
+  size,
+  color,
+  dateFrom,
+  dateTo,
 }: MerchandiseReportsParams = {}): Promise<MerchandiseReportsResult | void> => {
   try {
     const response: AxiosResponse<MerchandiseReportsResult> = await axios.get(
       `${backendConnection()}/api/reports`,
       {
         headers: createHeaders(),
-        params: { page, limit },
+        params: {
+          page,
+          limit,
+          search,
+          referenceCode,
+          studentId,
+          name,
+          course,
+          year,
+          productName,
+          size,
+          color,
+          dateFrom,
+          dateTo,
+        },
       }
     );
-    console.log(response.data);
     return response.data;
   } catch (error) {
     handleApiError(error, false);

--- a/client-side-ts/src/features/admin/reports/components/ReportsView.tsx
+++ b/client-side-ts/src/features/admin/reports/components/ReportsView.tsx
@@ -1,26 +1,49 @@
 import { useState, useMemo } from "react";
 import {
-  BadgeDollarSign, Download, Filter,
-  Package, Search, ShoppingBag,
-  Trash2, Wallet, X,
+  BadgeDollarSign,
+  Download,
+  Filter,
+  Package,
+  Search,
+  ShoppingBag,
+  Trash2,
+  Wallet,
+  X,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
-  Dialog, DialogContent, DialogFooter,
-  DialogHeader, DialogTitle,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
-  Select, SelectContent, SelectItem,
-  SelectTrigger, SelectValue,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
-import { useReportsData, ROWS_PER_PAGE, DEFAULT_FILTERS } from "../hooks/useReportsData";
+import {
+  useReportsData,
+  ROWS_PER_PAGE,
+  DEFAULT_FILTERS,
+} from "../hooks/useReportsData";
 import { downloadCsv } from "../utils/exportCsv";
-import type { MerchandiseOrderDetail, ReportsFilters } from "../types/reports.types";
+import type {
+  MerchandiseOrderDetail,
+  ReportsFilters,
+} from "../types/reports.types";
 
 const courses = ["BSIT", "BSCS", "ACT"];
 const years = ["1", "2", "3", "4"];
@@ -43,10 +66,9 @@ interface ReportsFilterPopoverProps {
   activeTab: "membership" | "merchandise";
   filters: ReportsFilters;
   uniqueProductNames: string[];
-  getBatchesForProduct: (productName: string) => string[]; 
+  getBatchesForProduct: (productName: string) => string[];
   onApply: (filters: ReportsFilters) => void;
 }
-
 
 const ReportsFilterPopover = ({
   activeTab,
@@ -151,7 +173,10 @@ const ReportsFilterPopover = ({
             {activeTab === "membership" && (
               <div>
                 <Label className="mb-1.5 block text-xs font-medium">Type</Label>
-                <Select value={draft.type} onValueChange={(v) => update("type", v)}>
+                <Select
+                  value={draft.type}
+                  onValueChange={(v) => update("type", v)}
+                >
                   <SelectTrigger className="h-9 w-full rounded-lg border-[#ececec]">
                     <SelectValue placeholder="All" />
                   </SelectTrigger>
@@ -173,7 +198,7 @@ const ReportsFilterPopover = ({
                     value={draft.productName}
                     onValueChange={(v) => {
                       update("productName", v);
-                      setDraft((current) => ({ ...current, batch: "" })); 
+                      setDraft((current) => ({ ...current, batch: "" }));
                     }}
                   >
                     <SelectTrigger className="h-9 w-full rounded-lg border-[#ececec]">
@@ -189,8 +214,13 @@ const ReportsFilterPopover = ({
                   </Select>
                 </div>
                 <div>
-                  <Label className="mb-1.5 block text-xs font-medium">Size</Label>
-                  <Select value={draft.size} onValueChange={(v) => update("size", v)}>
+                  <Label className="mb-1.5 block text-xs font-medium">
+                    Size
+                  </Label>
+                  <Select
+                    value={draft.size}
+                    onValueChange={(v) => update("size", v)}
+                  >
                     <SelectTrigger className="h-9 w-full rounded-lg border-[#ececec]">
                       <SelectValue placeholder="All sizes" />
                     </SelectTrigger>
@@ -230,7 +260,10 @@ const ReportsFilterPopover = ({
 
             <div>
               <Label className="mb-1.5 block text-xs font-medium">Course</Label>
-              <Select value={draft.course} onValueChange={(v) => update("course", v)}>
+              <Select
+                value={draft.course}
+                onValueChange={(v) => update("course", v)}
+              >
                 <SelectTrigger className="h-9 w-full rounded-lg border-[#ececec]">
                   <SelectValue placeholder="All" />
                 </SelectTrigger>
@@ -247,7 +280,10 @@ const ReportsFilterPopover = ({
               <Label className="mb-1.5 block text-xs font-medium">
                 Year Level
               </Label>
-              <Select value={draft.year} onValueChange={(v) => update("year", v)}>
+              <Select
+                value={draft.year}
+                onValueChange={(v) => update("year", v)}
+              >
                 <SelectTrigger className="h-9 w-full rounded-lg border-[#ececec]">
                   <SelectValue placeholder="All" />
                 </SelectTrigger>
@@ -282,7 +318,12 @@ const ReportsFilterPopover = ({
             </div>
           </div>
           <div className="mt-6 flex justify-end gap-3">
-            <Button type="button" variant="ghost" className="h-9 px-4" onClick={handleCancel}>
+            <Button
+              type="button"
+              variant="ghost"
+              className="h-9 px-4"
+              onClick={handleCancel}
+            >
               Cancel
             </Button>
             <Button
@@ -329,7 +370,12 @@ interface PaginationFooterProps {
   onPageChange: (page: number) => void;
 }
 
-const PaginationFooter = ({ page, totalPages, total, onPageChange }: PaginationFooterProps) => {
+const PaginationFooter = ({
+  page,
+  totalPages,
+  total,
+  onPageChange,
+}: PaginationFooterProps) => {
   const visiblePages = pageRange(page, totalPages);
   return (
     <div className="mt-7 flex flex-col items-center justify-between gap-3 text-xs text-[#8a8a8a] sm:flex-row">
@@ -348,7 +394,9 @@ const PaginationFooter = ({ page, totalPages, total, onPageChange }: PaginationF
         </button>
         {visiblePages.map((item, index) => (
           <div key={`${item}-${index}`} className="flex items-center gap-1">
-            {index > 0 && item - visiblePages[index - 1] > 1 && <span className="px-1">...</span>}
+            {index > 0 && item - visiblePages[index - 1] > 1 && (
+              <span className="px-1">...</span>
+            )}
             <button
               type="button"
               onClick={() => onPageChange(item)}
@@ -416,7 +464,7 @@ export const ReportsView = () => {
     totalMembershipRows,
     totalMerchandiseRows,
     membershipSummary,
-    merchandiseSalesSummary,
+    merchandiseSummary,
     uniqueProductNames,
     getBatchesForProduct,
     canDeleteReports,
@@ -428,7 +476,8 @@ export const ReportsView = () => {
     refetchMerchandise,
   } = useReportsData();
 
-  const [deleteTarget, setDeleteTarget] = useState<MerchandiseOrderDetail | null>(null);
+  const [deleteTarget, setDeleteTarget] =
+    useState<MerchandiseOrderDetail | null>(null);
 
   const isMembership = activeTab === "membership";
   const status = isMembership ? membershipStatus : merchandiseStatus;
@@ -445,7 +494,7 @@ export const ReportsView = () => {
   };
 
   return (
-    <div className="bg-background flex min-h-full flex-1 flex-col text-[#333] [&_button:not(:disabled)]:cursor-pointer [&_button:disabled]:cursor-not-allowed">
+    <div className="bg-background flex min-h-full flex-1 flex-col text-[#333] [&_button:disabled]:cursor-not-allowed [&_button:not(:disabled)]:cursor-pointer">
       <header className="px-4 py-4 sm:px-6 sm:py-6 lg:px-8">
         <h1 className="text-2xl font-bold sm:text-3xl">Reports</h1>
         <p className="text-muted-foreground mt-1 text-sm sm:text-base">
@@ -514,19 +563,12 @@ export const ReportsView = () => {
                 <SummaryCard
                   icon={Package}
                   label="Units Sold (filtered)"
-                  value={Array.from(merchandiseSalesSummary.values())
-                    .reduce((sum, item) => sum + item.unitsSold, 0)
-                    .toLocaleString()}
+                  value={merchandiseSummary.unitsSold.toLocaleString()}
                 />
                 <SummaryCard
                   icon={BadgeDollarSign}
                   label="Total Revenue (filtered)"
-                  value={formatCurrency(
-                    Array.from(merchandiseSalesSummary.values()).reduce(
-                      (sum, item) => sum + item.totalRevenue,
-                      0
-                    )
-                  )}
+                  value={formatCurrency(merchandiseSummary.totalRevenue)}
                 />
               </>
             )}
@@ -535,7 +577,10 @@ export const ReportsView = () => {
 
         {status === "error" && (
           <div className="mb-4 flex items-center justify-between rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-            <span>Unable to load {isMembership ? "membership" : "merchandise"} report data.</span>
+            <span>
+              Unable to load {isMembership ? "membership" : "merchandise"}{" "}
+              report data.
+            </span>
             <Button
               type="button"
               size="sm"
@@ -582,7 +627,11 @@ export const ReportsView = () => {
           </div>
 
           {isMembership ? (
-            <MembershipTable rows={pagedMembership} isLoading={status === "loading"} hasError={status === "error"} />
+            <MembershipTable
+              rows={pagedMembership}
+              isLoading={status === "loading"}
+              hasError={status === "error"}
+            />
           ) : (
             <MerchandiseTable
               rows={pagedMerchandise}
@@ -602,16 +651,20 @@ export const ReportsView = () => {
         </section>
       </div>
 
-      <Dialog open={Boolean(deleteTarget)} onOpenChange={(open) => !open && setDeleteTarget(null)}>
+      <Dialog
+        open={Boolean(deleteTarget)}
+        onOpenChange={(open) => !open && setDeleteTarget(null)}
+      >
         <DialogContent className="max-w-sm rounded-[20px]">
           <DialogHeader>
             <DialogTitle>Delete this report entry?</DialogTitle>
           </DialogHeader>
           <p className="text-sm text-[#777]">
             This removes{" "}
-            <span className="font-medium">{deleteTarget?.product_name}</span> from{" "}
-            <span className="font-medium">{deleteTarget?.student_name}</span>'s order
-            record. This cannot be undone.
+            <span className="font-medium">{deleteTarget?.product_name}</span>{" "}
+            from{" "}
+            <span className="font-medium">{deleteTarget?.student_name}</span>'s
+            order record. This cannot be undone.
           </p>
           <DialogFooter className="mt-3">
             <Button
@@ -657,13 +710,21 @@ const MembershipTable = ({
           <th className="w-[14%] rounded-l-md px-2 py-2 text-left font-medium">
             Reference Code
           </th>
-          <th className="w-[11%] px-2 py-2 text-left font-medium">Student ID</th>
+          <th className="w-[11%] px-2 py-2 text-left font-medium">
+            Student ID
+          </th>
           <th className="w-[16%] px-2 py-2 text-left font-medium">Name</th>
-          <th className="w-[11%] px-2 py-2 text-left font-medium">Course &amp; Year</th>
+          <th className="w-[11%] px-2 py-2 text-left font-medium">
+            Course &amp; Year
+          </th>
           <th className="w-[11%] px-2 py-2 text-left font-medium">Date</th>
           <th className="w-[11%] px-2 py-2 text-left font-medium">Type</th>
-          <th className="w-[14%] px-2 py-2 text-left font-medium">Managed By</th>
-          <th className="w-[12%] rounded-r-md px-2 py-2 text-right font-medium">Total</th>
+          <th className="w-[14%] px-2 py-2 text-left font-medium">
+            Managed By
+          </th>
+          <th className="w-[12%] rounded-r-md px-2 py-2 text-right font-medium">
+            Total
+          </th>
         </tr>
       </thead>
       <tbody>
@@ -679,8 +740,8 @@ const MembershipTable = ({
           ))
         ) : hasError ? null : rows.length > 0 ? (
           rows.map((row, index) => (
-            <tr 
-              key={`${row.reference_code}-${row.id_number}-${index}`} 
+            <tr
+              key={`${row.reference_code}-${row.id_number}-${index}`}
               className="border-b border-[#ededed] text-[#303030]"
             >
               <td className="truncate px-2 py-3">{row.reference_code}</td>
@@ -692,14 +753,17 @@ const MembershipTable = ({
               <td className="px-2 py-3">{formatDate(row.date)}</td>
               <td className="truncate px-2 py-3">{row.type}</td>
               <td className="truncate px-2 py-3">{row.admin || "-"}</td>
-              <td className="whitespace-nowrap px-2 py-3 text-right font-medium">
+              <td className="px-2 py-3 text-right font-medium whitespace-nowrap">
                 {formatCurrency(row.total || 0)}
               </td>
             </tr>
           ))
         ) : (
           <tr>
-            <td colSpan={8} className="px-3 py-16 text-center text-sm text-[#777]">
+            <td
+              colSpan={8}
+              className="px-3 py-16 text-center text-sm text-[#777]"
+            >
               No membership records found.
             </td>
           </tr>
@@ -730,14 +794,20 @@ const MerchandiseTable = ({
             Reference Code
           </th>
           <th className="w-[16%] px-2 py-2 text-left font-medium">Product</th>
-          <th className="w-[12%] px-2 py-2 text-left font-medium">Student ID</th>
+          <th className="w-[12%] px-2 py-2 text-left font-medium">
+            Student ID
+          </th>
           <th className="w-[15%] px-2 py-2 text-left font-medium">Name</th>
-          <th className="w-[10%] px-2 py-2 text-left font-medium">Course &amp; Year</th>
+          <th className="w-[10%] px-2 py-2 text-left font-medium">
+            Course &amp; Year
+          </th>
           <th className="w-[8%] px-2 py-2 text-left font-medium">Size</th>
           <th className="w-[8%] px-2 py-2 text-left font-medium">Color</th>
           <th className="w-[6%] px-2 py-2 text-right font-medium">Qty</th>
           <th className="w-[8%] px-2 py-2 text-right font-medium">Total</th>
-          <th className={cn("px-2 py-2 text-right", canDelete ? "w-[8%]" : "w-4")} />
+          <th
+            className={cn("px-2 py-2 text-right", canDelete ? "w-[8%]" : "w-4")}
+          />
         </tr>
       </thead>
       <tbody>
@@ -753,7 +823,10 @@ const MerchandiseTable = ({
           ))
         ) : hasError ? null : rows.length > 0 ? (
           rows.map((detail) => (
-            <tr key={detail._id} className="border-b border-[#ededed] text-[#303030]">
+            <tr
+              key={detail._id}
+              className="border-b border-[#ededed] text-[#303030]"
+            >
               <td className="truncate px-2 py-3">{detail.reference_code}</td>
               <td className="truncate px-2 py-3">{detail.product_name}</td>
               <td className="px-2 py-3">{detail.id_number}</td>
@@ -761,8 +834,14 @@ const MerchandiseTable = ({
               <td className="px-2 py-3">
                 {detail.course} {detail.year ? `- ${detail.year}` : ""}
               </td>
-              <td className="px-2 py-3">{detail.size.length > 0 ? detail.size.join(", ") : "-"}</td>
-              <td className="px-2 py-3">{detail.variation.length > 0 ? detail.variation.join(", ") : "-"}</td>
+              <td className="px-2 py-3">
+                {detail.size.length > 0 ? detail.size.join(", ") : "-"}
+              </td>
+              <td className="px-2 py-3">
+                {detail.variation.length > 0
+                  ? detail.variation.join(", ")
+                  : "-"}
+              </td>
               <td className="px-2 py-3 text-right">{detail.quantity}</td>
               <td className="px-2 py-3 text-right font-medium">
                 {formatCurrency(detail.total || 0)}

--- a/client-side-ts/src/features/admin/reports/hooks/useReportsData.ts
+++ b/client-side-ts/src/features/admin/reports/hooks/useReportsData.ts
@@ -11,7 +11,6 @@ import { PSITS_ROLES } from "../../constants/adminAccess";
 import type {
   MembershipReportRow,
   MerchandiseOrderDetail,
-  MerchandiseSalesSummary,
   ReportsFilters,
   ReportsStatus,
   ReportsTab,
@@ -20,7 +19,6 @@ import type {
 export const ROWS_PER_PAGE = 10;
 const SEARCH_DEBOUNCE_MS = 250;
 const EMPTY_MEMBERSHIP_ROWS: MembershipReportRow[] = [];
-const EMPTY_MERCHANDISE_DETAILS: MerchandiseOrderDetail[] = [];
 
 export const DEFAULT_FILTERS: ReportsFilters = {
   id: "",
@@ -41,25 +39,20 @@ const toDateKey = (value: string | Date | undefined): string => {
   if (!value) return "";
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return "";
-  return date.toISOString().slice(0, 10); 
+  return date.toISOString().slice(0, 10);
 };
 
-  const flattenVariantField = (value: unknown): string[] => {
-    if (value == null) return [];
-    if (typeof value === "string") return value.trim() ? [value] : [];
-    if (Array.isArray(value)) return value.flatMap(flattenVariantField);
-    if (typeof value === "object" && "$each" in (value as Record<string, unknown>)) {
-      return flattenVariantField((value as { $each: unknown }).$each);
-    }
-    return [];
-  };
-
-type MerchandiseReportsResult = {
-  data: MerchandiseOrderDetail[];
-  total: number;
-  page: number;
-  limit: number;
-  totalPages: number;
+const flattenVariantField = (value: unknown): string[] => {
+  if (value == null) return [];
+  if (typeof value === "string") return value.trim() ? [value] : [];
+  if (Array.isArray(value)) return value.flatMap(flattenVariantField);
+  if (
+    typeof value === "object" &&
+    "$each" in (value as Record<string, unknown>)
+  ) {
+    return flattenVariantField((value as { $each: unknown }).$each);
+  }
+  return [];
 };
 
 export const useReportsData = () => {
@@ -77,15 +70,25 @@ export const useReportsData = () => {
   >([]);
   const [merchandiseTotal, setMerchandiseTotal] = useState(0);
   const [merchandiseTotalPages, setMerchandiseTotalPages] = useState(1);
+  const [merchandiseProductNames, setMerchandiseProductNames] = useState<
+    string[]
+  >([]);
+  const [merchandiseSummary, setMerchandiseSummary] = useState({
+    unitsSold: 0,
+    totalRevenue: 0,
+  });
   const [merchandiseStatus, setMerchandiseStatus] =
     useState<ReportsStatus>("idle");
 
   const [filters, setFilters] = useState<ReportsFilters>(DEFAULT_FILTERS);
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
-  
+
   useEffect(() => {
-    const timer = setTimeout(() => setDebouncedSearch(search), SEARCH_DEBOUNCE_MS);
+    const timer = setTimeout(
+      () => setDebouncedSearch(search),
+      SEARCH_DEBOUNCE_MS
+    );
     return () => clearTimeout(timer);
   }, [search]);
 
@@ -96,7 +99,7 @@ export const useReportsData = () => {
 
   const isUcMainAdmin =
     user?.role === "admin" && normalizeCampus(user.campus) === "UC-MAIN";
-    
+
   const canDeleteReports =
     isUcMainAdmin &&
     (user?.access === PSITS_ROLES.ADMIN ||
@@ -118,34 +121,54 @@ export const useReportsData = () => {
     }
   }, []);
 
-  const fetchMerchandise = useCallback(async () => {
-    const requestId = ++merchandiseRequestRef.current;
-    setMerchandiseStatus("loading");
-    try {
-      const result = await merchandiseReports();
-      if (requestId !== merchandiseRequestRef.current) return;
-      if (!result) throw new Error("No merchandise reports returned");
-      const orders = result.map((order) => ({
-        _id: order._id,
-        order_details: order.order_details.map((detail) => ({
+  const fetchMerchandise = useCallback(
+    async (requestedPage: number) => {
+      const requestId = ++merchandiseRequestRef.current;
+      setMerchandiseStatus("loading");
+      try {
+        const result = await merchandiseReports({
+          page: requestedPage,
+          limit: ROWS_PER_PAGE,
+          search: debouncedSearch,
+          studentId: filters.id,
+          name: filters.name,
+          course: filters.course,
+          year: filters.year,
+          productName: filters.productName,
+          size: filters.size,
+          color: filters.color,
+          dateFrom: filters.dateFrom,
+          dateTo: filters.dateTo,
+        });
+        if (requestId !== merchandiseRequestRef.current) return;
+        if (!result) throw new Error("No merchandise reports returned");
+
+        const details = result.data.map((detail) => ({
           ...detail,
           size: flattenVariantField(detail.size),
           variation: flattenVariantField(detail.variation),
-        })),
-      }));
-      setMerchandiseOrders(orders);
-      const details = orders.flatMap((order) => order.order_details || []);
-      setMerchandiseDetails(details.filter(Boolean));
-      setMerchandiseStatus("success");
-    } catch {
-      if (requestId !== merchandiseRequestRef.current) return;
-      setMerchandiseOrders([]);
-      setMerchandiseDetails([]);
-      setMerchandiseTotal(0);
-      setMerchandiseTotalPages(1);
-      setMerchandiseStatus("error");
-    }
-  }, []);
+        }));
+
+        setMerchandiseDetails(details.filter(Boolean));
+        setMerchandiseTotal(result.total);
+        setMerchandiseTotalPages(result.totalPages);
+        setMerchandiseProductNames(result.productNames ?? []);
+        setMerchandiseSummary(
+          result.summary ?? { unitsSold: 0, totalRevenue: 0 }
+        );
+        setMerchandiseStatus("success");
+      } catch {
+        if (requestId !== merchandiseRequestRef.current) return;
+        setMerchandiseDetails([]);
+        setMerchandiseTotal(0);
+        setMerchandiseTotalPages(1);
+        setMerchandiseProductNames([]);
+        setMerchandiseSummary({ unitsSold: 0, totalRevenue: 0 });
+        setMerchandiseStatus("error");
+      }
+    },
+    [debouncedSearch, filters]
+  );
 
   useEffect(() => {
     if (activeTab === "membership" && membershipStatus === "idle") {
@@ -154,23 +177,21 @@ export const useReportsData = () => {
     if (activeTab === "merchandise") {
       fetchMerchandise(page);
     }
-  }, [activeTab, page, membershipStatus, fetchMembership, fetchMerchandise]);
+  }, [
+    activeTab,
+    page,
+    membershipStatus,
+    debouncedSearch,
+    filters,
+    fetchMembership,
+    fetchMerchandise,
+  ]);
 
   useEffect(() => {
     setPage(1);
   }, [activeTab, filters, search]);
 
-  const uniqueProductNames = useMemo(
-    () =>
-      Array.from(
-        new Set(
-          merchandiseDetails
-            .map((detail) => detail.product_name)
-            .filter(Boolean)
-        )
-      ),
-    [merchandiseDetails]
-  );
+  const uniqueProductNames = merchandiseProductNames;
 
   const getBatchesForProduct = useCallback(
     (productName: string): string[] => {
@@ -189,7 +210,7 @@ export const useReportsData = () => {
 
   const filteredMembership = useMemo(() => {
     if (activeTab !== "membership") return EMPTY_MEMBERSHIP_ROWS;
-    const query = search.trim().toLowerCase();
+    const query = debouncedSearch.trim().toLowerCase();
     return membershipData.filter((row) => {
       if (
         query &&
@@ -220,51 +241,6 @@ export const useReportsData = () => {
     });
   }, [activeTab, membershipData, filters, debouncedSearch]);
 
-  const filteredMerchandise = useMemo(() => {
-  if (activeTab !== "merchandise") return EMPTY_MERCHANDISE_DETAILS;
-  const query = search.trim().toLowerCase();
-
-    return merchandiseDetails.filter((detail) => {
-      if (
-        query &&
-        !`${detail.student_name} ${detail.id_number} ${detail.product_name}`
-          .toLowerCase()
-          .includes(query)
-      ) {
-        return false;
-      }
-      if (filters.id && !detail.id_number?.includes(filters.id)) 
-        return false;
-      if (
-        filters.name &&
-        !detail.student_name?.toLowerCase().includes(filters.name.toLowerCase())
-      )
-        return false;
-      if (filters.rfid && !detail.rfid?.includes(filters.rfid)) 
-        return false;
-      if (
-        filters.course &&
-        !detail.course?.toLowerCase().includes(filters.course.toLowerCase())
-      )
-        return false;
-      if (filters.year && String(detail.year) !== filters.year) 
-        return false;
-      if (filters.productName && detail.product_name !== filters.productName)
-        return false;
-      if (filters.batch && detail.batch !== filters.batch) 
-        return false;
-      if (filters.size && !detail.size.includes(filters.size)) 
-        return false;
-      if (filters.color && !detail.variation.includes(filters.color))
-        return false;
-      if (filters.dateFrom && toDateKey(detail.transaction_date) < filters.dateFrom)
-        return false;
-      if (filters.dateTo && toDateKey(detail.transaction_date) > filters.dateTo)
-        return false;
-      return true;
-    });
-  }, [activeTab, merchandiseDetails, filters, search]);
-
   const membershipSummary = useMemo(() => {
     const totalMembers = filteredMembership.length;
     const totalRevenue = filteredMembership.reduce(
@@ -273,20 +249,6 @@ export const useReportsData = () => {
     );
     return { totalMembers, totalRevenue };
   }, [filteredMembership]);
-
-  const merchandiseSalesSummary = useMemo(() => {
-    const map = new Map<string, MerchandiseSalesSummary>();
-    merchandiseDetails.forEach((detail) => {
-      const current = map.get(detail.product_name) || {
-        unitsSold: 0,
-        totalRevenue: 0,
-      };
-      current.unitsSold += detail.quantity || 0;
-      current.totalRevenue += detail.total || 0;
-      map.set(detail.product_name, current);
-    });
-    return map;
-  }, [merchandiseDetails]);
 
   const activeRowCount =
     activeTab === "membership" ? filteredMembership.length : merchandiseTotal;
@@ -305,10 +267,7 @@ export const useReportsData = () => {
     [filteredMembership, currentPage]
   );
 
-  const pagedMerchandise = useMemo(
-    () => merchandiseDetails,
-    [merchandiseDetails]
-  );
+  const pagedMerchandise = merchandiseDetails;
 
   const deleteMerchandiseReportItem = async (
     detail: MerchandiseOrderDetail
@@ -331,7 +290,7 @@ export const useReportsData = () => {
       setIsMutating(false);
     }
   };
-  
+
   const buildMembershipExportRows = () =>
     filteredMembership.map((row) => ({
       "Reference Code": row.reference_code,
@@ -377,7 +336,7 @@ export const useReportsData = () => {
     totalMembershipRows: filteredMembership.length,
     totalMerchandiseRows: merchandiseTotal,
     membershipSummary,
-    merchandiseSalesSummary,
+    merchandiseSummary,
     uniqueProductNames,
     getBatchesForProduct,
     canDeleteReports,

--- a/server-side/src/models/report.model.ts
+++ b/server-side/src/models/report.model.ts
@@ -35,4 +35,6 @@ const reportSchema = new Schema<IReportDocument>(
   }
 );
 
+reportSchema.index({ order_id: 1, merch_id: 1 }, { unique: true });
+
 export const Report = mongoose.model<IReportDocument>("Report", reportSchema);

--- a/server-side/src/services/report.service.ts
+++ b/server-side/src/services/report.service.ts
@@ -87,66 +87,51 @@ const toLowerTrim = (value: unknown): string => {
   return String(value).trim().toLowerCase();
 };
 
-const buildAggregationPipeline = (
-  filters: MerchandiseReportFilters,
-  skip: number,
-  limit: number
-) => {
-  const matchStage: Record<string, any>[] = [];
+const buildBasePipeline = (filters: MerchandiseReportFilters) => {
+  const matchConditions: Record<string, any>[] = [];
 
   if (filters.search) {
-    const q = filters.search.trim().toLowerCase();
-    matchStage.push({
-      $match: {
-        $or: [
-          { id_number: { $regex: q, $options: "i" } },
-          { order_id: { $regex: q, $options: "i" } },
-        ],
-      },
+    const q = filters.search.trim();
+    matchConditions.push({
+      $or: [
+        { effective_id_number: { $regex: q, $options: "i" } },
+        { effective_reference_code: { $regex: q, $options: "i" } },
+        { effective_student_name: { $regex: q, $options: "i" } },
+        { "merch.name": { $regex: q, $options: "i" } },
+      ],
     });
   }
 
   if (filters.referenceCode) {
-    matchStage.push({
-      $match: {
-        order_id: { $regex: filters.referenceCode.trim(), $options: "i" },
-      },
+    matchConditions.push({
+      effective_reference_code: { $regex: filters.referenceCode.trim(), $options: "i" },
     });
   }
 
   if (filters.studentId) {
-    matchStage.push({
-      $match: {
-        id_number: { $regex: filters.studentId.trim(), $options: "i" },
-      },
+    matchConditions.push({
+      effective_id_number: { $regex: filters.studentId.trim(), $options: "i" },
     });
   }
 
   if (filters.course) {
-    matchStage.push({
-      $match: {
-        "order_id.course": { $regex: filters.course.trim(), $options: "i" },
-      },
+    matchConditions.push({
+      effective_course: { $regex: filters.course.trim(), $options: "i" },
     });
   }
 
   if (filters.year) {
-    matchStage.push({
-      $match: { "order_id.year": Number(filters.year) },
-    });
+    matchConditions.push({ effective_year: Number(filters.year) });
   }
 
   if (filters.dateFrom || filters.dateTo) {
     const dateFilter: Record<string, any> = {};
     if (filters.dateFrom) dateFilter.$gte = new Date(filters.dateFrom);
     if (filters.dateTo) dateFilter.$lte = new Date(filters.dateTo);
-    matchStage.push({ $match: { date: dateFilter } });
+    matchConditions.push({ date: dateFilter });
   }
 
-  const matchPipeline =
-    matchStage.length > 0 ? { $match: matchStage[0].$match } : {};
-
-  const pipeline: any[] = [
+   const pipeline: any[] = [
     {
       $lookup: {
         from: "orders",
@@ -165,7 +150,6 @@ const buildAggregationPipeline = (
       },
     },
     { $unwind: { path: "$merch", preserveNullAndEmptyArrays: true } },
-    ...(Object.keys(matchPipeline).length > 0 ? [matchPipeline] : []),
     {
       $addFields: {
         effective_id_number: {
@@ -180,42 +164,19 @@ const buildAggregationPipeline = (
             $filter: {
               input: "$order.items",
               as: "item",
-              cond: {
-                $eq: ["$$item.product_id", "$merch._id"],
-              },
+              cond: { $eq: ["$$item.product_id", "$merch._id"] },
             },
           },
         },
-        effective_reference_code: {
-          $cond: {
-            if: { $gt: [{ $ifNull: ["$order.reference_code", ""] }, ""] },
-            then: "$order.reference_code",
-            else: "",
-          },
-        },
-        effective_student_name: {
-          $cond: {
-            if: { $gt: [{ $ifNull: ["$order.student_name", ""] }, ""] },
-            then: "$order.student_name",
-            else: "",
-          },
-        },
-        effective_course: {
-          $cond: {
-            if: { $gt: [{ $ifNull: ["$order.course", ""] }, ""] },
-            then: "$order.course",
-            else: "",
-          },
-        },
-        effective_year: {
-          $cond: {
-            if: { $gt: [{ $ifNull: ["$order.year", null] }, null] },
-            then: "$order.year",
-            else: null,
-          },
-        },
+        effective_reference_code: { $ifNull: ["$order.reference_code", ""] },
+        effective_student_name: { $ifNull: ["$order.student_name", ""] },
+        effective_course: { $ifNull: ["$order.course", ""] },
+        effective_year: { $ifNull: ["$order.year", null] },
       },
     },
+    ...(matchConditions.length > 0
+      ? [{ $match: { $and: matchConditions } }]
+      : []),
     {
       $project: {
         _id: 1,
@@ -233,8 +194,6 @@ const buildAggregationPipeline = (
       },
     },
     { $sort: { date: -1 } },
-    { $skip: skip },
-    { $limit: limit },
   ];
 
   return pipeline;
@@ -306,18 +265,17 @@ export const getMerchandiseReport = async (
 ): Promise<MerchandiseReportResult> => {
   const page = normalizePage(params.page);
   const limit = normalizeLimit(params.limit);
-  const skip = (page - 1) * limit;
 
-  const pipeline = buildAggregationPipeline(params, skip, limit);
-  const results = await Report.aggregate(pipeline);
+  const pipeline = buildBasePipeline(params);
+  const dbMatched = await Report.aggregate(pipeline);
 
-  const filteredResults = applyPostMatchFilters(results, params);
-
-  const totalCount = await Report.countDocuments();
-
-  const totalPages = Math.max(1, Math.ceil(totalCount / limit));
-
+  const filteredResults = applyPostMatchFilters(dbMatched, params);
   const rows = filteredResults.map(mapToRow);
+
+  const totalCount = rows.length;
+  const totalPages = Math.max(1, Math.ceil(totalCount / limit));
+  const skip = (page - 1) * limit;
+  const pagedRows = rows.slice(skip, skip + limit);
 
   const summary = rows.reduce(
     (acc, row) => {
@@ -329,14 +287,32 @@ export const getMerchandiseReport = async (
   );
 
   return {
-    rows,
-    data: rows,
+    rows: pagedRows,
+    data: pagedRows,
     total: totalCount,
     page,
     limit,
     totalPages,
     summary,
   };
+};
+
+export const getMerchandiseProductNames = async (): Promise<string[]> => {
+  const names = await Report.aggregate([
+    {
+      $lookup: {
+        from: "merches",
+        localField: "merch_id",
+        foreignField: "_id",
+        as: "merch",
+      },
+    },
+    { $unwind: { path: "$merch", preserveNullAndEmptyArrays: true } },
+    { $match: { "merch.name": { $ne: null } } },
+    { $group: { _id: "$merch.name" } },
+    { $sort: { _id: 1 } },
+  ]);
+  return names.map((n) => n._id).filter(Boolean);
 };
 
 export const getMerchandiseReportById = async (reportId: string) => {
@@ -418,32 +394,26 @@ export const createReports = async (
     date: payload.date ? new Date(payload.date) : new Date(),
   }));
 
-  const uniqueDocs = Array.from(
-    new Map(
-      docs.map((doc) => [
-        [
-          String(doc.order_id ?? ""),
-          String(doc.id_number ?? ""),
-          String(doc.merch_id ?? ""),
-          String(doc.item_count ?? 0),
-          String(doc.total ?? 0),
-          doc.date instanceof Date ? doc.date.toISOString() : String(doc.date),
-        ].join("|"),
-        doc,
-      ])
-    ).values()
-  );
+  if (!docs.length) {
+    return { success: true, report: [] };
+  }
 
-  const report = uniqueDocs.length
-    ? session
-      ? await Report.insertMany(uniqueDocs, { session })
-      : await Report.insertMany(uniqueDocs)
-    : [];
+  try {
+    const report = session
+      ? await Report.insertMany(docs, { session, ordered: false })
+      : await Report.insertMany(docs, { ordered: false });
 
-  return {
-    success: true,
-    report,
-  };
+    return { success: true, report };
+  } catch (err: any) {
+    if (err?.code === 11000) {
+      return {
+        success: true,
+        report: err.insertedDocs ?? [],
+        message: "One or more reports already existed and were skipped",
+      };
+    }
+    throw err;
+  }
 };
 
 export const reportService = {
@@ -451,6 +421,7 @@ export const reportService = {
   getMerchandiseReport,
   getMerchandiseReportById,
   deleteMerchandiseReportById,
+  getMerchandiseProductNames,
 };
 
 export default {
@@ -458,4 +429,5 @@ export default {
   getMerchandiseReport,
   getMerchandiseReportById,
   deleteMerchandiseReportById,
+  getMerchandiseProductNames,
 };


### PR DESCRIPTION
## Summary
Fixes duplicate report entries and broken filters/totals on Merchandise 
Reports.

## 1. Duplicate reports
Orders sometimes showed up twice. Caused by `createReports` only checking 
duplicates within a single call, not across calls.

**Fix:**
- Added a unique index on `order_id` + `merch_id` so MongoDB blocks 
  duplicates
- Updated `createReports` to skip duplicates safely instead of erroring
- Cleaned up existing duplicate data (with back up)

## 2. Filters/totals only worked on current page
Search, totals, and product dropdown only reflected the visible page of 10, 
not the full result set. Caused by only one filter being applied at a time, 
wrong field paths after the DB join, pagination happening before totals, 
and the frontend not sending most filter values.

**Fix:**
- Combined all filters into one query
- Fixed wrong field paths
- Totals/product list now calculated from the full filtered dataset
- Frontend now sends all filters correctly