### PR TITLE
Fix recruitment opening conflicts and student position selection

### DIFF
--- a/client-side-ts/src/api/recruitment.api.ts
+++ b/client-side-ts/src/api/recruitment.api.ts
@@ -13,6 +13,7 @@ type PositionListParams = {
   page?: number;
   limit?: number;
   status?: RecruitmentPosition["hiringStatus"];
+  availableOnly?: boolean;
 };
 
 type ApplicationPayload = FormData;
@@ -76,6 +77,8 @@ export const createOpening = (data: {
   endTime: string;
   roles: unknown[];
   roleRequirements: string;
+  requirementsByItem?: Record<string, string>;
+  conflictStrategy?: "update_existing" | "close_old_create_new";
 }) => api.post(`${BASE_PATH}/positions/bulk-open`, data);
 
 export const updatePosition = (id: string, data: PositionPayload) =>

--- a/client-side-ts/src/constants/recruitmentRoles.ts
+++ b/client-side-ts/src/constants/recruitmentRoles.ts
@@ -1,0 +1,59 @@
+export type RecruitmentRolePosition = {
+  id: string;
+  name: string;
+};
+
+export type RecruitmentRoleCatalogItem = {
+  id: string;
+  title: string;
+  positions: RecruitmentRolePosition[];
+};
+
+export const RECRUITMENT_ROLE_CATALOG: RecruitmentRoleCatalogItem[] = [
+  {
+    id: "developer",
+    title: "Developer",
+    positions: [
+      { id: "frontend", name: "Front-end" },
+      { id: "backend", name: "Back-end" },
+      { id: "fullstack", name: "Full-stack" },
+      { id: "uiux", name: "UI/UX Designer" },
+      { id: "qa", name: "QA Tester" },
+    ],
+  },
+  {
+    id: "media",
+    title: "Media Creative",
+    positions: [
+      { id: "video", name: "Videographer" },
+      { id: "photo", name: "Photojournalist" },
+      { id: "creatives", name: "Creatives" },
+      { id: "techwrite", name: "Technical Writer" },
+    ],
+  },
+  {
+    id: "officer",
+    title: "Officer",
+    positions: [
+      { id: "president", name: "President" },
+      { id: "vp-external", name: "Vice Pres. - External" },
+      { id: "vp-internal", name: "Vice Pres. - Internal" },
+      { id: "auditor", name: "Auditor" },
+      { id: "asst-treasurer", name: "Asst. Treasurer" },
+      { id: "treasurer", name: "Treasurer" },
+      { id: "secretary", name: "Secretary" },
+      { id: "chief-volunteer", name: "Chief Volunteer" },
+      { id: "pro", name: "PRO" },
+      { id: "pio", name: "PIO" },
+      { id: "rep-1st", name: "1st Year REP" },
+      { id: "rep-2nd", name: "2nd Year REP" },
+      { id: "rep-3rd", name: "3rd Year REP" },
+      { id: "rep-4th", name: "4th Year REP" },
+    ],
+  },
+  {
+    id: "volunteer",
+    title: "Volunteer",
+    positions: [],
+  },
+];

--- a/client-side-ts/src/features/admin/recruitment-management/components/OpenRole.tsx
+++ b/client-side-ts/src/features/admin/recruitment-management/components/OpenRole.tsx
@@ -16,10 +16,12 @@ import {
 
 import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
+import {
+  RECRUITMENT_ROLE_CATALOG,
+  type RecruitmentRolePosition,
+} from "@/constants/recruitmentRoles";
 
-type Position = {
-  id: string;
-  name: string;
+type Position = RecruitmentRolePosition & {
   enabled: boolean;
   slots?: number;
 };
@@ -32,58 +34,15 @@ type Role = {
   slots?: number;
 };
 
-const DEFAULT_ROLES: Role[] = [
-  {
-    id: "developer",
-    title: "Developer",
+const createDefaultRoles = (): Role[] =>
+  RECRUITMENT_ROLE_CATALOG.map((role) => ({
+    ...role,
     enabled: false,
-    positions: [
-      { id: "frontend", name: "Front-end", enabled: false },
-      { id: "backend", name: "Back-end", enabled: false },
-      { id: "fullstack", name: "Full-stack", enabled: false },
-      { id: "uiux", name: "UI/UX Designer", enabled: false },
-      { id: "qa", name: "QA Tester", enabled: false },
-    ],
-  },
-  {
-    id: "media",
-    title: "Media Creative",
-    enabled: false,
-    positions: [
-      { id: "video", name: "Videographer", enabled: false },
-      { id: "photo", name: "Photojournalist", enabled: false },
-      { id: "creatives", name: "Creatives", enabled: false },
-      { id: "techwrite", name: "Technical Writer", enabled: false },
-    ],
-  },
-  {
-    id: "officer",
-    title: "Officer",
-    enabled: false,
-    positions: [
-      { id: "president", name: "President", enabled: false },
-      { id: "vp-external", name: "Vice Pres. - External", enabled: false },
-      { id: "vp-internal", name: "Vice Pres. - Internal", enabled: false },
-      { id: "auditor", name: "Auditor", enabled: false },
-      { id: "asst-treasurer", name: "Asst. Treasurer", enabled: false },
-      { id: "treasurer", name: "Treasurer", enabled: false },
-      { id: "secretary", name: "Secretary", enabled: false },
-      { id: "chief-volunteer", name: "Chief Volunteer", enabled: false },
-      { id: "pro", name: "PRO", enabled: false },
-      { id: "pio", name: "PIO", enabled: false },
-      { id: "rep-1st", name: "1st Year REP", enabled: false },
-      { id: "rep-2nd", name: "2nd Year REP", enabled: false },
-      { id: "rep-3rd", name: "3rd Year REP", enabled: false },
-      { id: "rep-4th", name: "4th Year REP", enabled: false },
-    ],
-  },
-  {
-    id: "volunteer",
-    title: "Volunteer",
-    enabled: false,
-    positions: [],
-  },
-];
+    positions: role.positions.map((position) => ({
+      ...position,
+      enabled: false,
+    })),
+  }));
 
 function formatDateDisplay(date?: Date) {
   if (!date) return "";
@@ -343,7 +302,7 @@ export default function OpenRole({
   const [startTime, setStartTime] = useState("");
   const [endTime, setEndTime] = useState("");
 
-  const [roles, setRoles] = useState<Role[]>(DEFAULT_ROLES);
+  const [roles, setRoles] = useState<Role[]>(createDefaultRoles);
   const [saveSelection, setSaveSelection] = useState(false);
   const [requirementsByItem, setRequirementsByItem] = useState<Record<string, string>>({});
   const [activeRequirementId, setActiveRequirementId] = useState<string | null>(null);
@@ -477,14 +436,14 @@ export default function OpenRole({
   const handleConfirm = () => {
     if (!isStepOneValid) return;
 
-    const confirmationData = {
+    const confirmationData: OpenRecruitmentValues = {
       startDate: startDate!.toISOString(),
       endDate: endDate!.toISOString(),
       startTime,
       endTime,
       roles,
       requirementsByItem,
-    } as OpenRecruitmentValues & { requirementsByItem: Record<string, string> };
+    };
 
     onConfirm(confirmationData);
   };

--- a/client-side-ts/src/features/admin/recruitment-management/components/RecuitmentViews.tsx
+++ b/client-side-ts/src/features/admin/recruitment-management/components/RecuitmentViews.tsx
@@ -1,6 +1,7 @@
 import { Checkbox } from "@/components/ui/checkbox";
 import { useMemo, useState } from "react";
 import {
+  AlertTriangle,
   ArrowUpDown,
   Ban,
   Check,
@@ -33,6 +34,7 @@ import { cn } from "@/lib/utils";
 import {
   useRecruitmentData,
   ROWS_PER_PAGE,
+  POSITIONS_PER_PAGE,
   DEFAULT_FILTERS,
 } from "../hooks/useRecruitmentData";
 import type {
@@ -41,6 +43,9 @@ import type {
   RecruitmentPosition,
   RecruitmentSort,
   RecruitmentSortField,
+  OpenRecruitmentValues,
+  RecruitmentOpeningConflict,
+  RecruitmentOpeningConflictStrategy,
 } from "../types/Recruitment.types";
 import { ApplicantInfoModal } from "./ApplicantInfoModal";
 import { InterviewSchedulingModal } from "./InterviewSchedulingModal";
@@ -320,6 +325,10 @@ export const RecruitmentViews = () => {
     currentPage,
     totalPages,
     setPage,
+    positionsPage,
+    setPositionsPage,
+    positionsTotalPages,
+    positionsTotal,
     isLoading,
     isMutating,
     error,
@@ -362,6 +371,10 @@ export const RecruitmentViews = () => {
     useState<RecruitmentPosition | null>(null);
   const [isScheduleOpen, setIsScheduleOpen] = useState(false);
   const [isOpenRoleOpen, setIsOpenRoleOpen] = useState(false);
+  const [openingConflict, setOpeningConflict] = useState<{
+    values: OpenRecruitmentValues;
+    conflicts: RecruitmentOpeningConflict[];
+  } | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<RecruitmentApplicant | null>(
     null
   );
@@ -410,6 +423,11 @@ const allPositionsSelected =
   positions.length > 0 &&
   positions.every((p) => selectedPositionIds.includes(p._id));
 
+const positionsStart =
+  positionsTotal > 0 ? (positionsPage - 1) * POSITIONS_PER_PAGE + 1 : 0;
+const positionsEnd =
+  positionsTotal > 0 ? Math.min(positionsStart + positions.length - 1, positionsTotal) : 0;
+
 const togglePositionSelection = (id: string) => {
   setSelectedPositionIds((current) =>
     current.includes(id)
@@ -417,6 +435,57 @@ const togglePositionSelection = (id: string) => {
       : [...current, id]
   );
 };
+
+  const handleOpenRoleConfirm = async (data: OpenRecruitmentValues) => {
+    try {
+      await openRoleApplication(data);
+      setOpeningConflict(null);
+      setIsOpenRoleOpen(false);
+    } catch (error) {
+      const conflictError = error as {
+        code?: string;
+        conflicts?: RecruitmentOpeningConflict[];
+      };
+
+      if (conflictError.code === "RECRUITMENT_POSITION_CONFLICT") {
+        setOpeningConflict({
+          values: data,
+          conflicts: conflictError.conflicts ?? [],
+        });
+      }
+    }
+  };
+
+  const resolveOpeningConflict = async (
+    strategy: RecruitmentOpeningConflictStrategy
+  ) => {
+    if (!openingConflict) return;
+
+    try {
+      await openRoleApplication({
+        ...openingConflict.values,
+        conflictStrategy: strategy,
+      });
+      setOpeningConflict(null);
+      setIsOpenRoleOpen(false);
+    } catch (error) {
+      const conflictError = error as {
+        code?: string;
+        conflicts?: RecruitmentOpeningConflict[];
+      };
+
+      if (conflictError.code === "RECRUITMENT_POSITION_CONFLICT") {
+        setOpeningConflict((current) =>
+          current
+            ? {
+                ...current,
+                conflicts: conflictError.conflicts ?? current.conflicts,
+              }
+            : current
+        );
+      }
+    }
+  };
 
   return (
     <div className="bg-background flex min-h-full flex-1 flex-col text-[#333] [&_button:disabled]:cursor-not-allowed [&_button:not(:disabled)]:cursor-pointer">
@@ -804,6 +873,44 @@ const togglePositionSelection = (id: string) => {
                   )}
                 </tbody>
               </table>
+              <div className="mt-4 flex flex-col gap-3 text-sm text-[#777] sm:flex-row sm:items-center sm:justify-between">
+                <span>
+                  Showing {positionsStart} to {positionsEnd} of {positionsTotal}
+                </span>
+                <div className="flex items-center gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={positionsPage <= 1 || isPositionsLoading}
+                    onClick={() =>
+                      setPositionsPage(Math.max(1, positionsPage - 1))
+                    }
+                    className="h-8 rounded-full border-[#e8e8e8] bg-white px-3 text-xs"
+                  >
+                    Previous
+                  </Button>
+                  <span className="rounded-full bg-[#1c9dde] px-3 py-1 text-xs font-medium text-white">
+                    {positionsPage}
+                  </span>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={
+                      positionsPage >= positionsTotalPages || isPositionsLoading
+                    }
+                    onClick={() =>
+                      setPositionsPage(
+                        Math.min(positionsTotalPages, positionsPage + 1)
+                      )
+                    }
+                    className="h-8 rounded-full border-[#e8e8e8] bg-white px-3 text-xs"
+                  >
+                    Next
+                  </Button>
+                </div>
+              </div>
             </div>
           ) : activeTab === "applicants" ? (
             <div className="overflow-x-auto">
@@ -1262,16 +1369,85 @@ const togglePositionSelection = (id: string) => {
       <OpenRole
         open={isOpenRoleOpen}
         isSubmitting={isMutating}
-        onClose={() => setIsOpenRoleOpen(false)}
-        onConfirm={async (data) => {
-          try {
-            await openRoleApplication(data);
-            setIsOpenRoleOpen(false);
-          } catch {
-            // mutationError is already set by the hook
-          }
+        onClose={() => {
+          setIsOpenRoleOpen(false);
+          setOpeningConflict(null);
         }}
+        onConfirm={handleOpenRoleConfirm}
       />
+      <Dialog
+        open={!!openingConflict}
+        onOpenChange={(open) => !open && setOpeningConflict(null)}
+      >
+        <DialogContent className="max-w-lg rounded-2xl">
+          <div className="flex flex-col gap-4">
+            <div className="flex items-start gap-3">
+              <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-amber-50">
+                <AlertTriangle className="h-5 w-5 text-amber-500" />
+              </div>
+              <div>
+                <DialogTitle className="text-lg font-semibold">
+                  Some role applications are already open
+                </DialogTitle>
+                <p className="mt-1 text-sm text-slate-500">
+                  Choose how to handle the existing openings before continuing.
+                </p>
+              </div>
+            </div>
+
+            <div className="max-h-44 space-y-2 overflow-y-auto rounded-xl border border-slate-200 bg-slate-50 p-3">
+              {(openingConflict?.conflicts || []).slice(0, 6).map((conflict) => (
+                <div
+                  key={conflict._id}
+                  className="flex items-center justify-between gap-3 rounded-lg bg-white px-3 py-2 text-sm"
+                >
+                  <span className="font-medium text-slate-700">
+                    {conflict.title}
+                  </span>
+                  <span className="shrink-0 text-xs text-slate-400">
+                    {conflict.slots ?? 0} slot
+                    {conflict.slots === 1 ? "" : "s"}
+                  </span>
+                </div>
+              ))}
+              {(openingConflict?.conflicts.length || 0) > 6 && (
+                <p className="px-1 text-xs text-slate-500">
+                  +{(openingConflict?.conflicts.length || 0) - 6} more
+                </p>
+              )}
+            </div>
+
+            <div className="grid gap-2 sm:grid-cols-3">
+              <Button
+                type="button"
+                variant="outline"
+                className="h-auto rounded-xl px-3 py-2 text-sm"
+                disabled={isMutating}
+                onClick={() => setOpeningConflict(null)}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                className="h-auto rounded-xl px-3 py-2 text-sm"
+                disabled={isMutating}
+                onClick={() => resolveOpeningConflict("update_existing")}
+              >
+                Update existing
+              </Button>
+              <Button
+                type="button"
+                className="h-auto rounded-xl bg-[#1C9DDE] px-3 py-2 text-sm hover:bg-[#168bc7]"
+                disabled={isMutating}
+                onClick={() => resolveOpeningConflict("close_old_create_new")}
+              >
+                Close old and create
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
       <PositionEditModal
         open={!!editingPosition}
         isSubmitting={isMutating}

--- a/client-side-ts/src/features/admin/recruitment-management/hooks/useRecruitmentData.ts
+++ b/client-side-ts/src/features/admin/recruitment-management/hooks/useRecruitmentData.ts
@@ -11,6 +11,7 @@ import type {
   ScheduleInterviewValues,
   RecruitmentPosition,
   OpenRecruitmentValues,
+  RecruitmentOpeningConflictError,
 } from "../types/Recruitment.types";
 
 // Adjust this path if your actual file structure differs
@@ -32,6 +33,7 @@ import {
 } from "../../../../api/recruitment.api";
 
 export const ROWS_PER_PAGE = 8;
+export const POSITIONS_PER_PAGE = 8;
 
 export const DEFAULT_FILTERS: RecruitmentFilters = {
   roles: [],
@@ -226,6 +228,9 @@ export const useRecruitmentData = () => {
   const [positions, setPositions] = useState<RecruitmentPosition[]>([]);
   const [isPositionsLoading, setIsPositionsLoading] = useState(true);
   const [positionsError, setPositionsError] = useState<string | null>(null);
+  const [positionsPage, setPositionsPage] = useState(1);
+  const [positionsTotalPages, setPositionsTotalPages] = useState(1);
+  const [positionsTotal, setPositionsTotal] = useState(0);
 
   const [mutationError, setMutationError] = useState<string | null>(null);
 
@@ -317,12 +322,20 @@ export const useRecruitmentData = () => {
     }
   }, []);
 
-  const fetchPositions = useCallback(async () => {
+  const fetchPositions = useCallback(async (pageNumber = positionsPage) => {
     setIsPositionsLoading(true);
     setPositionsError(null);
     try {
-      const res = await listPositions({});
-      setPositions(res.data.data.positions);
+      const res = await listPositions({
+        page: pageNumber,
+        limit: POSITIONS_PER_PAGE,
+      });
+      const payload = res.data.data;
+      const pagination = payload.pagination;
+
+      setPositions(payload.positions || []);
+      setPositionsTotalPages(Number(pagination?.totalPages || 1));
+      setPositionsTotal(Number(pagination?.total || 0));
     } catch (err) {
       setPositionsError(
         err instanceof Error ? err.message : "Failed to load positions"
@@ -330,7 +343,7 @@ export const useRecruitmentData = () => {
     } finally {
       setIsPositionsLoading(false);
     }
-  }, []);
+  }, [positionsPage]);
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional fetch-on-mount; fetchPositions is also used for refetch, so its internal setIsPositionsLoading/setPositionsError calls are needed there
@@ -632,8 +645,33 @@ export const useRecruitmentData = () => {
         ...data,
         roleRequirements: data.roleRequirements ?? "",
       });
-      await fetchPositions();
+      setPositionsPage(1);
+      await fetchPositions(1);
     } catch (err) {
+      const response = (err as {
+        response?: {
+          status?: number;
+          data?: {
+            code?: string;
+            message?: string;
+            data?: { conflicts?: RecruitmentOpeningConflictError["conflicts"] };
+          };
+        };
+      }).response;
+
+      if (
+        response?.status === 409 &&
+        response.data?.code === "RECRUITMENT_POSITION_CONFLICT"
+      ) {
+        const conflictError = new Error(
+          response.data.message || "Some selected role applications already exist."
+        ) as RecruitmentOpeningConflictError;
+        conflictError.code = "RECRUITMENT_POSITION_CONFLICT";
+        conflictError.conflicts = response.data.data?.conflicts ?? [];
+        setMutationError(conflictError.message);
+        throw conflictError;
+      }
+
       setMutationError(
         err instanceof Error ? err.message : "Failed to open role application"
       );
@@ -696,7 +734,16 @@ export const useRecruitmentData = () => {
     setMutationError(null);
     try {
       await deletePositionApi(id);
-      setPositions((current) => current.filter((p) => p._id !== id));
+      const nextPage =
+        positions.length === 1 && positionsPage > 1
+          ? positionsPage - 1
+          : positionsPage;
+
+      if (nextPage !== positionsPage) {
+        setPositionsPage(nextPage);
+      }
+
+      await fetchPositions(nextPage);
     } catch (err) {
       setMutationError(
         err instanceof Error ? err.message : "Failed to delete position"
@@ -844,6 +891,10 @@ export const useRecruitmentData = () => {
     setPage,
     totalPages,
     currentPage,
+    positionsPage,
+    setPositionsPage,
+    positionsTotalPages,
+    positionsTotal,
     isLoading,
     isMutating,
     error,

--- a/client-side-ts/src/features/admin/recruitment-management/types/Recruitment.types.ts
+++ b/client-side-ts/src/features/admin/recruitment-management/types/Recruitment.types.ts
@@ -90,6 +90,24 @@ export interface OpenRecruitmentRole {
   slots?: number;
 }
 
+export type RecruitmentOpeningConflictStrategy =
+  | "update_existing"
+  | "close_old_create_new";
+
+export interface RecruitmentOpeningConflict {
+  _id: string;
+  title: string;
+  slots?: number;
+  applicationOpensAt?: string;
+  applicationDeadline?: string;
+  createdAt?: string;
+}
+
+export interface RecruitmentOpeningConflictError extends Error {
+  code: "RECRUITMENT_POSITION_CONFLICT";
+  conflicts: RecruitmentOpeningConflict[];
+}
+
 export interface OpenRecruitmentValues {
   startDate: string;
   endDate: string;
@@ -97,4 +115,6 @@ export interface OpenRecruitmentValues {
   endTime: string;
   roles: OpenRecruitmentRole[];
   roleRequirements?: string;
+  requirementsByItem?: Record<string, string>;
+  conflictStrategy?: RecruitmentOpeningConflictStrategy;
 }

--- a/client-side-ts/src/pages/student/ApplicationPage.tsx
+++ b/client-side-ts/src/pages/student/ApplicationPage.tsx
@@ -6,6 +6,7 @@ import {
   getApplicationsForUser,
 } from "@/api/recruitment.api";
 import type { Application, RecruitmentPosition } from "@/types/recruitment";
+import { RECRUITMENT_ROLE_CATALOG } from "@/constants/recruitmentRoles";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -22,16 +23,60 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Upload, Check, X } from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Upload, Check, X, ChevronDown } from "lucide-react";
 import { toast } from "sonner";
 
 const COURSES = ["BSIT", "BSCS"];
 const YEARS = ["1st Year", "2nd Year", "3rd Year", "4th Year"];
+const POSITIONS_PAGE_LIMIT = 100;
 const YEAR_MAP: Record<string, string> = {
   "1": "1st Year",
   "2": "2nd Year",
   "3": "3rd Year",
   "4": "4th Year",
+};
+
+const getPositionTimestamp = (position: RecruitmentPosition) => {
+  const timestamp = new Date(position.updatedAt || position.createdAt).getTime();
+  return Number.isFinite(timestamp) ? timestamp : 0;
+};
+
+const normalizePositionLabel = (value: string) =>
+  value.toLowerCase().replace(/[^a-z0-9]/g, "");
+
+const getPositionKey = (role: string, position: string | null) =>
+  `${normalizePositionLabel(role)}:${normalizePositionLabel(position || role)}`;
+
+const parsePositionTitle = (title: string) => {
+  const [base, ...rest] = title.split(" - ");
+  return {
+    baseRole: base.trim(),
+    subLabel: rest.length > 0 ? rest.join(" - ").trim() : null,
+  };
+};
+
+const isPositionCurrentlyOpen = (position?: RecruitmentPosition) => {
+  if (
+    !position ||
+    position.isActive === false ||
+    position.hiringStatus !== "OPEN"
+  ) {
+    return false;
+  }
+
+  const now = Date.now();
+  const deadline = position.applicationDeadline
+    ? new Date(position.applicationDeadline).getTime()
+    : null;
+
+  if (deadline && Number.isFinite(deadline) && deadline < now) return false;
+
+  return true;
 };
 
 type StatusStep = {
@@ -364,6 +409,7 @@ export const ApplicationPage = () => {
   const [selectedPositionId, setSelectedPositionId] = useState("");
   const [subPosition, setSubPosition] = useState("");
   const [selectedBaseRole, setSelectedBaseRole] = useState("");
+  const [positionSelectOpen, setPositionSelectOpen] = useState(false);
   const [acknowledged, setAcknowledged] = useState(false);
   const [resume, setResume] = useState<File | null>(null);
   const [uploadOpen, setUploadOpen] = useState(false);
@@ -417,8 +463,34 @@ export const ApplicationPage = () => {
   useEffect(() => {
     const fetchPositions = async () => {
       try {
-        const res = await listPositions({ status: "OPEN" });
-        setPositions(res.data.data?.positions || []);
+        const firstPage = await listPositions({
+          status: "OPEN",
+          page: 1,
+          limit: POSITIONS_PAGE_LIMIT,
+        });
+        const firstPayload = firstPage.data.data;
+        const allPositions: RecruitmentPosition[] = [
+          ...(firstPayload?.positions || []),
+        ];
+        const totalPages = Number(firstPayload?.pagination?.totalPages || 1);
+
+        if (totalPages > 1) {
+          const remainingPages = await Promise.all(
+            Array.from({ length: totalPages - 1 }, (_, index) =>
+              listPositions({
+                status: "OPEN",
+                page: index + 2,
+                limit: POSITIONS_PAGE_LIMIT,
+              })
+            )
+          );
+
+          remainingPages.forEach((pageResult) => {
+            allPositions.push(...(pageResult.data.data?.positions || []));
+          });
+        }
+
+        setPositions(allPositions);
       } catch (err) {
         console.error("Failed to load positions:", err);
         toast.error("Couldn't load open positions. Try refreshing.");
@@ -445,26 +517,88 @@ export const ApplicationPage = () => {
     fetchApplications();
   }, []);
 
-  // Position titles look like "Developer - Frontend" or plain "Volunteer".
-  // Split each into a base role + optional sub-label so the two dropdowns
-  // below can be driven from data that's actually stored as one combined
-  // string on the backend, rather than a hardcoded list of sub-positions.
+  const positionsByCatalogKey = useMemo(() => {
+    const byKey = new Map<string, RecruitmentPosition>();
+
+    positions.forEach((position) => {
+      const { baseRole, subLabel } = parsePositionTitle(position.title);
+      const key = getPositionKey(baseRole, subLabel);
+      const current = byKey.get(key);
+      const nextIsOpen = isPositionCurrentlyOpen(position);
+      const currentIsOpen = isPositionCurrentlyOpen(current);
+
+      if (
+        !current ||
+        (nextIsOpen && !currentIsOpen) ||
+        (nextIsOpen === currentIsOpen &&
+          getPositionTimestamp(position) > getPositionTimestamp(current))
+      ) {
+        byKey.set(key, position);
+      }
+    });
+
+    return byKey;
+  }, [positions]);
+
   const groupedPositions = useMemo(() => {
-  const groups: Record<string, { positionId: string; subLabel: string | null }[]> = {};
+    const groups: Record<
+      string,
+      {
+        id: string;
+        positionId: string;
+        subLabel: string | null;
+        isOpen: boolean;
+        position?: RecruitmentPosition;
+      }[]
+    > = {};
 
-    positions.forEach((p) => {
-      const [base, ...rest] = p.title.split(" - ");
-      const baseRole = base.trim();
-      const subLabel = rest.length > 0 ? rest.join(" - ").trim() : null;
+    RECRUITMENT_ROLE_CATALOG.forEach((role) => {
+      if (role.positions.length === 0) {
+        const position = positionsByCatalogKey.get(
+          getPositionKey(role.title, null)
+        );
+        groups[role.title] = [
+          {
+            id: role.id,
+            positionId: position?._id || "",
+            subLabel: null,
+            isOpen: isPositionCurrentlyOpen(position),
+            position,
+          },
+        ];
+        return;
+      }
 
-      if (!groups[baseRole]) groups[baseRole] = [];
-      groups[baseRole].push({ positionId: p._id, subLabel });
+      groups[role.title] = role.positions.map((catalogPosition) => {
+        const position = positionsByCatalogKey.get(
+          getPositionKey(role.title, catalogPosition.name)
+        );
+
+        return {
+          id: catalogPosition.id,
+          positionId: position?._id || "",
+          subLabel: catalogPosition.name,
+          isOpen: isPositionCurrentlyOpen(position),
+          position,
+        };
+      });
     });
 
     return groups;
-  }, [positions]);
+  }, [positionsByCatalogKey]);
 
-  const baseRoleOptions = Object.keys(groupedPositions);
+  const baseRoleOptions = RECRUITMENT_ROLE_CATALOG.map((role) => role.title);
+  const selectedRolePositionOptions =
+    groupedPositions[selectedBaseRole] || [];
+  const hasPositionOptions = selectedRolePositionOptions.length > 0;
+  const selectedPositionOption = selectedRolePositionOptions.find(
+    (item) => item.positionId && item.positionId === selectedPositionId
+  );
+  const selectedPositionLabel = selectedPositionOption
+    ? selectedPositionOption.subLabel ||
+      selectedPositionOption.position?.title ||
+      selectedBaseRole
+    : "";
 
   const selectedPosition = positions.find((p) => p._id === selectedPositionId);
 
@@ -541,8 +675,6 @@ export const ApplicationPage = () => {
     e.preventDefault();
     if (!isFormValid || !resume) return;
 
-     console.log("DEBUG submitting:", { selectedPositionId, subPosition });
-
     setSubmitting(true);
     try {
       const formData = new FormData();
@@ -562,7 +694,13 @@ export const ApplicationPage = () => {
       toast.success("Application submitted!");
     } catch (err) {
       console.error("Submission failed:", err);
-      toast.error("Application submission failed. Please try again.");
+      const message =
+        (err as { response?: { data?: { message?: string; error?: string } } })
+          .response?.data?.message ||
+        (err as { response?: { data?: { message?: string; error?: string } } })
+          .response?.data?.error ||
+        "Application submission failed. Please try again.";
+      toast.error(message);
     } finally {
       setSubmitting(false);
     }
@@ -621,10 +759,15 @@ export const ApplicationPage = () => {
                 onValueChange={(v) => {
                   setSelectedBaseRole(v);
                   setSubPosition("");
+                  setPositionSelectOpen(false);
                   // If this base role has no sub-labels (e.g. "Volunteer"),
                   // there's only one matching position — select it right away.
                   const group = groupedPositions[v] || [];
-                  if (group.length === 1 && group[0].subLabel === null) {
+                  if (
+                    group.length === 1 &&
+                    group[0].subLabel === null &&
+                    group[0].isOpen
+                  ) {
                     setSelectedPositionId(group[0].positionId);
                   } else {
                     setSelectedPositionId("");
@@ -650,35 +793,67 @@ export const ApplicationPage = () => {
                 </SelectContent>
               </Select>
 
-              <Select
-                value={subPosition}
-                onValueChange={(label) => {
-                  setSubPosition(label);
-                  const match = (
-                    groupedPositions[selectedBaseRole] || []
-                  ).find((item) => item.subLabel === label);
-                  if (match) setSelectedPositionId(match.positionId);
-                }}
-                disabled={
-                  !selectedBaseRole ||
-                  (groupedPositions[selectedBaseRole] || []).every(
-                    (item) => item.subLabel === null
+              <Popover
+                open={positionSelectOpen}
+                onOpenChange={(open) =>
+                  setPositionSelectOpen(
+                    open && !!selectedBaseRole && hasPositionOptions
                   )
                 }
               >
-                <SelectTrigger className="flex-1">
-                  <SelectValue placeholder="Position" />
-                </SelectTrigger>
-                <SelectContent>
-                  {(groupedPositions[selectedBaseRole] || [])
-                    .filter((item) => item.subLabel !== null)
-                    .map((item) => (
-                      <SelectItem key={item.positionId} value={item.subLabel!}>
-                        {item.subLabel}
-                      </SelectItem>
-                    ))}
-                </SelectContent>
-              </Select>
+                <PopoverTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={!selectedBaseRole}
+                    className="h-10 flex-1 justify-between rounded-md border-gray-200 bg-white px-3 text-left text-sm font-normal shadow-none hover:bg-white disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    <span
+                      className={
+                        selectedPositionLabel
+                          ? "truncate text-gray-900"
+                          : "truncate text-gray-400"
+                      }
+                    >
+                      {selectedPositionLabel || "Position"}
+                    </span>
+                    <ChevronDown className="h-4 w-4 shrink-0 text-gray-400" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent
+                  align="start"
+                  className="w-[var(--radix-popover-trigger-width)] p-1"
+                >
+                  {selectedRolePositionOptions.map((item) => {
+                    const label =
+                      item.subLabel || item.position?.title || selectedBaseRole;
+
+                    return (
+                      <button
+                        key={item.id}
+                        type="button"
+                        disabled={!item.isOpen}
+                        onClick={() => {
+                          if (!item.isOpen || !item.positionId) return;
+                          setSubPosition(item.subLabel || "");
+                          setSelectedPositionId(item.positionId);
+                          setPositionSelectOpen(false);
+                        }}
+                        className={
+                          item.isOpen
+                            ? "flex w-full cursor-pointer items-center justify-between gap-3 rounded-sm px-2 py-1.5 text-left text-sm text-[#0274b8] hover:bg-sky-50"
+                            : "flex w-full cursor-not-allowed items-center justify-between gap-3 rounded-sm px-2 py-1.5 text-left text-sm text-slate-400 opacity-60"
+                        }
+                      >
+                        <span className="truncate">{label}</span>
+                        <span className="shrink-0 text-[11px]">
+                          {item.isOpen ? "Open" : "Closed"}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </PopoverContent>
+              </Popover>
             </div>
 
             <div className="min-h-[180px] rounded-lg border border-gray-200 p-4 text-sm text-gray-500">

--- a/client-side-ts/src/types/recruitment.ts
+++ b/client-side-ts/src/types/recruitment.ts
@@ -7,6 +7,7 @@ export interface RecruitmentPosition {
   hiringStatus: "DRAFT" | "OPEN" | "CLOSED";
   isActive: boolean;
   slots?: number;
+  applicationOpensAt?: string;
   applicationDeadline?: string;
   sortOrder: number;
   createdAt: string;

--- a/server-side/src/controllers/recruitment.v2.controller.ts
+++ b/server-side/src/controllers/recruitment.v2.controller.ts
@@ -42,6 +42,13 @@ class RecruitmentController {
     async (req: Request, res: Response) => {
       const positions =
         await recruitmentService.createPositionsFromOpening(req);
+      if (!Array.isArray(positions) && positions?.conflict) {
+        return res.status(409).json({
+          code: "RECRUITMENT_POSITION_CONFLICT",
+          message: "Some selected role applications are already open.",
+          data: positions,
+        });
+      }
       return res.status(201).json({
         message: "Positions opened successfully",
         data: positions,

--- a/server-side/src/services/recruitment.service.ts
+++ b/server-side/src/services/recruitment.service.ts
@@ -33,6 +33,25 @@ const r2Client = new S3Client({
   },
 });
 
+const OPENING_CONFLICT_STRATEGIES = {
+  updateExisting: "update_existing",
+  closeOldCreateNew: "close_old_create_new",
+};
+
+const toBooleanQuery = (value: any) =>
+  value === true || value === "true" || value === "1";
+
+const toPositiveInteger = (value: any, fallback: number) => {
+  const parsed = parseInt(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+const toRequirementList = (value: any) =>
+  String(value ?? "")
+    .split("\n")
+    .map((line: string) => line.trim())
+    .filter((line: string) => line.length > 0);
+
 export class RecruitmentService {
   /** Create a new recruitment position */
   async createPosition(req: any) {
@@ -65,7 +84,8 @@ export class RecruitmentService {
       const now = Date.now();
       if (isActive && deadline.getTime() < now) {
         throw new AppError(
-          "Application deadline must be in future for open positions."
+          "Application deadline must be in future for open positions.",
+          400
         );
       }
     }
@@ -88,8 +108,16 @@ export class RecruitmentService {
 
   /** Admin: bulk-create positions from the "Open Role Application" modal */
   async createPositionsFromOpening(req: any) {
-    const { startDate, endDate, startTime, endTime, roles, roleRequirements } =
-      req.body;
+    const {
+      startDate,
+      endDate,
+      startTime,
+      endTime,
+      roles,
+      roleRequirements,
+      requirementsByItem,
+      conflictStrategy,
+    } = req.body;
 
     if (
       !startDate ||
@@ -118,11 +146,7 @@ export class RecruitmentService {
       );
     }
 
-    const requirementsList: string[] = (roleRequirements ?? "")
-      .split("\n")
-      .map((line: string) => line.trim())
-      .filter((line: string) => line.length > 0);
-
+    const fallbackRequirements = toRequirementList(roleRequirements);
     const createdBy = req.userV2?.sub || req.admin?._id.toString();
     const docs: any[] = [];
     let sortOrder = 0;
@@ -133,13 +157,19 @@ export class RecruitmentService {
         (p: any) => p.enabled
       );
       if (enabledSubPositions.length === 0) {
+        const itemRequirements = toRequirementList(
+          requirementsByItem?.[role.id]
+        );
+        const requirements =
+          itemRequirements.length > 0 ? itemRequirements : fallbackRequirements;
+
         // e.g. "Volunteer" — enabled with no sub-positions
         docs.push({
           title: role.title,
           hiringStatus: hiringStatus.OPEN,
           isActive: true,
           slots: role.slots ?? undefined,
-          requirements: requirementsList,
+          requirements,
           applicationOpensAt,
           applicationDeadline,
           sortOrder: sortOrder++,
@@ -149,12 +179,18 @@ export class RecruitmentService {
       }
 
       for (const position of enabledSubPositions) {
+        const itemRequirements = toRequirementList(
+          requirementsByItem?.[position.id]
+        );
+        const requirements =
+          itemRequirements.length > 0 ? itemRequirements : fallbackRequirements;
+
         docs.push({
           title: `${role.title} - ${position.name}`,
           hiringStatus: hiringStatus.OPEN,
           isActive: true,
           slots: position.slots ?? undefined,
-          requirements: requirementsList,
+          requirements,
           applicationOpensAt,
           applicationDeadline,
           sortOrder: sortOrder++,
@@ -167,13 +203,115 @@ export class RecruitmentService {
       throw new AppError("No roles or positions were selected.", 400);
     }
 
+    const selectedTitles = docs.map((doc) => doc.title);
+    const existingOpenPositions = await RecruitmentPosition.find({
+      title: { $in: selectedTitles },
+      hiringStatus: hiringStatus.OPEN,
+      isActive: true,
+    }).sort({ createdAt: -1 });
+
+    if (
+      existingOpenPositions.length > 0 &&
+      !Object.values(OPENING_CONFLICT_STRATEGIES).includes(conflictStrategy)
+    ) {
+      return {
+        conflict: true,
+        conflicts: existingOpenPositions.map((position: any) => ({
+          _id: position._id,
+          title: position.title,
+          slots: position.slots,
+          applicationOpensAt: position.applicationOpensAt,
+          applicationDeadline: position.applicationDeadline,
+          createdAt: position.createdAt,
+        })),
+      };
+    }
+
+    if (
+      conflictStrategy === OPENING_CONFLICT_STRATEGIES.closeOldCreateNew &&
+      existingOpenPositions.length > 0
+    ) {
+      await RecruitmentPosition.updateMany(
+        {
+          _id: {
+            $in: existingOpenPositions.map((position: any) => position._id),
+          },
+        },
+        {
+          $set: {
+            hiringStatus: hiringStatus.CLOSED,
+            isActive: false,
+          },
+        }
+      );
+      return RecruitmentPosition.insertMany(docs);
+    }
+
+    if (conflictStrategy === OPENING_CONFLICT_STRATEGIES.updateExisting) {
+      const existingByTitle = existingOpenPositions.reduce(
+        (map: Map<string, any[]>, position: any) => {
+          const list = map.get(position.title) ?? [];
+          list.push(position);
+          map.set(position.title, list);
+          return map;
+        },
+        new Map()
+      );
+
+      const savedPositions = [];
+
+      for (const doc of docs) {
+        const matchingPositions = existingByTitle.get(doc.title) ?? [];
+        const [primaryPosition, ...duplicatePositions] = matchingPositions;
+
+        if (!primaryPosition) {
+          const created = await RecruitmentPosition.create(doc);
+          savedPositions.push(created);
+          continue;
+        }
+
+        primaryPosition.set({
+          slots: doc.slots,
+          requirements: doc.requirements,
+          applicationOpensAt: doc.applicationOpensAt,
+          applicationDeadline: doc.applicationDeadline,
+          sortOrder: doc.sortOrder,
+          hiringStatus: hiringStatus.OPEN,
+          isActive: true,
+          createdBy,
+        });
+        await primaryPosition.save();
+        savedPositions.push(primaryPosition);
+
+        if (duplicatePositions.length > 0) {
+          await RecruitmentPosition.updateMany(
+            {
+              _id: {
+                $in: duplicatePositions.map((position: any) => position._id),
+              },
+            },
+            {
+              $set: {
+                hiringStatus: hiringStatus.CLOSED,
+                isActive: false,
+              },
+            }
+          );
+        }
+      }
+
+      return savedPositions;
+    }
+
     return RecruitmentPosition.insertMany(docs);
   }
 
   /** Get all positions with filtering */
   async listPositions(req: any) {
-    const { search, status, page = 1, limit = 10 } = req.query;
+    const { search, status, page = 1, limit = 10, availableOnly } = req.query;
     const query: any = {};
+    const currentPage = toPositiveInteger(page, 1);
+    const pageLimit = toPositiveInteger(limit, 10);
 
     // Public API defaults to only active/open positions unless filtered
     if (req.path.startsWith("/public")) {
@@ -181,6 +319,28 @@ export class RecruitmentService {
       query.hiringStatus = hiringStatus.OPEN;
     } else {
       if (status) query.hiringStatus = status;
+    }
+
+    if (toBooleanQuery(availableOnly)) {
+      const now = new Date();
+      query.isActive = true;
+      query.hiringStatus = hiringStatus.OPEN;
+      query.$and = [
+        {
+          $or: [
+            { applicationOpensAt: { $exists: false } },
+            { applicationOpensAt: null },
+            { applicationOpensAt: { $lte: now } },
+          ],
+        },
+        {
+          $or: [
+            { applicationDeadline: { $exists: false } },
+            { applicationDeadline: null },
+            { applicationDeadline: { $gte: now } },
+          ],
+        },
+      ];
     }
 
     if (search) {
@@ -191,15 +351,20 @@ export class RecruitmentService {
     }
 
     const positions = await RecruitmentPosition.find(query)
-      .sort({ sortOrder: 1 })
-      .skip((parseInt(page) - 1) * parseInt(limit))
-      .limit(parseInt(limit));
+      .sort({ sortOrder: 1, createdAt: -1 })
+      .skip((currentPage - 1) * pageLimit)
+      .limit(pageLimit);
 
     const total = await RecruitmentPosition.countDocuments(query);
 
     return {
       positions,
-      pagination: { page, limit, total, totalPages: Math.ceil(total / limit) },
+      pagination: {
+        page: currentPage,
+        limit: pageLimit,
+        total,
+        totalPages: Math.ceil(total / pageLimit),
+      },
     };
   }
 
@@ -250,7 +415,8 @@ export class RecruitmentService {
         position.applicationDeadline.getTime() < now
       ) {
         throw new AppError(
-          "Application deadline must be in future for open positions."
+          "Application deadline must be in future for open positions.",
+          400
         );
       }
     }
@@ -310,6 +476,13 @@ export class RecruitmentService {
       );
     }
 
+    if (
+      position.applicationOpensAt &&
+      position.applicationOpensAt > new Date()
+    ) {
+      throw new AppError("Application is not open yet.", 400);
+    }
+
     // Validate deadline not expired
     if (
       position.applicationDeadline &&
@@ -334,7 +507,7 @@ export class RecruitmentService {
 
     // Get student snapshot for historical record
     const student = await Student.findById(studentId)
-      .select("first_name last_name id_number email")
+      .select("first_name last_name id_number email course year")
       .lean();
     if (!student) throw new AppError("Student not found.", 404);
 
@@ -365,11 +538,13 @@ export class RecruitmentService {
       position: positionId,
       applicant: studentId,
       applicantSnapshot: {
-        name: `${student.first_name} ${student.last_name}`.trim(),
+        name: `${student.first_name || req.body.firstName} ${
+          student.last_name || req.body.lastName
+        }`.trim(),
         idNumber: student.id_number,
-        email: student.email,
-        course: student.course,
-        year: student.year,
+        email: student.email || req.body.email,
+        course: student.course || req.body.course,
+        year: student.year || req.body.year,
       },
       documents: {
         resume: {

--- a/server-side/src/util/errors.util.ts
+++ b/server-side/src/util/errors.util.ts
@@ -77,6 +77,17 @@ export const errorHandler = (err: Error, req: Request, res: Response, next: Next
         });
     }
 
+    const operationalError = err as Error & {
+        statusCode?: number;
+        isOperational?: boolean;
+    };
+
+    if (operationalError.isOperational && operationalError.statusCode) {
+        return res.status(operationalError.statusCode).json({
+            message: operationalError.message,
+        });
+    }
+
     // Handle other errors (e.g. Mongoose validation) here in the future
 
     return res.status(500).json({


### PR DESCRIPTION
**Summary**
- Prevent opening a new recruitment position from closing unrelated open roles
- Add admin conflict handling for already-open recruitment positions
- Paginate admin recruitment positions to avoid loading all rows at once
- Share the recruitment role catalog between admin and student flows
- Show all student-side positions with closed ones grayed out and open ones selectable
**Testing**
npm run build in server-side
node ./node_modules/typescript/bin/tsc -b in client-side-ts
**Notes**
Existing positions that were already closed by the old backend behavior may need to be reopened once.