### PR TITLE
feat: enhance event management, recruitment, and attendance workflows

### DIFF
--- a/client-side-ts/src/features/admin/event-management/components/modals/AddEventModal.tsx
+++ b/client-side-ts/src/features/admin/event-management/components/modals/AddEventModal.tsx
@@ -125,6 +125,11 @@ export const AddEventModal: React.FC<AddEventModalProps> = ({
         status: "Upcoming",
         sessionConfig: formData.sessionConfig,
         images: formData.image ? [formData.image] : [],
+        eventVenue: formData.eventVenue,
+        eventTheme: formData.eventTheme,
+        eventVenueSpecific: formData.eventVenueSpecific,
+        eventStartTime: formData.eventStartTime,
+        eventEndTime: formData.eventEndTime,
       });
 
       if (result) {

--- a/client-side-ts/src/features/admin/event-management/components/modals/AddWalkInAttendeeModal.tsx
+++ b/client-side-ts/src/features/admin/event-management/components/modals/AddWalkInAttendeeModal.tsx
@@ -69,6 +69,16 @@ const shouldShowShirtFields = (merch?: EventMerchMeta | null): boolean => {
   return merch.category === "ict-congress" && merch.type === "Tshirt w/ Bundle";
 };
 
+const getYearLevelLabel = (year: number): string => {
+  const suffixes: Record<number, string> = {
+    1: "1st Year",
+    2: "2nd Year",
+    3: "3rd Year",
+    4: "4th Year",
+  };
+  return suffixes[year] ?? "";
+};
+
 // Validation helper functions
 const validateName = (
   value: string,
@@ -192,7 +202,7 @@ export const AddWalkInAttendeeModal: React.FC<AddWalkInAttendeeModalProps> = ({
       lastName: student.last_name ?? "",
       email: student.email ?? "",
       course: student.course ?? "",
-      yearLevel: student.year ? `${student.year}st Year` : "",
+      yearLevel: student.year ? getYearLevelLabel(student.year) : "",
     }));
     setErrors({});
     setSearchQuery("");

--- a/client-side-ts/src/features/admin/event-management/components/modals/EditEventModal.tsx
+++ b/client-side-ts/src/features/admin/event-management/components/modals/EditEventModal.tsx
@@ -1,189 +1,189 @@
-import React, { useState, useEffect } from "react";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Button } from "@/components/ui/button";
-import { EventInfoTab } from "./EventInfoTab";
-import { SessionSetupTab } from "./SessionSetupTab";
-import type { EventFormData } from "./AddEventModal";
-import { showToast } from "@/utils/alertHelper";
-import { updateEventDetails } from "@/features/events/api/eventService";
+    import React, { useState, useEffect } from "react";
+    import {
+      Dialog,
+      DialogContent,
+      DialogHeader,
+      DialogTitle,
+    } from "@/components/ui/dialog";
+    import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+    import { Button } from "@/components/ui/button";
+    import { EventInfoTab } from "./EventInfoTab";
+    import { SessionSetupTab } from "./SessionSetupTab";
+    import type { EventFormData } from "./AddEventModal";
+    import { showToast } from "@/utils/alertHelper";
+    import { updateEventDetails } from "@/features/events/api/eventService";
 
-interface EditEventModalProps {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  onSaveEvent?: (event: unknown) => void;
-  eventData: {
-    id: string;
-    title: string;
-    description?: string;
-    eventVenue?: string;
-    startDate?: string;
-    image: string;
-    eventTheme?: string;
-    eventVenueSpecific?: string;
-    eventStartTime?: string;
-    eventEndTime?: string;
-  } | null;
-}
+    interface EditEventModalProps {
+      open: boolean;
+      onOpenChange: (open: boolean) => void;
+      onSaveEvent?: (event: unknown) => void;
+      eventData: {
+        id: string;
+        title: string;
+        description?: string;
+        eventVenue?: string;
+        startDate?: string;
+        image: string;
+        eventTheme?: string;
+        eventVenueSpecific?: string;
+        eventStartTime?: string;
+        eventEndTime?: string;
+      } | null;
+    }
 
-const defaultDisabledSessions: EventFormData["sessionConfig"] = {
-  morning: { enabled: false, timeRange: "" },
-  afternoon: { enabled: false, timeRange: "" },
-  evening: { enabled: false, timeRange: "" },
-};
+    const defaultDisabledSessions: EventFormData["sessionConfig"] = {
+      morning: { enabled: false, timeRange: "" },
+      afternoon: { enabled: false, timeRange: "" },
+      evening: { enabled: false, timeRange: "" },
+    };
 
-export const EditEventModal: React.FC<EditEventModalProps> = ({
-  open,
-  onOpenChange,
-  onSaveEvent,
-  eventData,
-}) => {
-  const [activeTab, setActiveTab] = useState("event-info");
-  const [isSaving, setIsSaving] = useState(false);
+    export const EditEventModal: React.FC<EditEventModalProps> = ({
+      open,
+      onOpenChange,
+      onSaveEvent,
+      eventData,
+    }) => {
+      const [activeTab, setActiveTab] = useState("event-info");
+      const [isSaving, setIsSaving] = useState(false);
 
-  const [formData, setFormData] = useState<EventFormData>({
-    eventName: "",
-    eventDescription: "",
-    eventSchedule: undefined,
-    attendanceType: "open",
-    image: null,
-    sessionConfig: defaultDisabledSessions,
-    eventVenue: "",
-    eventTheme: "",
-    eventVenueSpecific: "",
-    eventStartTime: "",
-    eventEndTime: "",
-  });
-
-  useEffect(() => {
-    if (open && eventData) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing form state from props when modal opens
-      setFormData({
-        eventName: eventData.title || "",
-        eventDescription: eventData.description || "",
-        eventSchedule: eventData.startDate
-          ? { from: new Date(eventData.startDate), to: undefined }
-          : undefined,
+      const [formData, setFormData] = useState<EventFormData>({
+        eventName: "",
+        eventDescription: "",
+        eventSchedule: undefined,
         attendanceType: "open",
         image: null,
         sessionConfig: defaultDisabledSessions,
-        eventVenue: eventData.eventVenue || "",
-        eventTheme: eventData.eventTheme || "",
-        eventVenueSpecific: eventData.eventVenueSpecific || "",
-        eventStartTime: eventData.eventStartTime || "",
-        eventEndTime: eventData.eventEndTime || "",
+        eventVenue: "",
+        eventTheme: "",
+        eventVenueSpecific: "",
+        eventStartTime: "",
+        eventEndTime: "",
       });
-    }
-  }, [eventData, open]);
 
-  const handleCancel = () => {
-    setActiveTab("event-info");
-    onOpenChange(false);
-  };
-
-  const handleSubmit = async () => {
-    if (!eventData?.id) return;
-    try {
-      setIsSaving(true);
-      const res = await updateEventDetails(eventData.id, {
-        eventName: formData.eventName,
-        eventDescription: formData.eventDescription,
-        eventDate: formData.eventSchedule,
-        eventVenue: formData.eventVenue,
-        eventTheme: formData.eventTheme,
-        eventVenueSpecific: formData.eventVenueSpecific,
-        eventStartTime: formData.eventStartTime,
-        eventEndTime: formData.eventEndTime,
-        image: formData.image,
-      });
-      if (res) {
-        showToast("success", "Event updated successfully");
-        if (onSaveEvent) {
-          onSaveEvent(res.data || res);
+      useEffect(() => {
+        if (open && eventData) {
+          // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing form state from props when modal opens
+          setFormData({
+            eventName: eventData.title || "",
+            eventDescription: eventData.description || "",
+            eventSchedule: eventData.startDate
+              ? { from: new Date(eventData.startDate), to: undefined }
+              : undefined,
+            attendanceType: "open",
+            image: null,
+            sessionConfig: defaultDisabledSessions,
+            eventVenue: eventData.eventVenue || "",
+            eventTheme: eventData.eventTheme || "",
+            eventVenueSpecific: eventData.eventVenueSpecific || "",
+            eventStartTime: eventData.eventStartTime || "",
+            eventEndTime: eventData.eventEndTime || "",
+          });
         }
+      }, [eventData, open]);
+
+      const handleCancel = () => {
+        setActiveTab("event-info");
         onOpenChange(false);
-      } else {
-        showToast("error", "Failed to update event");
-      }
-    } catch (error) {
-      const message =
-        error instanceof Error ? error.message : "Failed to update event";
-      showToast("error", message);
-    } finally {
-      setIsSaving(false);
-    }
-  };
+      };
 
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="mx-auto flex max-h-[90vh] w-[92%] max-w-4xl flex-col gap-0 overflow-y-auto rounded-3xl p-0 sm:w-full sm:max-w-2xl sm:rounded-xl">
-        <DialogHeader className="px-6 py-4">
-          <div className="flex items-center justify-between">
-            <DialogTitle className="text-xl leading-6 font-semibold">
-              Edit Event
-            </DialogTitle>
-          </div>
-        </DialogHeader>
+      const handleSubmit = async () => {
+        if (!eventData?.id) return;
+        try {
+          setIsSaving(true);
+          const res = await updateEventDetails(eventData.id, {
+            eventName: formData.eventName,
+            eventDescription: formData.eventDescription,
+            eventDate: formData.eventSchedule,
+            eventVenue: formData.eventVenue,
+            eventTheme: formData.eventTheme,
+            eventVenueSpecific: formData.eventVenueSpecific,
+            eventStartTime: formData.eventStartTime,
+            eventEndTime: formData.eventEndTime,
+            image: formData.image,
+          });
+          if (res) {
+            showToast("success", "Event updated successfully");
+            if (onSaveEvent) {
+              onSaveEvent(res.data || res);
+            }
+            onOpenChange(false);
+          } else {
+            showToast("error", "Failed to update event");
+          }
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : "Failed to update event";
+          showToast("error", message);
+        } finally {
+          setIsSaving(false);
+        }
+      };
 
-        <Tabs
-          value={activeTab}
-          onValueChange={setActiveTab}
-          className="flex min-h-0 flex-1 flex-col"
-        >
-          <TabsList className="h-auto w-full justify-start gap-6 rounded-none border-b bg-transparent px-6 py-0">
-            <TabsTrigger
-              value="event-info"
-              className="cursor-pointer rounded-none border-b-2 border-transparent px-0 pb-3 text-sm text-gray-500 data-[state=active]:border-b-[#1C9DDE] data-[state=active]:bg-transparent data-[state=active]:text-[#1C9DDE] data-[state=active]:shadow-none"
+      return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+          <DialogContent className="mx-auto flex max-h-[90vh] w-[92%] max-w-4xl flex-col gap-0 overflow-y-auto rounded-3xl p-0 sm:w-full sm:max-w-2xl sm:rounded-xl">
+            <DialogHeader className="px-6 py-4">
+              <div className="flex items-center justify-between">
+                <DialogTitle className="text-xl leading-6 font-semibold">
+                  Edit Event
+                </DialogTitle>
+              </div>
+            </DialogHeader>
+
+            <Tabs
+              value={activeTab}
+              onValueChange={setActiveTab}
+              className="flex min-h-0 flex-1 flex-col"
             >
-              Event Info
-            </TabsTrigger>
-            <TabsTrigger
-              value="session-setup"
-              className="cursor-pointer rounded-none border-b-2 border-transparent px-0 pb-3 text-sm text-gray-500 data-[state=active]:border-b-[#1C9DDE] data-[state=active]:bg-transparent data-[state=active]:text-[#1C9DDE] data-[state=active]:shadow-none"
-            >
-              Session Setup
-            </TabsTrigger>
-          </TabsList>
+              <TabsList className="h-auto w-full justify-start gap-6 rounded-none border-b bg-transparent px-6 py-0">
+                <TabsTrigger
+                  value="event-info"
+                  className="cursor-pointer rounded-none border-b-2 border-transparent px-0 pb-3 text-sm text-gray-500 data-[state=active]:border-b-[#1C9DDE] data-[state=active]:bg-transparent data-[state=active]:text-[#1C9DDE] data-[state=active]:shadow-none"
+                >
+                  Event Info
+                </TabsTrigger>
+                <TabsTrigger
+                  value="session-setup"
+                  className="cursor-pointer rounded-none border-b-2 border-transparent px-0 pb-3 text-sm text-gray-500 data-[state=active]:border-b-[#1C9DDE] data-[state=active]:bg-transparent data-[state=active]:text-[#1C9DDE] data-[state=active]:shadow-none"
+                >
+                  Session Setup
+                </TabsTrigger>
+              </TabsList>
 
-          <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6">
-            <TabsContent value="event-info" className="mt-0 h-full">
-              <EventInfoTab
-                formData={formData}
-                setFormData={setFormData}
-                initialImage={eventData?.image}
-                isEdit
-              />
-            </TabsContent>
+              <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6">
+                <TabsContent value="event-info" className="mt-0 h-full">
+                  <EventInfoTab
+                    formData={formData}
+                    setFormData={setFormData}
+                    initialImage={eventData?.image}
+                    isEdit
+                  />
+                </TabsContent>
 
-            <TabsContent value="session-setup" className="mt-0 h-full">
-              <SessionSetupTab formData={formData} setFormData={setFormData} />
-            </TabsContent>
-          </div>
+                <TabsContent value="session-setup" className="mt-0 h-full">
+                  <SessionSetupTab formData={formData} setFormData={setFormData} />
+                </TabsContent>
+              </div>
 
-          <div className="bg-background flex items-center justify-end gap-3 border-t px-6 py-4">
-            <Button
-              variant="outline"
-              onClick={handleCancel}
-              className="cursor-pointer"
-              disabled={isSaving}
-            >
-              Cancel
-            </Button>
-            <Button
-              onClick={handleSubmit}
-              className="cursor-pointer bg-[#1C9DDE] hover:bg-[#1C9DDE]"
-              disabled={isSaving}
-            >
-              {isSaving ? "Saving..." : "Save Changes"}
-            </Button>
-          </div>
-        </Tabs>
-      </DialogContent>
-    </Dialog>
-  );
-};
+              <div className="bg-background flex items-center justify-end gap-3 border-t px-6 py-4">
+                <Button
+                  variant="outline"
+                  onClick={handleCancel}
+                  className="cursor-pointer"
+                  disabled={isSaving}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  onClick={handleSubmit}
+                  className="cursor-pointer bg-[#1C9DDE] hover:bg-[#1C9DDE]"
+                  disabled={isSaving}
+                >
+                  {isSaving ? "Saving..." : "Save Changes"}
+                </Button>
+              </div>
+            </Tabs>
+          </DialogContent>
+        </Dialog>
+      );
+    };

--- a/client-side-ts/src/features/admin/event-management/components/modals/EventInfoTab.tsx
+++ b/client-side-ts/src/features/admin/event-management/components/modals/EventInfoTab.tsx
@@ -1,4 +1,5 @@
-import React, { useRef, useState } from "react";
+import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import {
   UploadCloud,
   Calendar as CalendarIcon,
@@ -10,11 +11,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
+
 import { cn } from "@/lib/utils";
 import { format } from "date-fns";
 import type { EventFormData } from "./AddEventModal";
@@ -36,6 +33,108 @@ export const EventInfoTab: React.FC<EventInfoTabProps> = ({
     initialImage || null
   );
   const [isDraggingOver, setIsDraggingOver] = useState(false);
+
+  // Controls the calendar panel open state
+  const [isCalendarOpen, setIsCalendarOpen] = useState(false);
+
+  // Tracks whether we're below the `sm` breakpoint — drives whether the
+  // calendar renders at the trigger-relative position (desktop) or
+  // centered on screen with larger cells (mobile).
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const checkMobile = () => setIsMobile(window.innerWidth < 640);
+    checkMobile();
+    window.addEventListener("resize", checkMobile);
+    return () => window.removeEventListener("resize", checkMobile);
+  }, []);
+
+  const PANEL_WIDTH = 300;
+  const PANEL_MARGIN = 16; // keep some breathing room from screen edges
+
+  // Root wrapper of this tab — used to compute where the panel should
+  // land on screen, since it's portaled out to escape the modal's
+  // scroll-clipping container.
+  const rootRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const [panelPos, setPanelPos] = useState({
+    top: 0,
+    left: 0,
+    width: PANEL_WIDTH,
+  });
+
+  const updatePanelPosition = () => {
+    if (!rootRef.current || isMobile) return;
+    const rect = rootRef.current.getBoundingClientRect();
+
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+
+    const effectiveWidth = Math.min(
+      PANEL_WIDTH,
+      viewportWidth - PANEL_MARGIN * 2
+    );
+
+    let left = rect.right - effectiveWidth;
+    left = Math.max(
+      PANEL_MARGIN,
+      Math.min(left, viewportWidth - effectiveWidth - PANEL_MARGIN)
+    );
+
+    const estimatedPanelHeight = panelRef.current?.offsetHeight ?? 420;
+    let top = rect.top;
+    top = Math.max(
+      PANEL_MARGIN,
+      Math.min(top, viewportHeight - estimatedPanelHeight - PANEL_MARGIN)
+    );
+
+    setPanelPos({ top, left, width: effectiveWidth });
+  };
+
+  useLayoutEffect(() => {
+    if (isCalendarOpen) updatePanelPosition();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isCalendarOpen, isMobile]);
+
+  useEffect(() => {
+    if (!isCalendarOpen || isMobile) return;
+    // Recalculate on scroll/resize so the panel stays pinned to the
+    // same visual spot even as the modal body scrolls internally.
+    window.addEventListener("scroll", updatePanelPosition, true);
+    window.addEventListener("resize", updatePanelPosition);
+    return () => {
+      window.removeEventListener("scroll", updatePanelPosition, true);
+      window.removeEventListener("resize", updatePanelPosition);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isCalendarOpen, isMobile]);
+
+  useEffect(() => {
+    if (!isCalendarOpen) return;
+    // A real backdrop <div> gets intercepted by the parent Dialog's own
+    // "click outside closes the dialog" handling, since our backdrop is
+    // technically outside Dialog.Content too. A document-level listener
+    // in the capture phase runs independently of Radix's interception,
+    // so it reliably closes just our panel instead.
+    const handlePointerDown = (e: PointerEvent) => {
+      const target = e.target as Node;
+      if (
+        panelRef.current &&
+        !panelRef.current.contains(target) &&
+        triggerRef.current &&
+        !triggerRef.current.contains(target)
+      ) {
+        setIsCalendarOpen(false);
+      }
+    };
+    document.addEventListener("pointerdown", handlePointerDown, true);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown, true);
+    };
+  }, [isCalendarOpen]);
+
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleFileChange = (file: File | null) => {
@@ -73,7 +172,7 @@ export const EventInfoTab: React.FC<EventInfoTabProps> = ({
   };
 
   return (
-    <div className="flex h-full flex-col gap-6">
+    <div ref={rootRef} className="relative flex h-full flex-col gap-6">
       {/* Top row - Image + Name/Description */}
       <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
         {/* Left Column - Image Upload */}
@@ -182,46 +281,180 @@ export const EventInfoTab: React.FC<EventInfoTabProps> = ({
 
       {/* Bottom row - Event Schedule + Location, spans full width */}
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-        <div className="flex min-w-0 flex-col gap-2">
+        <div className="sm:col--2 flex min-w-0 flex-col gap-2">
           <Label className="text-sm font-medium">Event Schedule</Label>
-          <Popover>
-            <PopoverTrigger asChild>
-              <Button
-                variant="outline"
+
+          {/* Single trigger field — just opens the panel, position is
+              fixed within the modal, not tied to this button's location */}
+          <button
+            ref={triggerRef}
+            type="button"
+            onClick={() => setIsCalendarOpen(true)}
+            className={cn(
+              "flex h-11 w-full items-center gap-2 rounded-xl border px-4 text-left text-sm transition-colors sm:w-60",
+              isCalendarOpen
+                ? "border-[#1C9DDE] ring-1 ring-[#1C9DDE]"
+                : "border-gray-200 hover:border-gray-300"
+            )}
+          >
+            <CalendarIcon className="h-4 w-4 shrink-0 text-gray-400" />
+            <span
+              className={cn(
+                "truncate",
+                !formData.eventSchedule?.from && "text-muted-foreground"
+              )}
+            >
+              {formData.eventSchedule?.from
+                ? formData.eventSchedule?.to
+                  ? `${format(formData.eventSchedule.from, "d MMM yyyy")} - ${format(formData.eventSchedule.to, "d MMM yyyy")}`
+                  : format(formData.eventSchedule.from, "d MMM yyyy")
+                : "Choose date"}
+            </span>
+          </button>
+        </div>
+
+        {/* Calendar panel — portaled to document.body.
+            Desktop: `fixed` coordinates computed from the root wrapper's
+            on-screen location, clamped to stay within the viewport.
+            Mobile (<640px): centered on screen with a dimmed backdrop and
+            larger day cells for easier tapping. */}
+        {isCalendarOpen &&
+          createPortal(
+            <>
+              {/* Backdrop, mobile only — dims content behind the panel */}
+              {isMobile && (
+                <div
+                  className="fixed inset-0 z-40 bg-black/40"
+                  onClick={() => setIsCalendarOpen(false)}
+                />
+              )}
+
+              <div
+                ref={panelRef}
+                style={
+                  isMobile
+                    ? undefined
+                    : {
+                        top: panelPos.top,
+                        left: panelPos.left,
+                        width: panelPos.width,
+                      }
+                }
                 className={cn(
-                  "w-full min-w-0 justify-start overflow-hidden rounded-lg border-gray-200 text-left font-normal shadow-sm",
-                  !formData.eventSchedule?.from && "text-muted-foreground"
+                  "pointer-events-auto fixed z-50 overflow-y-auto border border-gray-200 bg-white shadow-lg",
+                  isMobile
+                    ? "top-1/2 left-1/2 max-h-[85vh] w-[92vw] max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-3xl p-5"
+                    : "max-h-[520px] rounded-2xl p-4"
                 )}
               >
-                <CalendarIcon className="mr-2 h-4 w-4 shrink-0 text-gray-400" />
-                <span className="truncate">
-                  {formData.eventSchedule?.from ? (
-                    formData.eventSchedule.to ? (
-                      <>
-                        {format(formData.eventSchedule.from, "d MMM yyyy")} -{" "}
-                        {format(formData.eventSchedule.to, "d MMM yyyy")}
-                      </>
-                    ) : (
-                      format(formData.eventSchedule.from, "d MMM yyyy")
-                    )
-                  ) : (
-                    "Choose date range"
-                  )}
-                </span>
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent className="w-auto p-0" align="start">
-              <Calendar
-                mode="range"
-                selected={formData.eventSchedule}
-                onSelect={(range) =>
-                  setFormData((prev) => ({ ...prev, eventSchedule: range }))
-                }
-                initialFocus
-              />
-            </PopoverContent>
-          </Popover>
-        </div>
+                {/* Plain pill fields — no dashed borders, no "+" icons */}
+                <div className="mb-1 flex items-center gap-3">
+                  <div
+                    className={cn(
+                      "flex flex-1 items-center justify-center rounded-full border border-gray-200 text-sm",
+                      isMobile ? "h-9" : "h-9 px-3"
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        "truncate",
+                        !formData.eventSchedule?.from && "text-muted-foreground"
+                      )}
+                    >
+                      {formData.eventSchedule?.from
+                        ? format(formData.eventSchedule.from, "d MMM yyyy")
+                        : "Start date"}
+                    </span>
+                  </div>
+
+                  <div
+                    className={cn(
+                      "flex flex-1 items-center justify-center rounded-full border border-gray-200 text-sm",
+                      isMobile ? "h-9" : "h-7 px-3"
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        "truncate",
+                        !formData.eventSchedule?.to && "text-muted-foreground"
+                      )}
+                    >
+                      {formData.eventSchedule?.to
+                        ? format(formData.eventSchedule.to, "d MMM yyyy")
+                        : "End date"}
+                    </span>
+                  </div>
+                </div>
+
+                {/* Calendar — bigger cells on mobile for easier tapping */}
+                <Calendar
+                  mode="range"
+                  selected={formData.eventSchedule}
+                  onSelect={(range) =>
+                    setFormData((prev) => ({ ...prev, eventSchedule: range }))
+                  }
+                  initialFocus
+                  classNames={
+                    isMobile
+                      ? {
+                          day: "h-12 w-11 text-sm rounded-full",
+                          day_selected:
+                            "h-12 w-11 text-sm rounded-full bg-[#1C9DDE] text-white",
+
+                          cell: "w-11 h-10 p-0",
+
+                          head_cell: "w-11 text-center text-xs",
+
+                          caption_label: "text-base font-semibold",
+
+                          row: "flex w-fit mx-auto mt-1.5",
+
+                          head_row: "flex w-fit mx-auto",
+                        }
+                      : {
+                          day: "h-8 w-8 rounded-full text-xs",
+                          day_selected:
+                            "h-8 w-8 rounded-full bg-[#1C9DDE] text-white",
+
+                          cell: "w-8 h-10 p-0",
+
+                          head_cell:
+                            "w-8 text-center text-[10px] text-gray-400",
+
+                          caption_label: "text-sm font-semibold",
+
+                          row: "flex w-fit mx-auto",
+
+                          head_row: "flex w-fit mx-auto",
+
+                          day_range_middle:
+                            "bg-[#1C9DDE]/10 text-[#0879B5] rounded-none",
+
+                          day_range_start: "rounded-full",
+
+                          day_range_end: "rounded-full",
+                        }
+                  }
+                />
+
+                <div className="mt-2 border-t border-gray-100 pt-3">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setFormData((prev) => ({
+                        ...prev,
+                        eventSchedule: undefined,
+                      }));
+                    }}
+                    className="text-sm font-medium text-gray-500 hover:text-gray-700"
+                  >
+                    Clear all
+                  </button>
+                </div>
+              </div>
+            </>,
+            document.body
+          )}
 
         <div className="flex min-w-0 flex-col gap-2">
           <Label htmlFor="eventVenue" className="text-sm font-medium">
@@ -239,7 +472,7 @@ export const EventInfoTab: React.FC<EventInfoTabProps> = ({
                   eventVenue: e.target.value,
                 }))
               }
-              className="w-full min-w-0 rounded-lg border-gray-200 pl-9 shadow-sm"
+              className="h-11 w-full min-w-0 rounded-xl border-gray-200 pl-9 text-sm focus-visible:border-[#1C9DDE] focus-visible:ring-1 focus-visible:ring-[#1C9DDE]"
             />
           </div>
         </div>

--- a/client-side-ts/src/features/admin/recruitment-management/components/PositionEditModal.tsx
+++ b/client-side-ts/src/features/admin/recruitment-management/components/PositionEditModal.tsx
@@ -1,17 +1,12 @@
 import { useState } from "react";
-import { CalendarIcon, Clock, X } from "lucide-react";
+import { CalendarIcon, X } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
-import { Slider } from "@/components/ui/slider";
+import { TimePicker } from "@/components/ui/TimePicker";
 
 import type { RecruitmentPosition } from "../types/Recruitment.types";
 
@@ -22,122 +17,6 @@ function formatDateDisplay(date?: Date) {
     day: "numeric",
     year: "numeric",
   });
-}
-
-function formatTime12h(time24: string) {
-  const [h, m] = time24.split(":").map(Number);
-  const period = h >= 12 ? "PM" : "AM";
-  const hour12 = h % 12 === 0 ? 12 : h % 12;
-  return `${String(hour12).padStart(2, "0")}:${String(m).padStart(2, "0")} ${period}`;
-}
-
-function parseTime24(time24: string) {
-  if (!time24) return null;
-  const [h, m] = time24.split(":").map(Number);
-  return {
-    hour12: h % 12 === 0 ? 12 : h % 12,
-    minute: m,
-    period: h >= 12 ? "PM" : "AM",
-  } as const;
-}
-
-function toTime24(hour12: number, minute: number, period: "AM" | "PM") {
-  let hour = hour12 % 12;
-  if (period === "PM") hour += 12;
-  return `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
-}
-
-interface TimePickerPopoverProps {
-  value: string;
-  placeholder: string;
-  onChange: (value: string) => void;
-}
-
-function TimePickerPopover({
-  value,
-  placeholder,
-  onChange,
-}: TimePickerPopoverProps) {
-  const [open, setOpen] = useState(false);
-  const parsed = parseTime24(value);
-  const hour = parsed?.hour12 ?? 7;
-  const minute = parsed?.minute ?? 30;
-  const period = parsed?.period ?? "AM";
-
-  const commit = (h: number, m: number, p: "AM" | "PM") =>
-    onChange(toTime24(h, m, p));
-
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          className="flex h-9 items-center gap-2 rounded-lg border border-[#E5E7EB] px-3 text-sm"
-        >
-          <Clock className="h-4 w-4 text-slate-400" />
-          {value ? (
-            formatTime12h(value)
-          ) : (
-            <span className="text-slate-400">{placeholder}</span>
-          )}
-        </button>
-      </PopoverTrigger>
-      <PopoverContent align="start" className="w-56 rounded-2xl p-5">
-        <div className="mb-5 flex items-center justify-between">
-          <span className="text-lg font-medium">
-            {String(hour).padStart(2, "0")}:{String(minute).padStart(2, "0")}{" "}
-            {period}
-          </span>
-          <div className="flex gap-2">
-            {(["AM", "PM"] as const).map((p) => (
-              <button
-                key={p}
-                type="button"
-                onClick={() => commit(hour, minute, p)}
-                className={`flex h-8 w-8 items-center justify-center rounded-full text-xs transition ${
-                  p === period ? "bg-[#1C9DDE] text-white" : "border"
-                }`}
-              >
-                {p}
-              </button>
-            ))}
-          </div>
-        </div>
-        <div className="space-y-4">
-          <div>
-            <div className="mb-2 flex justify-between">
-              <Label>Hour</Label>
-              <span className="rounded border px-2 py-1 text-xs text-[#1C9DDE]">
-                {String(hour).padStart(2, "0")}
-              </span>
-            </div>
-            <Slider
-              value={[hour]}
-              min={1}
-              max={12}
-              step={1}
-              onValueChange={([v]) => commit(v, minute, period)}
-            />
-          </div>
-          <div>
-            <div className="mb-2 flex justify-between">
-              <Label>Minutes</Label>
-              <span className="rounded border px-2 py-1 text-xs text-[#1C9DDE]">
-                {String(minute).padStart(2, "0")}
-              </span>
-            </div>
-            <Slider
-              value={[minute]}
-              min={0}
-              max={59}
-              step={1}
-              onValueChange={([v]) => commit(hour, v, period)}
-            />
-          </div>
-        </div>
-      </PopoverContent>
-    </Popover>
-  );
 }
 
 interface DateInputProps {
@@ -320,7 +199,7 @@ export default function PositionEditModal({
                     active
                   />
 
-                  <TimePickerPopover
+                  <TimePicker
                     value={deadlineTime}
                     placeholder="End Time"
                     onChange={setDeadlineTime}

--- a/client-side-ts/src/features/admin/recruitment-management/components/RecuitmentViews.tsx
+++ b/client-side-ts/src/features/admin/recruitment-management/components/RecuitmentViews.tsx
@@ -13,6 +13,7 @@ import {
   X,
   Plus,
   Trash2,
+  RotateCcw,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -331,6 +332,7 @@ export const RecruitmentViews = () => {
     setPositionsPage,
     positionsTotalPages,
     positionsTotal,
+    openPositionsCount,
     isLoading,
     isMutating,
     error,
@@ -355,6 +357,7 @@ export const RecruitmentViews = () => {
     positionsError,
     updatePosition,
     closePosition,
+    reopenPosition,
     deletePosition,
     verificationApplicants,
     verifyApplicant,
@@ -538,10 +541,11 @@ export const RecruitmentViews = () => {
             <Skeleton className="h-[76px] rounded-2xl" />
           </div>
         ) : (
-          <div className="mb-5 grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <div className="mb-5 grid grid-cols-1 gap-4 sm:grid-cols-4">
             <StatCard label="Pending" value={counts.pending} />
             <StatCard label="Approved" value={counts.approved} />
             <StatCard label="Verifications" value={counts.verifications} />
+            <StatCard label="Open Roles" value={openPositionsCount} />
           </div>
         )}
 
@@ -893,18 +897,31 @@ export const RecruitmentViews = () => {
                                   Edit Role Application
                                 </button>
 
-                                <button
-                                  type="button"
-                                  disabled={position.hiringStatus === "CLOSED"}
-                                  onClick={() => {
-                                    closePosition(position._id);
-                                    setOpenPositionMenuId(null);
-                                  }}
-                                  className="flex w-full cursor-pointer items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm text-red-600 hover:bg-slate-50 disabled:cursor-not-allowed disabled:text-slate-300"
-                                >
-                                  <Ban className="h-4 w-4" />
-                                  Close Role Application
-                                </button>
+                                {position.hiringStatus === "CLOSED" ? (
+                                  <button
+                                    type="button"
+                                    onClick={() => {
+                                      reopenPosition(position._id);
+                                      setOpenPositionMenuId(null);
+                                    }}
+                                    className="flex w-full cursor-pointer items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm text-emerald-600 hover:bg-slate-50"
+                                  >
+                                    <RotateCcw className="h-4 w-4" />
+                                    Reopen Role Application
+                                  </button>
+                                ) : (
+                                  <button
+                                    type="button"
+                                    onClick={() => {
+                                      closePosition(position._id);
+                                      setOpenPositionMenuId(null);
+                                    }}
+                                    className="flex w-full cursor-pointer items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm text-red-600 hover:bg-slate-50"
+                                  >
+                                    <Ban className="h-4 w-4" />
+                                    Close Role Application
+                                  </button>
+                                )}
 
                                 {position.hiringStatus === "CLOSED" && (
                                   <button
@@ -1465,10 +1482,10 @@ export const RecruitmentViews = () => {
               </div>
               <div>
                 <DialogTitle className="text-lg font-semibold">
-                  Some role applications are already open
+                  Some role applications already exist
                 </DialogTitle>
                 <p className="mt-1 text-sm text-slate-500">
-                  Choose how to handle the existing openings before continuing.
+                  Choose how to handle the existing role before continuing.
                 </p>
               </div>
             </div>
@@ -1522,7 +1539,7 @@ export const RecruitmentViews = () => {
                 disabled={isMutating}
                 onClick={() => resolveOpeningConflict("close_old_create_new")}
               >
-                Close old and create
+                Delete old and Create
               </Button>
             </div>
           </div>

--- a/client-side-ts/src/features/admin/recruitment-management/hooks/useRecruitmentData.ts
+++ b/client-side-ts/src/features/admin/recruitment-management/hooks/useRecruitmentData.ts
@@ -232,6 +232,7 @@ export const useRecruitmentData = () => {
   const [positionsPage, setPositionsPage] = useState(1);
   const [positionsTotalPages, setPositionsTotalPages] = useState(1);
   const [positionsTotal, setPositionsTotal] = useState(0);
+  const [openPositionsCount, setOpenPositionsCount] = useState(0);
 
   const [mutationError, setMutationError] = useState<string | null>(null);
 
@@ -349,10 +350,24 @@ export const useRecruitmentData = () => {
     [positionsPage]
   );
 
+  const fetchOpenPositionsCount = useCallback(async () => {
+    try {
+      const res = await listPositions({ status: "OPEN", limit: 1 });
+      setOpenPositionsCount(Number(res.data.data.pagination?.total || 0));
+    } catch {
+      // Non-critical — the stat card just won't update this cycle.
+    }
+  }, []);
+
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional fetch-on-mount; fetchPositions is also used for refetch, so its internal setIsPositionsLoading/setPositionsError calls are needed there
     fetchPositions();
   }, [fetchPositions]);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional fetch-on-mount
+    fetchOpenPositionsCount();
+  }, [fetchOpenPositionsCount]);
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional fetch-on-mount; fetchApplicants is also used for refetch, so its internal setIsLoading/setError calls are needed there
@@ -659,6 +674,7 @@ export const useRecruitmentData = () => {
       });
       setPositionsPage(1);
       await fetchPositions(1);
+      await fetchOpenPositionsCount();
     } catch (err) {
       const response = (
         err as {
@@ -734,6 +750,7 @@ export const useRecruitmentData = () => {
       setPositions((current) =>
         current.map((p) => (p._id === id ? updated : p))
       );
+      await fetchOpenPositionsCount();
     } catch (err) {
       setMutationError(
         err instanceof Error ? err.message : "Failed to close role"
@@ -743,6 +760,24 @@ export const useRecruitmentData = () => {
     }
   };
 
+  const reopenPosition = async (id: string) => {
+    setIsMutating(true);
+    setMutationError(null);
+    try {
+      const res = await toggleHiringStatus(id, "OPEN");
+      const updated = res.data.data;
+      setPositions((current) =>
+        current.map((p) => (p._id === id ? updated : p))
+      );
+      await fetchOpenPositionsCount();
+    } catch (err) {
+      setMutationError(
+        err instanceof Error ? err.message : "Failed to reopen role"
+      );
+    } finally {
+      setIsMutating(false);
+    }
+  };
   // Delete a position (only for CLOSED roles — the UI gates this).
   // The backend hard-deletes if no applications exist, otherwise
   // soft-disables (isActive = false).
@@ -761,6 +796,7 @@ export const useRecruitmentData = () => {
       }
 
       await fetchPositions(nextPage);
+      await fetchOpenPositionsCount();
     } catch (err) {
       setMutationError(
         err instanceof Error ? err.message : "Failed to delete position"
@@ -916,6 +952,7 @@ export const useRecruitmentData = () => {
     setPositionsPage,
     positionsTotalPages,
     positionsTotal,
+    openPositionsCount,
     isLoading,
     isMutating,
     error,
@@ -947,6 +984,7 @@ export const useRecruitmentData = () => {
     openRoleApplication,
     updatePosition,
     closePosition,
+    reopenPosition,
     deletePosition,
     verificationApplicants,
     verifyApplicant,

--- a/client-side-ts/src/features/events/api/eventService.ts
+++ b/client-side-ts/src/features/events/api/eventService.ts
@@ -144,6 +144,14 @@ export const createEventV2 = async (
     if (payload.limit && payload.limit.length > 0) {
       formData.append("limit", JSON.stringify(payload.limit));
     }
+    if (payload.eventVenue) formData.append("eventVenue", payload.eventVenue);
+    if (payload.eventTheme) formData.append("eventTheme", payload.eventTheme);
+    if (payload.eventVenueSpecific)
+      formData.append("eventVenueSpecific", payload.eventVenueSpecific);
+    if (payload.eventStartTime)
+      formData.append("eventStartTime", payload.eventStartTime);
+    if (payload.eventEndTime)
+      formData.append("eventEndTime", payload.eventEndTime);
     payload.images?.forEach((file) => formData.append("images", file));
 
     const response = await api.post<CreateEventV2Response>(

--- a/client-side-ts/src/features/events/types/event.types.ts
+++ b/client-side-ts/src/features/events/types/event.types.ts
@@ -260,6 +260,11 @@ export interface CreateEventV2Payload {
   sessionConfig: CanonicalSessionConfig;
   images?: File[];
   limit?: CampusLimit[];
+  eventVenue?: string;
+  eventTheme?: string;
+  eventVenueSpecific?: string;
+  eventStartTime?: string;
+  eventEndTime?: string;
 }
 
 export interface CreateEventV2Response {

--- a/client-side-ts/src/pages/admin/EventManagement.tsx
+++ b/client-side-ts/src/pages/admin/EventManagement.tsx
@@ -79,16 +79,32 @@ interface EventSessionConfig {
 
 type EventStatus = EventDetails["status"];
 
-import { formatEventDateLabel } from "@/utils/date-manila";
+import { formatEventDateLabel, formatEventDateKey } from "@/utils/date-manila";
 
-const normalizeStatus = (value: unknown): EventStatus => {
+const normalizeStatus = (
+  value: unknown,
+  eventDate?: string | Date | null
+): EventStatus => {
   const normalized = String(value ?? "")
     .trim()
     .toLowerCase();
 
+  if (normalized === "ended" || normalized === "cancelled") return "ended";
   if (normalized === "ongoing") return "ongoing";
-  if (normalized === "upcoming") return "upcoming";
-  return "ended";
+  if (eventDate) {
+    const parsedEventDate =
+      typeof eventDate === "string" ? new Date(eventDate) : eventDate;
+
+    if (parsedEventDate && !Number.isNaN(parsedEventDate.getTime())) {
+      const todayKey = formatEventDateKey(new Date());
+      const eventKey = formatEventDateKey(parsedEventDate);
+      if (todayKey === eventKey) {
+        return "ongoing";
+      }
+    }
+  }
+
+  return "upcoming";
 };
 
 const getSessionBounds = (
@@ -228,7 +244,7 @@ const mapApiEventToEventDetails = (
   return {
     id: String(event.eventId ?? routeEventId),
     title: String(event.eventName ?? "Untitled Event"),
-    status: normalizeStatus(event.status),
+    status: normalizeStatus(event.status, event.eventDate),
     startDate: formatEventDateLabel(event.eventDate),
     startTime,
     endDate: formatEventDateLabel(event.eventDate),
@@ -533,7 +549,7 @@ const EventManagement: React.FC = () => {
               <div className="bg-card flex flex-col gap-4 rounded-xl border p-4 sm:flex-row">
                 {/* Event Image (thumbnail) */}
                 <div className="sm:w-56 sm:flex-shrink-0 md:w-90">
-                  <div className="bg-muted aspect-[4/3] w-full overflow-hidden rounded-lg sm:aspect-auto sm:h-full">
+                  <div className="bg-muted aspect-[4/3] w-full overflow-hidden rounded-lg sm:aspect-auto sm:h-48 md:h-56">
                     <img
                       src={eventDetails.image}
                       alt={eventDetails.title}

--- a/server-side/src/controllers/eventV2.controller.ts
+++ b/server-side/src/controllers/eventV2.controller.ts
@@ -73,7 +73,10 @@ const buildEventLookupQuery = (eventId: string) => {
   };
 };
 
-const buildProxyImageUrl = (req: Request, file: Express.MulterS3.File): string =>
+const buildProxyImageUrl = (
+  req: Request,
+  file: Express.MulterS3.File
+): string =>
   `${req.protocol}://${req.get("host")}/api/v2/events/image/${file.key}`;
 
 const LEGACY_CAMPUS_MAP: Record<string, string> = {
@@ -2870,6 +2873,11 @@ interface CreateEventV2Body {
   status?: string;
   sessionConfig?: unknown;
   limit?: unknown;
+  eventVenue?: string;
+  eventTheme?: string;
+  eventVenueSpecific?: string;
+  eventStartTime?: string;
+  eventEndTime?: string;
 }
 
 const parseManilaMidnightDate = (value: string): Date | null => {
@@ -2974,9 +2982,9 @@ export const createEventV2Controller = async (req: Request, res: Response) => {
 
   try {
     const imageUrl =
-  (req.files as Express.MulterS3.File[] | undefined)?.map((file) =>
-    buildProxyImageUrl(req, file)
-  ) ?? [];
+      (req.files as Express.MulterS3.File[] | undefined)?.map((file) =>
+        buildProxyImageUrl(req, file)
+      ) ?? [];
 
     const createdBy =
       req.admin?.name ??
@@ -2994,6 +3002,18 @@ export const createEventV2Controller = async (req: Request, res: Response) => {
       sessionConfig: parsedSessionConfigResult,
       createdBy,
       attendees: [],
+      eventVenue:
+        typeof body.eventVenue === "string" ? body.eventVenue.trim() : "",
+      eventTheme:
+        typeof body.eventTheme === "string" ? body.eventTheme.trim() : "",
+      eventVenueSpecific:
+        typeof body.eventVenueSpecific === "string"
+          ? body.eventVenueSpecific.trim()
+          : "",
+      eventStartTime:
+        typeof body.eventStartTime === "string" ? body.eventStartTime : "",
+      eventEndTime:
+        typeof body.eventEndTime === "string" ? body.eventEndTime : "",
     };
 
     if (parsedLimitResult.length > 0) {

--- a/server-side/src/models/recruitmentPosition.model.ts
+++ b/server-side/src/models/recruitmentPosition.model.ts
@@ -11,6 +11,7 @@ export interface IRecruitmentPosition extends Document {
   hiringStatus: keyof typeof hiringStatus;
   isActive: boolean;
   slots?: number;
+  slotsFilled: number;
   applicationOpensAt?: Date;
   applicationDeadline?: Date;
   sortOrder: number;
@@ -26,6 +27,7 @@ const RecruitmentPositionSchema = new Schema<IRecruitmentPosition>(
     responsibilities: { type: [String], default: [] },
     requirements: { type: [String], default: [] },
     slots: { type: Number, default: null },
+    slotsFilled: { type: Number, default: 0 },
     applicationOpensAt: Date,
     hiringStatus: {
       type: String,

--- a/server-side/src/services/attendance.service.ts
+++ b/server-side/src/services/attendance.service.ts
@@ -60,11 +60,12 @@ export type HydratableAttendee = IAttendee & {
   _id?: Types.ObjectId | string | null;
 };
 
-type EventWithAttendees<TAttendee extends HydratableAttendee = HydratableAttendee> =
-  {
-    _id?: unknown;
-    attendees?: TAttendee[] | null;
-  };
+type EventWithAttendees<
+  TAttendee extends HydratableAttendee = HydratableAttendee,
+> = {
+  _id?: unknown;
+  attendees?: TAttendee[] | null;
+};
 
 type EventAttendee = HydratableAttendee & { _id: Types.ObjectId };
 type AttendanceEventMetadata = {
@@ -187,7 +188,9 @@ function buildAttendanceKey(eventId: string, attendeeId: string) {
   return `${eventId}:${attendeeId}`;
 }
 
-function extractAttendeeRef(attendee: HydratableAttendee): Types.ObjectId | null {
+function extractAttendeeRef(
+  attendee: HydratableAttendee
+): Types.ObjectId | null {
   return toObjectId(attendee._id);
 }
 
@@ -314,7 +317,7 @@ function getActiveSession(event: {
   eventDate: Date;
   status: string;
 }): keyof IAttendanceSession {
-  if (event.status !== "Ongoing") {
+  if (event.status === "Ended" || event.status === "Cancelled") {
     throw new AttendanceError(
       "EVENT_NOT_ACTIVE",
       "This event is not currently active."

--- a/server-side/src/services/recruitment.service.ts
+++ b/server-side/src/services/recruitment.service.ts
@@ -206,9 +206,13 @@ export class RecruitmentService {
     }
 
     const selectedTitles = docs.map((doc) => doc.title);
+    // Block re-creating a title while any *live* position document for it
+    // still exists — OPEN, CLOSED, or DRAFT, as long as it's active.
+    // Archived positions (isActive: false — set when deletePosition can't
+    // hard-delete due to existing applications) don't block reuse; the
+    // archive itself is the "deletion" for title-reuse purposes.
     const existingOpenPositions = await RecruitmentPosition.find({
       title: { $in: selectedTitles },
-      hiringStatus: hiringStatus.OPEN,
       isActive: true,
     }).sort({ createdAt: -1 });
 
@@ -233,20 +237,27 @@ export class RecruitmentService {
       conflictStrategy === OPENING_CONFLICT_STRATEGIES.closeOldCreateNew &&
       existingOpenPositions.length > 0
     ) {
-      await RecruitmentPosition.updateMany(
-        {
-          _id: {
-            $in: existingOpenPositions.map((position: any) => position._id),
-          },
-        },
-        {
-          $set: {
-            hiringStatus: hiringStatus.CLOSED,
-            isActive: false,
-          },
-        }
-      );
-      return RecruitmentPosition.insertMany(docs);
+      // Create the replacements first so we have real _ids to reassign
+      // applicants onto, then move every application from each old
+      // position to its same-titled replacement, then hard-delete the old
+      // position — safe now that it has zero applications left, so it
+      // never becomes a permanently-archived zombie row.
+      const created = await RecruitmentPosition.insertMany(docs);
+      const newByTitle = new Map(created.map((p: any) => [p.title, p]));
+
+      for (const oldPosition of existingOpenPositions) {
+        const replacement = newByTitle.get(oldPosition.title);
+        if (!replacement) continue; // titles always match here by construction
+
+        await Application.updateMany(
+          { position: oldPosition._id },
+          { $set: { position: replacement._id } }
+        );
+
+        await RecruitmentPosition.deleteOne({ _id: oldPosition._id });
+      }
+
+      return created;
     }
 
     if (conflictStrategy === OPENING_CONFLICT_STRATEGIES.updateExisting) {
@@ -315,6 +326,17 @@ export class RecruitmentService {
     const currentPage = toPositiveInteger(page, 1);
     const pageLimit = toPositiveInteger(limit, 10);
 
+    // Lazily close any OPEN positions whose deadline has passed.
+    // Cheap enough to run on every list call — indexed on hiringStatus +
+    // applicationDeadline — and keeps the UI honest without a cron job.
+    await RecruitmentPosition.updateMany(
+      {
+        hiringStatus: hiringStatus.OPEN,
+        applicationDeadline: { $lt: new Date() },
+      },
+      { $set: { hiringStatus: hiringStatus.CLOSED } }
+    );
+
     // Public API defaults to only active/open positions unless filtered
     if (req.path.startsWith("/public")) {
       query.isActive = true;
@@ -374,6 +396,16 @@ export class RecruitmentService {
   async getPositionById(id: string, req?: any) {
     const position = await RecruitmentPosition.findById(id);
     if (!position) throw new AppError("Position not found.", 404);
+
+    if (
+      position.hiringStatus === hiringStatus.OPEN &&
+      position.applicationDeadline &&
+      position.applicationDeadline < new Date()
+    ) {
+      position.hiringStatus = hiringStatus.CLOSED;
+      await position.save();
+    }
+
     return position;
   }
 
@@ -485,11 +517,16 @@ export class RecruitmentService {
       throw new AppError("Application is not open yet.", 400);
     }
 
-    // Validate deadline not expired
+    // Validate deadline not expired — also lazily flip the position closed
+    // so it doesn't keep showing OPEN to other readers after this point.
     if (
       position.applicationDeadline &&
       position.applicationDeadline < new Date()
     ) {
+      if (position.hiringStatus === hiringStatus.OPEN) {
+        position.hiringStatus = hiringStatus.CLOSED;
+        await position.save();
+      }
       throw new AppError("Application deadline has passed.", 400);
     }
 
@@ -507,16 +544,62 @@ export class RecruitmentService {
       );
     }
 
+    // ── Reserve a slot atomically (only if this position has a slot cap) ──
+    // The $expr condition means "only match/update if slotsFilled < slots"
+    // is evaluated and applied in the same atomic operation, so two
+    // simultaneous applicants can never both win the last slot.
+    const hasSlotLimit =
+      typeof position.slots === "number" && position.slots > 0;
+    let reservedPosition: any = null;
+
+    if (hasSlotLimit) {
+      reservedPosition = await RecruitmentPosition.findOneAndUpdate(
+        {
+          _id: positionId,
+          hiringStatus: hiringStatus.OPEN,
+          isActive: true,
+          $expr: { $lt: ["$slotsFilled", "$slots"] },
+        },
+        { $inc: { slotsFilled: 1 } },
+        { new: true }
+      );
+
+      if (!reservedPosition) {
+        throw new AppError("No slots available for this position.", 400);
+      }
+
+      // This reservation just filled the last slot — close hiring.
+      if (reservedPosition.slotsFilled >= (reservedPosition.slots ?? 0)) {
+        reservedPosition.hiringStatus = hiringStatus.CLOSED;
+        await reservedPosition.save();
+      }
+    }
+
+    const releaseReservation = async () => {
+      if (!hasSlotLimit) return;
+      await RecruitmentPosition.updateOne(
+        { _id: positionId },
+        {
+          $inc: { slotsFilled: -1 },
+          $set: { hiringStatus: hiringStatus.OPEN },
+        }
+      );
+    };
+
     // Get student snapshot for historical record
     const student = await Student.findById(studentId)
       .select("first_name last_name id_number email course year")
       .lean();
-    if (!student) throw new AppError("Student not found.", 404);
+    if (!student) {
+      await releaseReservation();
+      throw new AppError("Student not found.", 404);
+    }
 
     // Extract document metadata from request files (multer middleware)
     const files = req.files as any;
     const resume = files.resume?.[0];
     if (!resume) {
+      await releaseReservation();
       throw new AppError("Resume is required.", 400);
     }
 
@@ -530,6 +613,7 @@ export class RecruitmentService {
     // object that doesn't exist in the bucket (NoSuchKey on download).
     const resumeStorageKey = resume.key;
     if (!resumeStorageKey) {
+      await releaseReservation();
       throw new AppError(
         "Resume upload succeeded but no storage key was returned.",
         500
@@ -578,6 +662,9 @@ export class RecruitmentService {
       await application.save();
       return application;
     } catch (error) {
+      // Roll back the slot reservation — the application was never actually created.
+      await releaseReservation();
+
       const rawMessage =
         error instanceof Error
           ? error.message
@@ -871,7 +958,10 @@ export class RecruitmentService {
 
     if (!adminId) throw new AppError("Authentication required.", 401);
 
-    const app = await Application.findById(id).populate("position", "title");
+    const app = await Application.findById(id).populate(
+      "position",
+      "title slots slotsFilled hiringStatus applicationDeadline isActive"
+    );
     if (!app) throw new AppError("Application not found.", 404);
 
     // Validate allowed transition
@@ -919,6 +1009,41 @@ export class RecruitmentService {
       `\n[${new Date().toISOString()}] ${note || ""}`;
 
     await app.save();
+
+    // Release the reserved slot when an application is rejected — only if
+    // this position actually tracks slots. Also reopens hiring if the
+    // position was auto-closed for being full (but leaves it CLOSED if the
+    // deadline has since passed or an admin explicitly closed it for other
+    // reasons — see the deadline guard below).
+    if (status === applicationStatus.REJECTED) {
+      const position = app.position as any;
+      const hasSlotLimit =
+        typeof position?.slots === "number" && position.slots > 0;
+
+      if (hasSlotLimit) {
+        const deadlinePassed =
+          position.applicationDeadline &&
+          new Date(position.applicationDeadline) < new Date();
+
+        const update: any = { $inc: { slotsFilled: -1 } };
+
+        if (
+          position.hiringStatus === hiringStatus.CLOSED &&
+          position.isActive &&
+          !deadlinePassed
+        ) {
+          update.$set = { hiringStatus: hiringStatus.OPEN };
+        }
+
+        await RecruitmentPosition.updateOne(
+          {
+            _id: position._id,
+            slotsFilled: { $gt: 0 },
+          },
+          update
+        );
+      }
+    }
 
     // Send rejection email automatically when the decision is REJECTED
     if (status === applicationStatus.REJECTED) {


### PR DESCRIPTION
### Summary
---
Adds event venue/theme fields to admin event creation and editing, replaces the recruitment module's custom time picker with the shared TimePicker component, and fixes several bugs across event management, attendance, and recruitment.

### Changes
Event Management
Event Schedule calendar (EventInfoTab.tsx): replaced the Popover-based date picker with a manually-positioned, portaled panel to fix clipping inside the modal's scroll container. Adds responsive behavior — floating panel anchored to the trigger on desktop, centered overlay with larger touch targets on mobile.
Added eventVenue, eventTheme, eventVenueSpecific, eventStartTime, eventEndTime fields end-to-end: AddEventModal → EditEventModal → eventService.ts → event.types.ts → eventV2.controller.ts.
Fixed event image thumbnail sizing in EventManagement.tsx (EventManagement.tsx) by giving the container an explicit height instead of relying on sm:h-full.
Fixed normalizeStatus to correctly derive "ongoing" from the event date instead of defaulting unmatched values to "ended".
### Walk-In Attendees
Fixed AddWalkInAttendeeModal.tsx: year level was hardcoded to always append "st" (e.g. "3st Year"), which also silently broke the pre-filled Select since the value didn't match any YEAR_LEVEL_OPTIONS. Added getYearLevelLabel() to map year number → correct ordinal label.
### Recruitment
Replaced the local TimePickerPopover in PositionEditModal.tsx with the shared TimePicker component — removes ~120 lines of duplicated popover/slider logic.
Added Reopen Role Application action for closed positions (reopenPosition in useRecruitmentData.ts, toggleHiringStatus call, UI button in RecuitmentViews.tsx).
Added an Open Roles stat card, backed by a new fetchOpenPositionsCount call.
Backend: positions now auto-close when applicationDeadline passes, checked lazily on list/get (recruitment.service.ts) rather than requiring a cron job.
Added atomic slot reservation (slotsFilled field + $expr guard on findOneAndUpdate) so concurrent applicants can't oversubscribe a position's slot cap. Auto-closes hiring when the last slot fills, and rolls back/reopens correctly on application failure or rejection.
Title-reuse conflict resolution (close_old_create_new strategy) now hard-deletes the old position and reassigns its applications to the new one, instead of soft-closing and leaving an orphaned "zombie" row.
Attendance
Fixed getActiveSession: previously required event.status === "Ongoing" exactly, which incorrectly blocked attendance marking for other valid active states. Now only blocks when status is "Ended" or "Cancelled".