### PR TITLE
Fix attendee confirmation columns, add event end date support, prevent rescheduling closed applications

### DIFF
--- a/client-side-ts/src/features/admin/event-management/components/AttendeesTable.tsx
+++ b/client-side-ts/src/features/admin/event-management/components/AttendeesTable.tsx
@@ -115,6 +115,35 @@ export const AttendeesTable: React.FC<AttendeesTableProps> = ({
     return `${year}-${month}-${day}`;
   };
 
+  // Derives a "Confirmed on" label from the attendance session timestamps.
+  // There is no flat `confirmedOn` field from the backend — only per-session
+  // timestamps (attendance.morning/afternoon/evening.timestamp), written
+  // when markAttendanceV2 / markAttendance() records that session. This
+  // picks whichever session timestamp is set (an attendee can only ever
+  // have one, since sessions are mutually exclusive time windows).
+  const getConfirmedOnLabel = (attendance: Attendee["attendance"]): string => {
+    const ts =
+      attendance?.morning?.timestamp ??
+      attendance?.afternoon?.timestamp ??
+      attendance?.evening?.timestamp ??
+      null;
+
+    if (!ts) return "--";
+
+    const date = new Date(ts);
+    if (Number.isNaN(date.getTime())) return "--";
+
+    return (
+      date.toLocaleDateString("en-US", {
+        month: "short",
+        day: "2-digit",
+        year: "numeric",
+      }) +
+      "\n" +
+      date.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit" })
+    );
+  };
+
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
@@ -319,6 +348,7 @@ export const AttendeesTable: React.FC<AttendeesTableProps> = ({
         campus: attendee.campus,
         shirtSize: attendee.shirtSize,
         shirtPrice: attendee.shirtPrice?.toString(),
+        confirmedBy: attendee.confirmedBy,
       }));
 
       const headers = [
@@ -331,6 +361,8 @@ export const AttendeesTable: React.FC<AttendeesTableProps> = ({
         "Status",
         "Registered On",
         "Registered By",
+        "Confirmed On",
+        "Confirmed By",
         "Shirt Size",
         "Shirt Price",
       ];
@@ -345,6 +377,8 @@ export const AttendeesTable: React.FC<AttendeesTableProps> = ({
         getAttendanceSummary(attendee.attendance),
         attendee.registeredOn.replace("\n", " "),
         attendee.registeredBy,
+        getConfirmedOnLabel(attendee.attendance).replace("\n", " "),
+        attendee.confirmedBy || "--",
         attendee.shirtSize || "",
         attendee.shirtPrice || "",
       ]);
@@ -860,24 +894,36 @@ export const AttendeesTable: React.FC<AttendeesTableProps> = ({
                         </button>
                       </TableCell>
                       <TableCell>{attendee.courseYear}</TableCell>
+                      {/* FIX: was attendee.registeredOn (= transactDate, a
+                          registration-time field that is never set by the
+                          QR / manual "Mark Attendance" flow). Now derives
+                          the label from the actual attendance session
+                          timestamp, which IS set whenever attendance is
+                          confirmed. */}
                       <TableCell>
                         <div className="text-sm">
-                          {attendee.registeredOn.split("\n").map((line, i) => (
-                            <div
-                              key={i}
-                              className={
-                                i === 0
-                                  ? "font-medium"
-                                  : "text-muted-foreground"
-                              }
-                            >
-                              {line}
-                            </div>
-                          ))}
+                          {getConfirmedOnLabel(attendee.attendance)
+                            .split("\n")
+                            .map((line, i) => (
+                              <div
+                                key={i}
+                                className={
+                                  i === 0
+                                    ? "font-medium"
+                                    : "text-muted-foreground"
+                                }
+                              >
+                                {line}
+                              </div>
+                            ))}
                         </div>
                       </TableCell>
+                      {/* FIX: was attendee.registeredBy (= transactBy, also
+                          a registration-time field). Now uses the real
+                          confirmedBy value returned by the API, which is
+                          written whenever an admin confirms attendance. */}
                       <TableCell className="text-sm">
-                        {attendee.registeredBy}
+                        {attendee.confirmedBy || "--"}
                       </TableCell>
                       <TableCell>
                         <Button
@@ -974,12 +1020,15 @@ export const AttendeesTable: React.FC<AttendeesTableProps> = ({
                     </p>
                     <p className="font-medium">{attendee.courseYear}</p>
                   </div>
+                  {/* FIX: same swap as the desktop table above */}
                   <div>
                     <p className="text-muted-foreground text-xs">
                       Confirmed on
                     </p>
                     <p className="font-medium">
-                      {attendee.registeredOn.split("\n").join(" · ")}
+                      {getConfirmedOnLabel(attendee.attendance)
+                        .split("\n")
+                        .join(" · ")}
                     </p>
                   </div>
                   <div>
@@ -987,7 +1036,7 @@ export const AttendeesTable: React.FC<AttendeesTableProps> = ({
                       Confirmed by
                     </p>
                     <p className="truncate font-medium">
-                      {attendee.registeredBy}
+                      {attendee.confirmedBy || "--"}
                     </p>
                   </div>
                 </div>

--- a/client-side-ts/src/features/admin/event-management/components/modals/AddEventModal.tsx
+++ b/client-side-ts/src/features/admin/event-management/components/modals/AddEventModal.tsx
@@ -121,6 +121,9 @@ export const AddEventModal: React.FC<AddEventModalProps> = ({
         eventName: formData.eventName,
         eventDescription: formData.eventDescription,
         eventDate: formatDateKey(formData.eventSchedule.from),
+        eventEndDate: formData.eventSchedule?.to
+          ? formatDateKey(formData.eventSchedule.to)
+          : undefined,
         attendanceType: formData.attendanceType,
         status: "Upcoming",
         sessionConfig: formData.sessionConfig,

--- a/client-side-ts/src/features/admin/event-management/components/modals/EditEventModal.tsx
+++ b/client-side-ts/src/features/admin/event-management/components/modals/EditEventModal.tsx
@@ -1,189 +1,196 @@
-    import React, { useState, useEffect } from "react";
-    import {
-      Dialog,
-      DialogContent,
-      DialogHeader,
-      DialogTitle,
-    } from "@/components/ui/dialog";
-    import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-    import { Button } from "@/components/ui/button";
-    import { EventInfoTab } from "./EventInfoTab";
-    import { SessionSetupTab } from "./SessionSetupTab";
-    import type { EventFormData } from "./AddEventModal";
-    import { showToast } from "@/utils/alertHelper";
-    import { updateEventDetails } from "@/features/events/api/eventService";
+import React, { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
+import { EventInfoTab } from "./EventInfoTab";
+import { SessionSetupTab } from "./SessionSetupTab";
+import type { EventFormData } from "./AddEventModal";
+import { showToast } from "@/utils/alertHelper";
+import { updateEventDetails } from "@/features/events/api/eventService";
 
-    interface EditEventModalProps {
-      open: boolean;
-      onOpenChange: (open: boolean) => void;
-      onSaveEvent?: (event: unknown) => void;
-      eventData: {
-        id: string;
-        title: string;
-        description?: string;
-        eventVenue?: string;
-        startDate?: string;
-        image: string;
-        eventTheme?: string;
-        eventVenueSpecific?: string;
-        eventStartTime?: string;
-        eventEndTime?: string;
-      } | null;
-    }
+interface EditEventModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSaveEvent?: (event: unknown) => void;
+  eventData: {
+    id: string;
+    title: string;
+    description?: string;
+    eventVenue?: string;
+    startDate?: string;
+    image: string;
+    eventTheme?: string;
+    eventVenueSpecific?: string;
+    eventStartTime?: string;
+    eventEndTime?: string;
+    eventEndDate?: string;
+  } | null;
+}
 
-    const defaultDisabledSessions: EventFormData["sessionConfig"] = {
-      morning: { enabled: false, timeRange: "" },
-      afternoon: { enabled: false, timeRange: "" },
-      evening: { enabled: false, timeRange: "" },
-    };
+const defaultDisabledSessions: EventFormData["sessionConfig"] = {
+  morning: { enabled: false, timeRange: "" },
+  afternoon: { enabled: false, timeRange: "" },
+  evening: { enabled: false, timeRange: "" },
+};
 
-    export const EditEventModal: React.FC<EditEventModalProps> = ({
-      open,
-      onOpenChange,
-      onSaveEvent,
-      eventData,
-    }) => {
-      const [activeTab, setActiveTab] = useState("event-info");
-      const [isSaving, setIsSaving] = useState(false);
+export const EditEventModal: React.FC<EditEventModalProps> = ({
+  open,
+  onOpenChange,
+  onSaveEvent,
+  eventData,
+}) => {
+  const [activeTab, setActiveTab] = useState("event-info");
+  const [isSaving, setIsSaving] = useState(false);
 
-      const [formData, setFormData] = useState<EventFormData>({
-        eventName: "",
-        eventDescription: "",
-        eventSchedule: undefined,
+  const [formData, setFormData] = useState<EventFormData>({
+    eventName: "",
+    eventDescription: "",
+    eventSchedule: undefined,
+    attendanceType: "open",
+    image: null,
+    sessionConfig: defaultDisabledSessions,
+    eventVenue: "",
+    eventTheme: "",
+    eventVenueSpecific: "",
+    eventStartTime: "",
+    eventEndTime: "",
+  });
+
+  useEffect(() => {
+    if (open && eventData) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing form state from props when modal opens
+      setFormData({
+        eventName: eventData.title || "",
+        eventDescription: eventData.description || "",
+        eventSchedule: eventData.startDate
+          ? {
+              from: new Date(eventData.startDate),
+              to: eventData.eventEndDate
+                ? new Date(eventData.eventEndDate)
+                : undefined,
+            }
+          : undefined,
         attendanceType: "open",
         image: null,
         sessionConfig: defaultDisabledSessions,
-        eventVenue: "",
-        eventTheme: "",
-        eventVenueSpecific: "",
-        eventStartTime: "",
-        eventEndTime: "",
+        eventVenue: eventData.eventVenue || "",
+        eventTheme: eventData.eventTheme || "",
+        eventVenueSpecific: eventData.eventVenueSpecific || "",
+        eventStartTime: eventData.eventStartTime || "",
+        eventEndTime: eventData.eventEndTime || "",
       });
+    }
+  }, [eventData, open]);
 
-      useEffect(() => {
-        if (open && eventData) {
-          // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing form state from props when modal opens
-          setFormData({
-            eventName: eventData.title || "",
-            eventDescription: eventData.description || "",
-            eventSchedule: eventData.startDate
-              ? { from: new Date(eventData.startDate), to: undefined }
-              : undefined,
-            attendanceType: "open",
-            image: null,
-            sessionConfig: defaultDisabledSessions,
-            eventVenue: eventData.eventVenue || "",
-            eventTheme: eventData.eventTheme || "",
-            eventVenueSpecific: eventData.eventVenueSpecific || "",
-            eventStartTime: eventData.eventStartTime || "",
-            eventEndTime: eventData.eventEndTime || "",
-          });
+  const handleCancel = () => {
+    setActiveTab("event-info");
+    onOpenChange(false);
+  };
+
+  const handleSubmit = async () => {
+    if (!eventData?.id) return;
+    try {
+      setIsSaving(true);
+      const res = await updateEventDetails(eventData.id, {
+        eventName: formData.eventName,
+        eventDescription: formData.eventDescription,
+        eventDate: formData.eventSchedule?.from?.toISOString(),
+        eventEndDate: formData.eventSchedule?.to?.toISOString(),
+        eventVenue: formData.eventVenue,
+        eventTheme: formData.eventTheme,
+        eventVenueSpecific: formData.eventVenueSpecific,
+        eventStartTime: formData.eventStartTime,
+        eventEndTime: formData.eventEndTime,
+        image: formData.image,
+      });
+      if (res) {
+        showToast("success", "Event updated successfully");
+        if (onSaveEvent) {
+          onSaveEvent(res.data || res);
         }
-      }, [eventData, open]);
-
-      const handleCancel = () => {
-        setActiveTab("event-info");
         onOpenChange(false);
-      };
+      } else {
+        showToast("error", "Failed to update event");
+      }
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to update event";
+      showToast("error", message);
+    } finally {
+      setIsSaving(false);
+    }
+  };
 
-      const handleSubmit = async () => {
-        if (!eventData?.id) return;
-        try {
-          setIsSaving(true);
-          const res = await updateEventDetails(eventData.id, {
-            eventName: formData.eventName,
-            eventDescription: formData.eventDescription,
-            eventDate: formData.eventSchedule,
-            eventVenue: formData.eventVenue,
-            eventTheme: formData.eventTheme,
-            eventVenueSpecific: formData.eventVenueSpecific,
-            eventStartTime: formData.eventStartTime,
-            eventEndTime: formData.eventEndTime,
-            image: formData.image,
-          });
-          if (res) {
-            showToast("success", "Event updated successfully");
-            if (onSaveEvent) {
-              onSaveEvent(res.data || res);
-            }
-            onOpenChange(false);
-          } else {
-            showToast("error", "Failed to update event");
-          }
-        } catch (error) {
-          const message =
-            error instanceof Error ? error.message : "Failed to update event";
-          showToast("error", message);
-        } finally {
-          setIsSaving(false);
-        }
-      };
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="mx-auto flex max-h-[90vh] w-[92%] max-w-4xl flex-col gap-0 overflow-y-auto rounded-3xl p-0 sm:w-full sm:max-w-2xl sm:rounded-xl">
+        <DialogHeader className="px-6 py-4">
+          <div className="flex items-center justify-between">
+            <DialogTitle className="text-xl leading-6 font-semibold">
+              Edit Event
+            </DialogTitle>
+          </div>
+        </DialogHeader>
 
-      return (
-        <Dialog open={open} onOpenChange={onOpenChange}>
-          <DialogContent className="mx-auto flex max-h-[90vh] w-[92%] max-w-4xl flex-col gap-0 overflow-y-auto rounded-3xl p-0 sm:w-full sm:max-w-2xl sm:rounded-xl">
-            <DialogHeader className="px-6 py-4">
-              <div className="flex items-center justify-between">
-                <DialogTitle className="text-xl leading-6 font-semibold">
-                  Edit Event
-                </DialogTitle>
-              </div>
-            </DialogHeader>
-
-            <Tabs
-              value={activeTab}
-              onValueChange={setActiveTab}
-              className="flex min-h-0 flex-1 flex-col"
+        <Tabs
+          value={activeTab}
+          onValueChange={setActiveTab}
+          className="flex min-h-0 flex-1 flex-col"
+        >
+          <TabsList className="h-auto w-full justify-start gap-6 rounded-none border-b bg-transparent px-6 py-0">
+            <TabsTrigger
+              value="event-info"
+              className="cursor-pointer rounded-none border-b-2 border-transparent px-0 pb-3 text-sm text-gray-500 data-[state=active]:border-b-[#1C9DDE] data-[state=active]:bg-transparent data-[state=active]:text-[#1C9DDE] data-[state=active]:shadow-none"
             >
-              <TabsList className="h-auto w-full justify-start gap-6 rounded-none border-b bg-transparent px-6 py-0">
-                <TabsTrigger
-                  value="event-info"
-                  className="cursor-pointer rounded-none border-b-2 border-transparent px-0 pb-3 text-sm text-gray-500 data-[state=active]:border-b-[#1C9DDE] data-[state=active]:bg-transparent data-[state=active]:text-[#1C9DDE] data-[state=active]:shadow-none"
-                >
-                  Event Info
-                </TabsTrigger>
-                <TabsTrigger
-                  value="session-setup"
-                  className="cursor-pointer rounded-none border-b-2 border-transparent px-0 pb-3 text-sm text-gray-500 data-[state=active]:border-b-[#1C9DDE] data-[state=active]:bg-transparent data-[state=active]:text-[#1C9DDE] data-[state=active]:shadow-none"
-                >
-                  Session Setup
-                </TabsTrigger>
-              </TabsList>
+              Event Info
+            </TabsTrigger>
+            <TabsTrigger
+              value="session-setup"
+              className="cursor-pointer rounded-none border-b-2 border-transparent px-0 pb-3 text-sm text-gray-500 data-[state=active]:border-b-[#1C9DDE] data-[state=active]:bg-transparent data-[state=active]:text-[#1C9DDE] data-[state=active]:shadow-none"
+            >
+              Session Setup
+            </TabsTrigger>
+          </TabsList>
 
-              <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6">
-                <TabsContent value="event-info" className="mt-0 h-full">
-                  <EventInfoTab
-                    formData={formData}
-                    setFormData={setFormData}
-                    initialImage={eventData?.image}
-                    isEdit
-                  />
-                </TabsContent>
+          <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6">
+            <TabsContent value="event-info" className="mt-0 h-full">
+              <EventInfoTab
+                formData={formData}
+                setFormData={setFormData}
+                initialImage={eventData?.image}
+                isEdit
+              />
+            </TabsContent>
 
-                <TabsContent value="session-setup" className="mt-0 h-full">
-                  <SessionSetupTab formData={formData} setFormData={setFormData} />
-                </TabsContent>
-              </div>
+            <TabsContent value="session-setup" className="mt-0 h-full">
+              <SessionSetupTab formData={formData} setFormData={setFormData} />
+            </TabsContent>
+          </div>
 
-              <div className="bg-background flex items-center justify-end gap-3 border-t px-6 py-4">
-                <Button
-                  variant="outline"
-                  onClick={handleCancel}
-                  className="cursor-pointer"
-                  disabled={isSaving}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  onClick={handleSubmit}
-                  className="cursor-pointer bg-[#1C9DDE] hover:bg-[#1C9DDE]"
-                  disabled={isSaving}
-                >
-                  {isSaving ? "Saving..." : "Save Changes"}
-                </Button>
-              </div>
-            </Tabs>
-          </DialogContent>
-        </Dialog>
-      );
-    };
+          <div className="bg-background flex items-center justify-end gap-3 border-t px-6 py-4">
+            <Button
+              variant="outline"
+              onClick={handleCancel}
+              className="cursor-pointer"
+              disabled={isSaving}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleSubmit}
+              className="cursor-pointer bg-[#1C9DDE] hover:bg-[#1C9DDE]"
+              disabled={isSaving}
+            >
+              {isSaving ? "Saving..." : "Save Changes"}
+            </Button>
+          </div>
+        </Tabs>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/client-side-ts/src/features/admin/recruitment-management/components/ApplicantInfoModal.tsx
+++ b/client-side-ts/src/features/admin/recruitment-management/components/ApplicantInfoModal.tsx
@@ -13,6 +13,7 @@ interface ApplicantInfoModalProps {
   onClose: () => void;
   onSetSchedule: () => void;
   onReschedule: () => void;
+  canReschedule?: boolean;
   onViewResume: (id: string) => void;
   onDownloadResume: (id: string) => void;
   isResumeLoading: boolean;
@@ -48,6 +49,7 @@ export const ApplicantInfoModal = ({
   onClose,
   onSetSchedule,
   onReschedule,
+  canReschedule = true,
   onViewResume,
   onDownloadResume,
   isResumeLoading,
@@ -244,7 +246,7 @@ export const ApplicantInfoModal = ({
           <div className="mt-auto flex shrink-0 justify-center gap-3 px-6 py-4">
             {hasInterview ? (
               <>
-                {canManageRecruitment && (
+                {canManageRecruitment && canReschedule && (
                   <Button
                     type="button"
                     className="h-11 rounded-full bg-[#1c9dde] px-9 text-sm font-semibold hover:bg-[#168bc7]"
@@ -263,7 +265,7 @@ export const ApplicantInfoModal = ({
                   Close
                 </Button>
               </>
-            ) : canManageRecruitment ? (
+            ) : canManageRecruitment && canReschedule ? (
               <Button
                 type="button"
                 className="h-11 rounded-full bg-[#1c9dde] px-9 text-sm font-semibold hover:bg-[#168bc7]"

--- a/client-side-ts/src/features/admin/recruitment-management/components/RecuitmentViews.tsx
+++ b/client-side-ts/src/features/admin/recruitment-management/components/RecuitmentViews.tsx
@@ -1567,6 +1567,10 @@ export const RecruitmentViews = () => {
         onClose={closeApplicantDetails}
         onSetSchedule={() => setIsScheduleOpen(true)}
         onReschedule={() => setIsScheduleOpen(true)}
+        canReschedule={
+          selectedApplicant?.status !== "Approved" &&
+          selectedApplicant?.status !== "Rejected"
+        }
         onViewResume={viewResume}
         onDownloadResume={downloadResume}
         isResumeLoading={isResumeLoading}
@@ -1583,10 +1587,10 @@ export const RecruitmentViews = () => {
           if (!selectedApplicant) return;
           const hasInterview = Boolean(
             selectedApplicant.interviewDate ||
-              selectedApplicant.interviewOfficer ||
-              selectedApplicant.interviewType ||
-              selectedApplicant.interviewStart ||
-              selectedApplicant.interviewEnd
+            selectedApplicant.interviewOfficer ||
+            selectedApplicant.interviewType ||
+            selectedApplicant.interviewStart ||
+            selectedApplicant.interviewEnd
           );
           if (hasInterview) {
             await rescheduleInterview(selectedApplicant.id, values);

--- a/client-side-ts/src/features/events/api/eventService.ts
+++ b/client-side-ts/src/features/events/api/eventService.ts
@@ -138,6 +138,7 @@ export const createEventV2 = async (
     formData.append("eventName", payload.eventName);
     formData.append("eventDescription", payload.eventDescription ?? "");
     formData.append("eventDate", payload.eventDate);
+    if (payload.eventEndDate) formData.append("eventEndDate", payload.eventEndDate);
     formData.append("attendanceType", payload.attendanceType);
     if (payload.status) formData.append("status", payload.status);
     formData.append("sessionConfig", JSON.stringify(payload.sessionConfig));
@@ -841,7 +842,8 @@ export const updateEventDetails = async (
   payload: {
     eventName?: string;
     eventDescription?: string;
-    eventDate?: unknown;
+    eventDate?: string;
+    eventEndDate?: string;
     eventVenue?: string;
     eventTheme?: string;
     eventVenueSpecific?: string;
@@ -854,30 +856,11 @@ export const updateEventDetails = async (
 ): Promise<any> => {
   const { image, ...rest } = payload;
 
-  // Only use multipart/form-data when there's an actual file to send;
-  // otherwise keep the simpler JSON path.
   if (image) {
     const formData = new FormData();
 
     for (const [key, value] of Object.entries(rest)) {
       if (value === undefined || value === null) continue;
-
-      // eventDate is a DateRange object ({ from, to }) — send the start
-      // date as a plain ISO string so the backend can parse it directly
-      // from multipart/form-data.
-      if (
-        key === "eventDate" &&
-        value &&
-        typeof value === "object" &&
-        "from" in value
-      ) {
-        const from = (value as { from?: Date }).from;
-        if (from) {
-          formData.append(key, from.toISOString());
-        }
-        continue;
-      }
-
       formData.append(
         key,
         typeof value === "string" ? value : JSON.stringify(value)

--- a/client-side-ts/src/features/events/types/event.types.ts
+++ b/client-side-ts/src/features/events/types/event.types.ts
@@ -7,6 +7,7 @@ export interface Event {
   eventName: string;
   eventImage?: string[] | string;
   eventDate?: string | Date | null;
+  eventEndDate?: string | Date | null;
   eventDescription?: string;
   attendanceType?: string;
   sessionConfig?: CanonicalSessionConfig | Record<string, unknown>;
@@ -255,6 +256,7 @@ export interface CreateEventV2Payload {
   eventName: string;
   eventDescription?: string;
   eventDate: string;
+  eventEndDate?: string;
   attendanceType: AttendanceType;
   status?: EventStatus;
   sessionConfig: CanonicalSessionConfig;

--- a/client-side-ts/src/pages/admin/EventManagement.tsx
+++ b/client-side-ts/src/pages/admin/EventManagement.tsx
@@ -37,8 +37,9 @@ interface EventDetails {
   status: "ongoing" | "ended" | "upcoming";
   startDate: string;
   startTime: string;
-  endDate: string;
   endTime: string;
+  endDate: string;
+  rawEndDate?: string;
   location: string;
   description: string;
   image: string;
@@ -247,7 +248,12 @@ const mapApiEventToEventDetails = (
     status: normalizeStatus(event.status, event.eventDate),
     startDate: formatEventDateLabel(event.eventDate),
     startTime,
-    endDate: formatEventDateLabel(event.eventDate),
+    endDate: formatEventDateLabel(event.eventEndDate ?? event.eventDate),
+    rawEndDate: event.eventEndDate
+      ? String(event.eventEndDate)
+      : event.eventDate
+        ? String(event.eventDate)
+        : undefined,
     endTime,
     location:
       (typeof event.eventVenue === "string" && event.eventVenue) ||
@@ -747,6 +753,7 @@ const EventManagement: React.FC = () => {
           description: eventDetails?.description ?? "",
           eventVenue: eventDetails?.location ?? "",
           startDate: eventDetails?.startDate ?? "",
+          eventEndDate: eventDetails?.rawEndDate ?? "",
           image: eventDetails?.image ?? "",
           eventTheme: eventDetails?.eventTheme ?? "",
           eventVenueSpecific: eventDetails?.eventVenueSpecific ?? "",

--- a/client-side/src/pages/admin/Logs.jsx
+++ b/client-side/src/pages/admin/Logs.jsx
@@ -31,7 +31,7 @@ function Logs() {
       sortable: true,
       cell: (row) => {
         // Convert timestamp to PHT (GMT+8)
-        const date = new Date(row.timestamp); // Ensure this is a valid ISO string or timestamp
+        const date = new Date(row.timestamp);
         const options = {
           year: "numeric",
           month: "long",

--- a/server-side/src/controllers/eventV2.controller.ts
+++ b/server-side/src/controllers/eventV2.controller.ts
@@ -17,6 +17,7 @@ import {
   hydrateAttendeesAttendance,
   hydrateEventsAttendance,
   markAttendance,
+  syncAttendanceForAttendee,
 } from "../services/attendance.service";
 import { EventV2Service } from "../services/eventV2.service";
 import { computeEventStatistics } from "../services/eventStatistics.service";
@@ -27,6 +28,7 @@ import {
   parseCampusLimitsPayload,
   parseSessionConfigPayload,
 } from "../dtos/events.dto";
+import { parseTimeRangeToMinutes } from "../utils/timeRange";
 
 const logAdminAction = (
   req: Request,
@@ -132,48 +134,6 @@ interface SessionConfig {
   afternoon?: SessionConfigEntry;
   evening?: SessionConfigEntry;
 }
-
-/**
- * Parses a "7:00 AM - 12:00 PM" style range into 24h minute-of-day bounds.
- */
-const parseTimeRangeToMinutes = (
-  timeRange: string
-): { startMinutes: number; endMinutes: number } | null => {
-  const [startRaw, endRaw] = timeRange.split("-").map((s) => s.trim());
-  if (!startRaw || !endRaw) return null;
-
-  const toMinutes = (raw: string): number | null => {
-    // Try 24-hour format first: "07:30", "13:00"
-    const match24 = raw.match(/^(\d{1,2}):(\d{2})$/);
-    if (match24) {
-      const hour = parseInt(match24[1], 10);
-      const minute = parseInt(match24[2], 10);
-      if (hour > 23 || minute > 59) return null;
-      return hour * 60 + minute;
-    }
-
-    // Fall back to 12-hour format: "7:30 AM", "12:00 PM"
-    const match12 = raw.match(/^(\d{1,2}):(\d{2})\s*(AM|PM)$/i);
-    if (match12) {
-      let hour = parseInt(match12[1], 10);
-      const minute = parseInt(match12[2], 10);
-      const meridiem = match12[3].toUpperCase();
-
-      if (meridiem === "PM" && hour !== 12) hour += 12;
-      if (meridiem === "AM" && hour === 12) hour = 0;
-
-      return hour * 60 + minute;
-    }
-
-    return null;
-  };
-
-  const startMinutes = toMinutes(startRaw);
-  const endMinutes = toMinutes(endRaw);
-  if (startMinutes === null || endMinutes === null) return null;
-
-  return { startMinutes, endMinutes };
-};
 
 /**
  * Returns which session (morning/afternoon/evening) is currently active
@@ -1423,6 +1383,19 @@ export const addAttendeeV2Controller = async (req: Request, res: Response) => {
     normalizeEventCampusFields(event);
     await event.save({ session });
 
+    // Step 4: Sync the separate Attendance collection so hydration does not
+    // surface a stale all-false record as "Absent" for this attendee.
+    const savedAttendee = event.attendees[event.attendees.length - 1] as
+      | (IAttendee & { _id?: Types.ObjectId })
+      | undefined;
+    if (savedAttendee?._id) {
+      await syncAttendanceForAttendee(
+        event._id as Types.ObjectId,
+        savedAttendee as IAttendee & { _id: Types.ObjectId },
+        session
+      );
+    }
+
     await session.commitTransaction();
     session.endSession();
 
@@ -1721,6 +1694,19 @@ export const addWalkInAttendeeV2Controller = async (
 
     normalizeEventCampusFields(event);
     await event.save({ session });
+
+    // Step 3: Sync the separate Attendance collection so hydration does not
+    // surface a stale all-false record as "Absent" for this attendee.
+    const savedAttendee = event.attendees[event.attendees.length - 1] as
+      | (IAttendee & { _id?: Types.ObjectId })
+      | undefined;
+    if (savedAttendee?._id) {
+      await syncAttendanceForAttendee(
+        event._id as Types.ObjectId,
+        savedAttendee as IAttendee & { _id: Types.ObjectId },
+        session
+      );
+    }
 
     await session.commitTransaction();
     session.endSession();
@@ -2869,6 +2855,7 @@ interface CreateEventV2Body {
   eventName?: string;
   eventDescription?: string;
   eventDate?: string;
+  eventEndDate?: string;
   attendanceType?: string;
   status?: string;
   sessionConfig?: unknown;
@@ -2990,6 +2977,10 @@ export const createEventV2Controller = async (req: Request, res: Response) => {
       req.admin?.name ??
       (typeof req.userV2?.sub === "string" ? req.userV2.sub : "unknown-admin");
 
+    const parsedEndDate = body.eventEndDate
+      ? parseManilaMidnightDate(body.eventEndDate)
+      : null;
+
     const eventFields: Record<string, unknown> = {
       eventId: new mongoose.Types.ObjectId(),
       eventName,
@@ -3015,6 +3006,10 @@ export const createEventV2Controller = async (req: Request, res: Response) => {
       eventEndTime:
         typeof body.eventEndTime === "string" ? body.eventEndTime : "",
     };
+
+    if (parsedEndDate) {
+      eventFields.eventEndDate = parsedEndDate;
+    }
 
     if (parsedLimitResult.length > 0) {
       eventFields.limit = parsedLimitResult;
@@ -3082,6 +3077,7 @@ export const updateEventV2Controller = async (
       eventName,
       eventDescription,
       eventDate,
+      eventEndDate,
       eventVenue,
       eventTheme,
       eventVenueSpecific,
@@ -3116,11 +3112,40 @@ export const updateEventV2Controller = async (
       normalizedEventDate = parsed;
     }
 
+    // eventEndDate may arrive as a plain ISO string or as a range-picker
+    // object like { from, to } — only the "to" value maps to eventEndDate.
+    let normalizedEventEndDate: Date | undefined;
+    if (eventEndDate !== undefined) {
+      const rawEndDateValue =
+        eventEndDate && typeof eventEndDate === "object" && "to" in eventEndDate
+          ? (eventEndDate as { to?: string }).to
+          : eventEndDate;
+
+      if (typeof rawEndDateValue !== "string" || !rawEndDateValue.trim()) {
+        return res.status(400).json({
+          error: "VALIDATION",
+          message: "Event end date must be a valid date string",
+        });
+      }
+
+      const parsedEnd = new Date(rawEndDateValue);
+      if (Number.isNaN(parsedEnd.getTime())) {
+        return res.status(400).json({
+          error: "VALIDATION",
+          message: "Invalid event end date",
+        });
+      }
+      normalizedEventEndDate = parsedEnd;
+    }
+
     const updateFields: Record<string, unknown> = {
       eventName,
       eventDescription,
       ...(normalizedEventDate !== undefined && {
         eventDate: normalizedEventDate,
+      }),
+      ...(normalizedEventEndDate !== undefined && {
+        eventEndDate: normalizedEventEndDate,
       }),
       eventVenue,
       eventTheme,

--- a/server-side/src/models/event.interface.ts
+++ b/server-side/src/models/event.interface.ts
@@ -6,6 +6,7 @@ export interface IEvent {
   eventName: string;
   eventImage?: [String];
   eventDate: Date;
+  eventEndDate?: Date;
   eventDescription: string;
   attendanceType: string;
   sessionConfig: ISessionConfig;

--- a/server-side/src/models/event.model.ts
+++ b/server-side/src/models/event.model.ts
@@ -40,6 +40,7 @@ const eventSchema = new Schema<IEventDocument>({
   eventName: { type: String, required: true },
   eventImage: { type: Array },
   eventDate: { type: Date },
+  eventEndDate: { type: Date },
   eventDescription: { type: String, required: true },
   attendanceType: {
     type: String,

--- a/server-side/src/services/attendance.service.ts
+++ b/server-side/src/services/attendance.service.ts
@@ -4,6 +4,7 @@ import { Attendance } from "../models/attendance.model";
 import { IAttendanceSession, IAttendee } from "../models/attendee.interface";
 import { ISessionConfig } from "../models/event.interface";
 import { Event } from "../models/event.model";
+import { parseTimeRangeToMinutes } from "../utils/timeRange";
 
 const TIMEZONE = "Asia/Manila";
 
@@ -341,14 +342,13 @@ function getActiveSession(event: {
     const config = event.sessionConfig?.[sessionName];
     if (!config?.enabled || !config.timeRange) continue;
 
-    const [startStr, endStr] = config.timeRange.split(" - ");
-    const [sh, sm] = startStr.split(":").map(Number);
-    const [eh, em] = endStr.split(":").map(Number);
+    const bounds = parseTimeRangeToMinutes(config.timeRange);
+    if (!bounds) continue;
 
-    const startMinutes = sh * 60 + sm;
-    const endMinutes = eh * 60 + em;
-
-    if (currentMinutes >= startMinutes && currentMinutes <= endMinutes) {
+    if (
+      currentMinutes >= bounds.startMinutes &&
+      currentMinutes <= bounds.endMinutes
+    ) {
       matchedSessions.push(sessionName);
     }
   }
@@ -518,6 +518,33 @@ async function ensureAttendanceSeed(
       throw error;
     }
   }
+}
+
+/**
+ * Upserts the `Attendance` collection record for an attendee so it matches
+ * the attendee's embedded attendance. This keeps the separate Attendance
+ * collection in sync when an attendee is added via the V2 add/walk-in flows
+ * (which only write to the embedded `event.attendees[].attendance`), so
+ * hydration does not surface a stale all-false record as "Absent".
+ */
+export async function syncAttendanceForAttendee(
+  eventId: Types.ObjectId,
+  attendee: EventAttendee,
+  session: ClientSession
+) {
+  await Attendance.updateOne(
+    { event: eventId, attendeeRef: attendee._id },
+    {
+      $set: {
+        event: eventId,
+        attendeeRef: attendee._id,
+        id_number: attendee.id_number,
+        attendance: normalizeAttendance(attendee.attendance),
+        confirmedBy: attendee.confirmedBy ?? "",
+      },
+    },
+    { upsert: true, session }
+  );
 }
 
 async function updateAttendanceRecord(

--- a/server-side/src/services/recruitment.service.ts
+++ b/server-side/src/services/recruitment.service.ts
@@ -1197,6 +1197,16 @@ export class RecruitmentService {
     if (!app.interview)
       throw new AppError("No interview scheduled for this application.", 400);
 
+    if (
+      app.status === applicationStatus.APPROVED ||
+      app.status === applicationStatus.REJECTED
+    ) {
+      throw new AppError(
+        `Cannot reschedule an interview for an application that is already ${app.status.toLowerCase()}.`,
+        400
+      );
+    }
+
     const { scheduledAt, location, notes, status } = req.body;
 
     if (scheduledAt) {

--- a/server-side/src/utils/timeRange.ts
+++ b/server-side/src/utils/timeRange.ts
@@ -1,0 +1,47 @@
+/**
+ * Parses a time range string into 24h minute-of-day bounds.
+ *
+ * Supports both:
+ *  - 24-hour format: "07:30 - 12:00"
+ *  - 12-hour format: "7:00 AM - 12:00 PM"
+ *
+ * Returns null if the range cannot be parsed.
+ */
+export function parseTimeRangeToMinutes(
+  timeRange: string
+): { startMinutes: number; endMinutes: number } | null {
+  const [startRaw, endRaw] = timeRange.split("-").map((s) => s.trim());
+  if (!startRaw || !endRaw) return null;
+
+  const toMinutes = (raw: string): number | null => {
+    // Try 24-hour format first: "07:30", "13:00"
+    const match24 = raw.match(/^(\d{1,2}):(\d{2})$/);
+    if (match24) {
+      const hour = parseInt(match24[1], 10);
+      const minute = parseInt(match24[2], 10);
+      if (hour > 23 || minute > 59) return null;
+      return hour * 60 + minute;
+    }
+
+    // Fall back to 12-hour format: "7:30 AM", "12:00 PM"
+    const match12 = raw.match(/^(\d{1,2}):(\d{2})\s*(AM|PM)$/i);
+    if (match12) {
+      let hour = parseInt(match12[1], 10);
+      const minute = parseInt(match12[2], 10);
+      const meridiem = match12[3].toUpperCase();
+
+      if (meridiem === "PM" && hour !== 12) hour += 12;
+      if (meridiem === "AM" && hour === 12) hour = 0;
+
+      return hour * 60 + minute;
+    }
+
+    return null;
+  };
+
+  const startMinutes = toMinutes(startRaw);
+  const endMinutes = toMinutes(endRaw);
+  if (startMinutes === null || endMinutes === null) return null;
+
+  return { startMinutes, endMinutes };
+}


### PR DESCRIPTION
### Summary

Fixes blank "Confirmed on"/"Confirmed by" columns in the attendees table, adds event end date support, and prevents rescheduling interviews for already approved/rejected applicants.

### Changes
Fix: "Confirmed on"/"Confirmed by" columns were showing registration data instead of actual attendance confirmation data  now pulls from the correct fields 
Fix: Attendees added via Add Attendee/Walk-in flow could incorrectly show as "Absent" — synced the Attendance collection on creation
Feature: Added event end date field across event create/edit 
Fix: Prevented rescheduling interviews for applicants already marked Approved/Rejected 
Minor: removed stale comment in Logs.jsx, deduplicated time-range parsing helper