### PR TITLE
Fix Report Product Filter/Fix and add routed the SetNewPassword

### DIFF
--- a/client-side-ts/src/features/admin/organization/components/OrganizationView.tsx
+++ b/client-side-ts/src/features/admin/organization/components/OrganizationView.tsx
@@ -79,7 +79,14 @@ const tabs: Array<{
 
 const courses = ["BSIT", "BSCS", "ACT"];
 const years = ["1", "2", "3", "4"];
-const campuses = ["UC-Main", "UC-Banilad", "UC-LM", "UC-PT", "UC-CS"];
+const campuses = [
+  "UC_MAIN",
+  "UC_BANILAD",
+  "UC_LM",
+  "UC_PT",
+  "UC_JONES",
+  "OTHER_CAMPUS",
+];
 const adminRoles = [
   "President",
   "Vice-President Internal",

--- a/client-side-ts/src/features/admin/reports/components/ReportsView.tsx
+++ b/client-side-ts/src/features/admin/reports/components/ReportsView.tsx
@@ -205,6 +205,7 @@ const ReportsFilterPopover = ({
                       <SelectValue placeholder="All products" />
                     </SelectTrigger>
                     <SelectContent>
+                      <SelectItem value="all">All products</SelectItem>
                       {uniqueProductNames.map((name) => (
                         <SelectItem key={name} value={name}>
                           {name}

--- a/client-side-ts/src/features/admin/reports/hooks/useReportsData.ts
+++ b/client-side-ts/src/features/admin/reports/hooks/useReportsData.ts
@@ -140,6 +140,9 @@ export const useReportsData = () => {
           dateFrom: filters.dateFrom,
           dateTo: filters.dateTo,
         });
+
+        
+
         if (requestId !== merchandiseRequestRef.current) return;
         if (!result) throw new Error("No merchandise reports returned");
 

--- a/client-side-ts/src/pages/auth/SetNewPassword.tsx
+++ b/client-side-ts/src/pages/auth/SetNewPassword.tsx
@@ -1,17 +1,75 @@
+import { useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import {
   SetNewPasswordForm,
   type SetNewPasswordCredentials,
 } from "@/features/auth";
 
 export default function SetNewPassword() {
-  const handleSetNewPassword = (_values: SetNewPasswordCredentials) => {
-    // insert login here
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get("token");
+  const navigate = useNavigate();
+  const [message, setMessage] = useState<{
+    type: "error" | "success";
+    text: string;
+  } | null>(null);
+
+  const handleSetNewPassword = async (values: SetNewPasswordCredentials) => {
+    if (!token) {
+      setMessage({ type: "error", text: "Invalid or missing reset token." });
+      return;
+    }
+
+    try {
+      const response = await fetch(
+        `https://staging-api.psits.org/api/student/reset-password/${token}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ newPassword: values.password }),
+        }
+      );
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        setMessage({
+          type: "error",
+          text: data.message || "Something went wrong.",
+        });
+        return;
+      }
+
+      setMessage({
+        type: "success",
+        text: data.message || "Password updated!",
+      });
+      setTimeout(() => {
+        navigate("/auth/login");
+      }, 2000);
+    } catch {
+      setMessage({
+        type: "error",
+        text: "Network error. Please try again.",
+      });
+    }
   };
 
   return (
     <div className="flex h-screen w-screen flex-row bg-gray-300">
       <div className="flex w-full items-center justify-center bg-white md:w-1/2">
-        <SetNewPasswordForm onResetPassword={handleSetNewPassword} />
+        <div className="w-full max-w-md">
+          {message && (
+            <p
+              className={`mb-4 text-center text-sm ${
+                message.type === "error" ? "text-red-500" : "text-green-600"
+              }`}
+            >
+              {message.text}
+            </p>
+          )}
+          <SetNewPasswordForm onResetPassword={handleSetNewPassword} />
+        </div>
       </div>
     </div>
   );

--- a/client-side/src/pages/authentication/ResetPassword.jsx
+++ b/client-side/src/pages/authentication/ResetPassword.jsx
@@ -50,7 +50,9 @@ const NewPasswordForm = () => {
         }, 3000);
       })
       .catch((error) => {
-        showToast("error", "Your link has expired");
+        const message =
+          error.response?.data?.message || "Something went wrong. Please try again.";
+        showToast("error", message);
       });
   };
 

--- a/server-side/src/controllers/index.controller.ts
+++ b/server-side/src/controllers/index.controller.ts
@@ -13,7 +13,7 @@ const token_key = process.env.JWT_SECRET ?? "Default_Token";
 const url =
   process.env.DB_NAME !== "psits-test"
     ? "https://psits.vercel.app/reset-password/"
-    : "https://psits-staging.vercel.app/reset-password/";
+    : "https://staging-v2.psits.org/auth/reset-password?token=";
 
 export const loginController = async (req: Request, res: Response) => {
   const { id_number, password } = req.body;

--- a/server-side/src/controllers/index.v2.controller.ts
+++ b/server-side/src/controllers/index.v2.controller.ts
@@ -17,7 +17,7 @@ const token_key = process.env.JWT_SECRET ?? "Default_Token";
 const url =
   process.env.DB_NAME !== "psits-test"
     ? "https://psits.vercel.app/reset-password/"
-    : "https://psits-staging.vercel.app/reset-password/";
+    : "http://localhost:5173/auth/reset-password?token=";
 
 import { studentService } from "../services/student.service";
 import { adminService } from "../services/admin.service";
@@ -170,7 +170,6 @@ export interface jwtPayload {
 export const resetPasswordController = async (req: Request, res: Response) => {
   try {
     const decodedToken = jwt.verify(req.params.token, token_key) as jwtPayload;
-
     if (!decodedToken) {
       return res.status(401).send({ message: "Invalid token" });
     }

--- a/server-side/src/controllers/report.v2.controller.ts
+++ b/server-side/src/controllers/report.v2.controller.ts
@@ -29,6 +29,7 @@ class ReportController {
       limit: result.limit,
       totalPages: result.totalPages,
       summary: result.summary,
+      productNames: result.productNames,
     });
   });
 }

--- a/server-side/src/index.ts
+++ b/server-side/src/index.ts
@@ -43,6 +43,7 @@ const allowedOrigins = [
   process.env.CORS3,
 ].filter((origin): origin is string => Boolean(origin));
 
+
 app.use(
   helmet({
     crossOriginResourcePolicy: false,

--- a/server-side/src/services/admin.service.ts
+++ b/server-side/src/services/admin.service.ts
@@ -429,7 +429,7 @@ class AdminService {
       req.body;
 
     //Check if id number existed
-    const admin = await this.retrieveSpecific(id_number);
+    const admin = await Admin.findOne({ id_number });
     if (admin) {
       throw new AppError("Already have an account!", 404);
     }

--- a/server-side/src/services/report.service.ts
+++ b/server-side/src/services/report.service.ts
@@ -70,6 +70,7 @@ export interface MerchandiseReportResult {
   limit: number;
   totalPages: number;
   summary: MerchandiseReportSummary;
+  productNames: string[];
 }
 
 const normalizePage = (value?: number) => {
@@ -289,6 +290,8 @@ export const getMerchandiseReport = async (
     { unitsSold: 0, totalRevenue: 0 }
   );
 
+  const productNames = await getMerchandiseProductNames();
+
   return {
     rows: pagedRows,
     data: pagedRows,
@@ -297,6 +300,7 @@ export const getMerchandiseReport = async (
     limit,
     totalPages,
     summary,
+    productNames,
   };
 };
 


### PR DESCRIPTION
## Summary
FIxed The "All Product" not showing in reports, added and wired up the reset-password flow for v2 auth routes.

## Changes
- **Fixed reset link URL for v2 staging** — Backend was generating links using the old path-param style (`/reset-password/:token`), but the v2 frontend router (`staging-v2.psits.org`) registers this route without a `:token` param. Updated the URL builder to use the `/auth` prefix and pass the token as a query string (`?token=`) to match the actual router config.
- **Implemented `handleSetNewPassword` in `SetNewPassword.tsx`** — This handler was previously just a stub that did nothing on submit. It now reads the token via `useSearchParams`, calls the reset-password API, and handles both success and error states.
- **Fixed silent error swallowing in `NewPasswordForm.tsx`** — The `catch` block previously always displayed a generic "Your link has expired" message regardless of the actual cause. It now surfaces the actual error message returned by the backend.