### PR TITLE
fix(auth): resolve student password setup, signup API routing, and reset token handling

### DIFF
--- a/client-side-ts/src/features/auth/components/SetNewPasswordForm.tsx
+++ b/client-side-ts/src/features/auth/components/SetNewPasswordForm.tsx
@@ -16,7 +16,12 @@ import { Check } from "lucide-react";
 
 const formSchema = z
   .object({
-    password: z.string().min(8, "Password must be at least 8 characters"),
+    password: z
+      .string()
+      .min(8, "Password must be at least 8 characters")
+      .regex(/[a-z]/, "Must include at least one small letter")
+      .regex(/[A-Z]/, "Must include at least one capital letter")
+      .regex(/[\d\W]/, "Must include at least one number or symbol"),
     confirmPassword: z.string(),
   })
   .refine((data) => data.password === data.confirmPassword, {

--- a/client-side-ts/src/features/auth/components/SignupForm.tsx
+++ b/client-side-ts/src/features/auth/components/SignupForm.tsx
@@ -35,7 +35,12 @@ const baseSchema = z.object({
   email: z.email({ error: "Invalid email address" }),
   course: z.string().min(1, "Course is required"),
   year: z.string().min(1, "Year level is required"),
-  password: z.string().min(8, "Password must be at least 8 characters"),
+  password: z
+    .string()
+    .min(8, "Password must be at least 8 characters")
+    .regex(/[a-z]/, "Must include at least one small letter")
+    .regex(/[A-Z]/, "Must include at least one capital letter")
+    .regex(/[\d\W]/, "Must include at least one number or symbol"),
   confirmPassword: z.string(),
 });
 

--- a/client-side-ts/src/pages/auth/SetNewPassword.tsx
+++ b/client-side-ts/src/pages/auth/SetNewPassword.tsx
@@ -1,7 +1,8 @@
 import sidePhoto from "@/assets/side_photo_forms.png";
 
 import { useState } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams, useParams } from "react-router-dom";
+import backendConnection from "@/api/backendApi";
 import {
   SetNewPasswordForm,
   type SetNewPasswordCredentials,
@@ -9,7 +10,8 @@ import {
 
 export default function SetNewPassword() {
   const [searchParams] = useSearchParams();
-  const token = searchParams.get("token");
+  const routeParams = useParams();
+  const token = searchParams.get("token") || routeParams.token;
   const navigate = useNavigate();
   const [message, setMessage] = useState<{
     type: "error" | "success";
@@ -24,7 +26,7 @@ export default function SetNewPassword() {
 
     try {
       const response = await fetch(
-        `https://staging-api.psits.org/api/student/reset-password/${token}`,
+        `${backendConnection()}/api/student/reset-password/${token}`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -32,12 +34,12 @@ export default function SetNewPassword() {
         }
       );
 
-      const data = await response.json();
+      const data = await response.json().catch(() => null);
 
       if (!response.ok) {
         setMessage({
           type: "error",
-          text: data.message || "Something went wrong.",
+          text: data?.message || "Something went wrong.",
         });
         return;
       }

--- a/client-side-ts/src/pages/auth/SignUp.tsx
+++ b/client-side-ts/src/pages/auth/SignUp.tsx
@@ -4,6 +4,7 @@ import { Link } from "react-router";
 import { ArrowLeft } from "lucide-react";
 import sidePhoto from "@/assets/side_photo_forms.png";
 import { useNavigate } from "react-router";
+import backendConnection from "@/api/backendApi";
 const courses = ["BSIT", "BSCS"];
 import { showToast } from "@/utils/alertHelper";
 
@@ -15,18 +16,18 @@ export default function Signup() {
     if (isSubmitting) return;
     setIsSubmitting(true);
     try {
-      const res = await fetch("/api/v2/auth/signup", {
+      const res = await fetch(`${backendConnection()}/api/v2/auth/signup`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(values),
       });
-      const data = await res.json();
+      const data = await res.json().catch(() => null);
       if (!res.ok) {
         showToast(
           "error",
-          data.message || "Something went wrong. Please try again."
+          data?.message || "Something went wrong. Please try again."
         );
-        console.error(data.message);
+        console.error(data?.message || "Signup failed");
         return;
       }
       showToast("success", "Welcome! Your PSITS account is ready.");

--- a/server-side/src/controllers/index.v2.controller.ts
+++ b/server-side/src/controllers/index.v2.controller.ts
@@ -14,10 +14,13 @@ import dotenv from "dotenv";
 dotenv.config();
 const token_key = process.env.JWT_SECRET ?? "Default_Token";
 
-const url =
-  process.env.DB_NAME !== "psits-test"
-    ? "https://psits.vercel.app/reset-password/"
-    : "https://staging-v2.psits.org/auth/reset-password?token=";
+const frontendBaseUrl =
+  process.env.FRONTEND_URL ||
+  (process.env.DB_NAME !== "psits-test"
+    ? "https://psits.org"
+    : "https://staging-v2.psits.org");
+
+const url = `${frontendBaseUrl}/auth/reset-password?token=`;
 
 import { studentService } from "../services/student.service";
 import { adminService } from "../services/admin.service";


### PR DESCRIPTION
## Summary
Fixes issues preventing students from setting passwords and completing account registration in deployed environments (e.g. `psits.org`). Addresses missing API server base URLs on auth endpoints, hardcoded staging domains, token parameter parsing mismatches, and password validation schema constraints.

---

## Key Changes

###  Frontend (`client-side-ts`)
* **Signup Endpoint Connection** ([`SignUp.tsx`](file:///c:/Download/PSITS-2/PSITS-web-react/client-side-ts/src/pages/auth/SignUp.tsx)):
  * Replaced raw relative path `/api/v2/auth/signup` with dynamic `${backendConnection()}/api/v2/auth/signup` to prevent static frontend host `404` HTML responses.
  * Added fallback handling for non-JSON error responses to display accurate error toasts.
* **Set Password Endpoint & Token Support** ([`SetNewPassword.tsx`](file:///c:/Download/PSITS-2/PSITS-web-react/client-side-ts/src/pages/auth/SetNewPassword.tsx)):
  * Replaced hardcoded `https://staging-api.psits.org` with dynamic `backendConnection()`.
  * Updated token extraction to accept both query parameters (`?token=...`) and route path parameters (`/reset-password/:token`).
* **Password Validation Schemas** ([`SignupForm.tsx`](file:///c:/Download/PSITS-2/PSITS-web-react/client-side-ts/src/features/auth/components/SignupForm.tsx) & [`SetNewPasswordForm.tsx`](file:///c:/Download/PSITS-2/PSITS-web-react/client-side-ts/src/features/auth/components/SetNewPasswordForm.tsx)):
  * Added Zod regex validations enforcing all 4 UI password requirements (min 8 chars, lowercase, uppercase, and number/symbol) prior to form submission.

### Backend (`server-side`)
* **Reset Password Email URL Configuration** ([`index.v2.controller.ts`](file:///c:/Download/PSITS-2/PSITS-web-react/server-side/src/controllers/index.v2.controller.ts)):
  * Updated reset email link construction to respect `process.env.FRONTEND_URL` and generate standard query parameter links (`https://psits.org/auth/reset-password?token=...`).

---

## Root Causes Resolved
1. **Static Server 404 Interception**: Relative `fetch("/api/v2/auth/signup")` requests on production were hitting the static frontend web server instead of the API server, returning HTML pages that triggered generic `"Something went wrong"` banner errors.
2. **CORS / Domain Mismatch**: Hardcoded `staging-api.psits.org` host caused CORS failures in production.
3. **Password Requirement Drift**: Frontend UI displayed regex rules (lowercase, uppercase, symbol) that were not being checked in the Zod validation schema.

---

## Verification
* Checked TypeScript compilation across client (`npx tsc -b`) and server (`npx tsc --noEmit`).
* Verified error handling gracefully extracts API response messages.
