### PR TITLE
Implement pagination for applicant queries in recruitment

### DIFF
--- a/client-side-ts/src/api/recruitment.api.ts
+++ b/client-side-ts/src/api/recruitment.api.ts
@@ -112,6 +112,9 @@ export const updateApplicationStatus = (
 export const deleteApplication = (id: string) =>
   api.delete(`${BASE_PATH}/applications/${id}`);
 
+export const clearRejectedApplications = () =>
+  api.delete(`${BASE_PATH}/applicants/rejected`);
+
 export const createInterview = (
   applicationId: string,
   data: InterviewPayload

--- a/client-side-ts/src/features/admin/recruitment-management/components/RecuitmentViews.tsx
+++ b/client-side-ts/src/features/admin/recruitment-management/components/RecuitmentViews.tsx
@@ -34,7 +34,6 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import {
   useRecruitmentData,
-  ROWS_PER_PAGE,
   POSITIONS_PER_PAGE,
   DEFAULT_FILTERS,
 } from "../hooks/useRecruitmentData";
@@ -97,6 +96,26 @@ function getAvatarColor(name: string) {
 
 function getInitial(name: string) {
   return name.trim().charAt(0).toUpperCase() || "?";
+}
+
+function getPaginationItems(
+  currentPage: number,
+  totalPages: number
+): Array<number | "ellipsis"> {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, index) => index + 1);
+  }
+
+  const items: Array<number | "ellipsis"> = [1];
+  const start = Math.max(2, currentPage - 1);
+  const end = Math.min(totalPages - 1, currentPage + 1);
+
+  if (start > 2) items.push("ellipsis");
+  for (let page = start; page <= end; page += 1) items.push(page);
+  if (end < totalPages - 1) items.push("ellipsis");
+  items.push(totalPages);
+
+  return items;
 }
 
 // Convert an ISO timestamp to a local "YYYY-MM-DD" string for the date input.
@@ -181,7 +200,7 @@ const RecruitmentFilterPopover = ({
   const updateSingle = (field: "roles" | "courses" | "years", value: string) =>
     setDraft((current) => ({
       ...current,
-      [field]: value ? [value] : [],
+      [field]: value && value !== "all" ? [value] : [],
     }));
 
   const handleCancel = () => {
@@ -347,7 +366,6 @@ export const RecruitmentViews = () => {
     setActiveTab,
     applicants,
     pagedApplicants,
-    filteredApplicants,
     selectedIds,
     toggleApplicantSelection,
     clearSelection,
@@ -361,6 +379,8 @@ export const RecruitmentViews = () => {
     currentPage,
     totalPages,
     setPage,
+    applicantPagination,
+    applicantSummary,
     positionsPage,
     setPositionsPage,
     positionsTotalPages,
@@ -441,15 +461,16 @@ export const RecruitmentViews = () => {
     };
   }, [selectedApplicant]);
 
-  const counts = useMemo(() => {
-    return {
-      pending: applicants.filter((a) => a.status === "Pending").length,
-      approved: applicants.filter((a) => a.status === "Approved").length,
-      verifications: verificationApplicants.length,
-    };
-  }, [applicants, verificationApplicants]);
-
-  const total = filteredApplicants.length;
+  const counts = applicantSummary;
+  const total = applicantPagination.total;
+  const applicantStart =
+    total > 0 ? (currentPage - 1) * applicantPagination.limit + 1 : 0;
+  const applicantEnd =
+    total > 0 ? Math.min(applicantStart + applicants.length - 1, total) : 0;
+  const applicantPageItems = useMemo(
+    () => getPaginationItems(currentPage, totalPages),
+    [currentPage, totalPages]
+  );
 
   const allOnPageSelected =
     pagedApplicants.length > 0 &&
@@ -677,9 +698,9 @@ export const RecruitmentViews = () => {
                 }`}
               >
                 Rejected
-                {rejectedApplicants.length > 0 && (
+                {applicantSummary.rejected > 0 && (
                   <span className="ml-1.5 rounded-full bg-red-100 px-1.5 py-0.5 text-[10px] font-semibold text-red-600">
-                    {rejectedApplicants.length}
+                    {applicantSummary.rejected}
                   </span>
                 )}
               </button>
@@ -1343,7 +1364,7 @@ export const RecruitmentViews = () => {
                 <h2 className="text-base font-medium text-slate-700">
                   Rejected Applicants
                 </h2>
-                {rejectedApplicants.length > 0 && canManageRecruitment && (
+                {applicantSummary.rejected > 0 && canManageRecruitment && (
                   <Button
                     type="button"
                     variant="outline"
@@ -1513,11 +1534,12 @@ export const RecruitmentViews = () => {
 
           {/* Pagination (applicants tab only — the positions and
               verification tabs aren't paginated with these controls) */}
-          {activeTab === "applicants" && (
+          {(activeTab === "applicants" ||
+            activeTab === "rejected" ||
+            activeTab === "verification") && (
             <div className="mt-7 flex flex-col items-center justify-between gap-3 text-xs text-[#8a8a8a] sm:flex-row">
               <span>
-                Showing {total > 0 ? (currentPage - 1) * ROWS_PER_PAGE + 1 : 0}{" "}
-                to {Math.min(currentPage * ROWS_PER_PAGE, total)} of {total}
+                Showing {applicantStart} to {applicantEnd} of {total}
               </span>
               <div className="flex items-center gap-1">
                 <button
@@ -1528,20 +1550,27 @@ export const RecruitmentViews = () => {
                 >
                   Previous
                 </button>
-                {Array.from({ length: totalPages }, (_, i) => i + 1).map(
-                  (p) => (
+                {applicantPageItems.map((item, index) =>
+                  item === "ellipsis" ? (
+                    <span
+                      key={`ellipsis-${index}`}
+                      className="px-1 text-[#8a8a8a]"
+                    >
+                      ...
+                    </span>
+                  ) : (
                     <button
                       type="button"
-                      key={p}
-                      onClick={() => setPage(p)}
+                      key={item}
+                      onClick={() => setPage(item)}
                       className={cn(
                         "h-7 min-w-7 cursor-pointer rounded-full px-2",
-                        p === currentPage
+                        item === currentPage
                           ? "bg-[#1c9dde] text-white"
                           : "border border-[#eeeeee] bg-white text-[#696969]"
                       )}
                     >
-                      {p}
+                      {item}
                     </button>
                   )
                 )}
@@ -1762,10 +1791,10 @@ export const RecruitmentViews = () => {
             <p className="text-sm text-slate-500">
               This will permanently delete{" "}
               <span className="font-medium text-slate-700">
-                {rejectedApplicants.length}
+                {applicantSummary.rejected}
               </span>{" "}
               rejected application
-              {rejectedApplicants.length === 1 ? "" : "s"}. This action cannot
+              {applicantSummary.rejected === 1 ? "" : "s"}. This action cannot
               be undone.
             </p>
             <div className="mt-2 flex w-full justify-center gap-3">

--- a/client-side-ts/src/features/admin/recruitment-management/hooks/useRecruitmentData.ts
+++ b/client-side-ts/src/features/admin/recruitment-management/hooks/useRecruitmentData.ts
@@ -1,6 +1,6 @@
 // src/features/admin/recruitment-management/hooks/useRecruitmentData.ts
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAdminPermissions } from "@/features/admin/hooks/useAdminPermissions";
 
 import type {
@@ -29,6 +29,7 @@ import {
   toggleHiringStatus,
   verifyApplicantAccount,
   deleteApplication,
+  clearRejectedApplications,
   deletePosition as deletePositionApi,
 } from "../../../../api/recruitment.api";
 
@@ -45,6 +46,27 @@ export const DEFAULT_FILTERS: RecruitmentFilters = {
 const DEFAULT_SORT: RecruitmentSort = {
   field: "name",
   direction: "asc",
+};
+
+type ApplicantPagination = {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+};
+
+type ApplicantSummary = {
+  pending: number;
+  approved: number;
+  rejected: number;
+  verifications: number;
+};
+
+const EMPTY_APPLICANT_SUMMARY: ApplicantSummary = {
+  pending: 0,
+  approved: 0,
+  rejected: 0,
+  verifications: 0,
 };
 
 interface RawApplicantRecord {
@@ -222,13 +244,26 @@ const STATUS = {
 
 export const useRecruitmentData = () => {
   const { canManageRecruitment } = useAdminPermissions();
-  const [activeTab, setActiveTab] = useState<RecruitmentTab>("applicants");
+  const [activeTab, setActiveTabState] =
+    useState<RecruitmentTab>("applicants");
   const [applicants, setApplicants] = useState<RecruitmentApplicant[]>([]);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
   const [filters, setFilters] = useState<RecruitmentFilters>(DEFAULT_FILTERS);
   const [sort, setSort] = useState<RecruitmentSort>(DEFAULT_SORT);
   const [page, setPage] = useState(1);
+  const [applicantPagination, setApplicantPagination] =
+    useState<ApplicantPagination>({
+      page: 1,
+      limit: ROWS_PER_PAGE,
+      total: 0,
+      totalPages: 1,
+    });
+  const [applicantSummary, setApplicantSummary] =
+    useState<ApplicantSummary>(EMPTY_APPLICANT_SUMMARY);
+  const [roleOptions, setRoleOptions] = useState<string[]>([]);
+  const applicantRequestId = useRef(0);
   const [isLoading, setIsLoading] = useState(true);
   const [isMutating, setIsMutating] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -243,6 +278,12 @@ export const useRecruitmentData = () => {
   const [mutationError, setMutationError] = useState<string | null>(null);
 
   const clearMutationError = useCallback(() => setMutationError(null), []);
+
+  const setActiveTab = useCallback((tab: RecruitmentTab) => {
+    setActiveTabState(tab);
+    setPage(1);
+    setSelectedIds([]);
+  }, []);
 
   // ── Applicant details dialog state ────────────────────────────────────
   const [selectedApplicant, setSelectedApplicant] =
@@ -314,21 +355,57 @@ export const useRecruitmentData = () => {
   }, []);
 
   const fetchApplicants = useCallback(async () => {
+    const requestId = ++applicantRequestId.current;
     setIsLoading(true);
     setError(null);
 
     try {
-      const res = await getApplicants({});
-      const list = res.data.data.applicants;
-      setApplicants(list.map(mapApplication));
+      const tabStatus =
+        activeTab === "rejected"
+          ? "Rejected"
+          : activeTab === "verification"
+            ? undefined
+            : filters.status === "all"
+              ? undefined
+              : filters.status;
+      const res = await getApplicants({
+        page,
+        limit: ROWS_PER_PAGE,
+        search: debouncedSearch || undefined,
+        status: tabStatus,
+        role: filters.roles[0],
+        course: filters.courses[0],
+        year: filters.years[0],
+        sortField: sort.field,
+        sortDirection: sort.direction,
+        verificationOnly: activeTab === "verification" || undefined,
+      });
+
+      if (requestId !== applicantRequestId.current) return;
+
+      const payload = res.data.data;
+      const pagination = payload.pagination ?? {};
+      setApplicants((payload.applicants ?? []).map(mapApplication));
+      setApplicantPagination({
+        page: Number(pagination.page ?? page),
+        limit: Number(pagination.limit ?? ROWS_PER_PAGE),
+        total: Number(pagination.total ?? 0),
+        totalPages: Math.max(1, Number(pagination.totalPages ?? 1)),
+      });
+      setApplicantSummary({
+        ...EMPTY_APPLICANT_SUMMARY,
+        ...(payload.summary ?? {}),
+      });
+      setRoleOptions(payload.filterOptions?.roles ?? []);
     } catch (err) {
+      if (requestId !== applicantRequestId.current) return;
       setError(
         err instanceof Error ? err.message : "Failed to load applicants"
       );
     } finally {
-      setIsLoading(false);
+      if (requestId === applicantRequestId.current) setIsLoading(false);
     }
-  }, []);
+  }, [activeTab, debouncedSearch, filters, page, sort]);
 
   const fetchPositions = useCallback(
     async (pageNumber = positionsPage) => {
@@ -376,122 +453,24 @@ export const useRecruitmentData = () => {
   }, [fetchOpenPositionsCount]);
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional fetch-on-mount; fetchApplicants is also used for refetch, so its internal setIsLoading/setError calls are needed there
+    const timeoutId = window.setTimeout(() => {
+      setDebouncedSearch(search.trim());
+    }, 300);
+    return () => window.clearTimeout(timeoutId);
+  }, [search]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [filters, debouncedSearch, sort]);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- fetches only the current server page.
     fetchApplicants();
   }, [fetchApplicants]);
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional fetch-on-mount; setIsLoading/setError also serve the exposed refetch() path
-    setPage(1);
-  }, [filters, search]);
-
-  const filteredApplicants = useMemo(() => {
-    const query = search.trim().toLowerCase();
-
-    return applicants
-      .filter((applicant) => {
-        if (
-          query &&
-          ![
-            applicant.name,
-            applicant.id_number,
-            applicant.email,
-            applicant.course,
-            applicant.year,
-            applicant.roleApplied,
-            applicant.status,
-          ]
-            .join(" ")
-            .toLowerCase()
-            .includes(query)
-        ) {
-          return false;
-        }
-
-        if (
-          filters.roles.length > 0 &&
-          !filters.roles.includes(applicant.roleApplied)
-        ) {
-          return false;
-        }
-
-        if (
-          filters.courses.length > 0 &&
-          !filters.courses.includes(applicant.course)
-        ) {
-          return false;
-        }
-
-        if (filters.years.length > 0) {
-          // applicant.year may be "1st Year", "2", etc. — normalize to the
-          // leading digit so the filter values ("1".."4") match.
-          const yearDigit = String(applicant.year).match(/\d+/)?.[0] ?? "";
-          if (!filters.years.includes(yearDigit)) {
-            return false;
-          }
-        }
-
-        if (filters.status !== "all" && applicant.status !== filters.status) {
-          return false;
-        }
-
-        return true;
-      })
-      .sort((left, right) => {
-        let leftValue = "";
-        let rightValue = "";
-
-        switch (sort.field) {
-          case "courseYear":
-            leftValue = `${left.course} ${left.year}`;
-            rightValue = `${right.course} ${right.year}`;
-            break;
-
-          case "roleApplied":
-            leftValue = left.roleApplied;
-            rightValue = right.roleApplied;
-            break;
-
-          default:
-            leftValue = String(
-              left[sort.field as keyof RecruitmentApplicant] ?? ""
-            );
-
-            rightValue = String(
-              right[sort.field as keyof RecruitmentApplicant] ?? ""
-            );
-        }
-
-        const result = leftValue.localeCompare(rightValue, undefined, {
-          numeric: true,
-          sensitivity: "base",
-        });
-
-        return sort.direction === "asc" ? result : -result;
-      });
-  }, [applicants, search, filters, sort]);
-
-  const totalPages = Math.max(
-    1,
-    Math.ceil(filteredApplicants.length / ROWS_PER_PAGE)
-  );
-
-  const currentPage = Math.min(page, totalPages);
-
-  const pagedApplicants = filteredApplicants.slice(
-    (currentPage - 1) * ROWS_PER_PAGE,
-    currentPage * ROWS_PER_PAGE
-  );
-
-  const roleOptions = useMemo(
-    () =>
-      Array.from(
-        new Set(
-          applicants.map((applicant) => applicant.roleApplied).filter(Boolean)
-        )
-      ).sort(),
-    [applicants]
-  );
+  const pagedApplicants = applicants;
+  const totalPages = applicantPagination.totalPages;
+  const currentPage = applicantPagination.page;
 
   const toggleSort = (field: RecruitmentSortField) => {
     setSort((current) =>
@@ -560,6 +539,7 @@ export const useRecruitmentData = () => {
       setSelectedApplicant((current) =>
         current?.id === id ? updated : current
       );
+      await fetchApplicants();
       Promise.all([
         fetchPositions(positionsPage),
         fetchOpenPositionsCount(),
@@ -588,6 +568,7 @@ export const useRecruitmentData = () => {
       setSelectedApplicant((current) =>
         current?.id === id ? updated : current
       );
+      await fetchApplicants();
     } catch (err) {
       setMutationError(
         err instanceof Error ? err.message : "Failed to update applicant"
@@ -612,6 +593,7 @@ export const useRecruitmentData = () => {
       setSelectedApplicant((current) =>
         current?.id === id ? updated : current
       );
+      await fetchApplicants();
     } catch (err) {
       setMutationError(
         err instanceof Error ? err.message : "Failed to update applicant"
@@ -640,6 +622,7 @@ export const useRecruitmentData = () => {
       setSelectedApplicant((current) =>
         current?.id === id ? updated : current
       );
+      await fetchApplicants();
       Promise.all([
         fetchPositions(positionsPage),
         fetchOpenPositionsCount(),
@@ -669,6 +652,7 @@ export const useRecruitmentData = () => {
       setSelectedApplicant((current) =>
         current?.id === id ? updated : current
       );
+      await fetchApplicants();
     } catch (err) {
       setMutationError(
         err instanceof Error ? err.message : "Failed to schedule interview"
@@ -836,6 +820,7 @@ export const useRecruitmentData = () => {
       setSelectedApplicant((current) =>
         current?.id === id ? updated : current
       );
+      await fetchApplicants();
     } catch (err) {
       setMutationError(
         err instanceof Error ? err.message : "Failed to reschedule interview"
@@ -858,8 +843,13 @@ export const useRecruitmentData = () => {
 
   const verificationApplicants = useMemo(
     () =>
-      applicants.filter((a) => a.status === "Approved" && !a.volunteerAccount),
-    [applicants]
+      activeTab === "verification"
+        ? applicants.filter(
+            (applicant) =>
+              applicant.status === "Approved" && !applicant.volunteerAccount
+          )
+        : [],
+    [activeTab, applicants]
   );
 
   const verifyApplicant = useCallback(
@@ -888,6 +878,7 @@ export const useRecruitmentData = () => {
           username: account.username,
           tempPassword: account.tempPassword,
         });
+        await fetchApplicants();
       } catch (err) {
         setMutationError(
           err instanceof Error ? err.message : "Failed to verify applicant"
@@ -896,13 +887,16 @@ export const useRecruitmentData = () => {
         setIsMutating(false);
       }
     },
-    [applicants, canManageRecruitment]
+    [applicants, canManageRecruitment, fetchApplicants]
   );
 
   // ── Rejected applicants (delete) ───────────────────────────────────────
   const rejectedApplicants = useMemo(
-    () => applicants.filter((a) => a.status === "Rejected"),
-    [applicants]
+    () =>
+      activeTab === "rejected"
+        ? applicants.filter((applicant) => applicant.status === "Rejected")
+        : [],
+    [activeTab, applicants]
   );
 
   const deleteRejectedApplicant = async (id: string) => {
@@ -912,6 +906,11 @@ export const useRecruitmentData = () => {
       await deleteApplication(id);
       setApplicants((current) => current.filter((a) => a.id !== id));
       setSelectedApplicant((current) => (current?.id === id ? null : current));
+      if (applicants.length === 1 && page > 1) {
+        setPage(page - 1);
+      } else {
+        await fetchApplicants();
+      }
     } catch (err) {
       setMutationError(
         err instanceof Error ? err.message : "Failed to delete applicant"
@@ -925,11 +924,10 @@ export const useRecruitmentData = () => {
     setIsMutating(true);
     setMutationError(null);
     try {
-      const ids = rejectedApplicants.map((a) => a.id);
-      await Promise.all(ids.map((id) => deleteApplication(id)));
-      setApplicants((current) =>
-        current.filter((a) => a.status !== "Rejected")
-      );
+      await clearRejectedApplications();
+      setSelectedIds([]);
+      setPage(1);
+      if (page === 1) await fetchApplicants();
     } catch (err) {
       setMutationError(
         err instanceof Error
@@ -949,7 +947,6 @@ export const useRecruitmentData = () => {
     activeTab,
     setActiveTab,
     applicants,
-    filteredApplicants,
     pagedApplicants,
     selectedIds,
     search,
@@ -962,6 +959,8 @@ export const useRecruitmentData = () => {
     setPage,
     totalPages,
     currentPage,
+    applicantPagination,
+    applicantSummary,
     positionsPage,
     setPositionsPage,
     positionsTotalPages,

--- a/client-side-ts/src/types/recruitment.ts
+++ b/client-side-ts/src/types/recruitment.ts
@@ -81,7 +81,13 @@ export interface PaginatedResponse<T> {
 export interface ApplicantFilters {
   page?: number;
   limit?: number;
-  status?: Application["status"];
+  status?: Application["status"] | string;
   positionId?: string;
   search?: string;
+  role?: string;
+  course?: string;
+  year?: string;
+  sortField?: "name" | "id_number" | "courseYear" | "roleApplied" | "status";
+  sortDirection?: "asc" | "desc";
+  verificationOnly?: boolean;
 }

--- a/server-side/src/controllers/recruitment.v2.controller.ts
+++ b/server-side/src/controllers/recruitment.v2.controller.ts
@@ -197,6 +197,15 @@ class RecruitmentController {
     return res.status(200).json(result);
   });
 
+  /** Admin: Delete all rejected applications */
+  clearRejectedApplications = catchAsync(
+    async (req: Request, res: Response) => {
+      const result = await recruitmentService.clearRejectedApplications(req);
+      await logAdminAction(req, logs_action.CLEAR_REJECTED, "Rejected applicants");
+      return res.status(200).json(result);
+    }
+  );
+
   /** Admin: Create the volunteer account for an Approved applicant */
   verifyApplicantAccount = catchAsync(async (req: Request, res: Response) => {
     const id = req.params.id as string;

--- a/server-side/src/routes/recruitment.route.ts
+++ b/server-side/src/routes/recruitment.route.ts
@@ -199,6 +199,14 @@ router.get(
   recruitmentController.getApplicationDetails
 );
 
+router.delete(
+  "/applicants/rejected",
+  requireAccessTokenWithDBCheck,
+  roleAuthenticateV2(["admin"]),
+  adminAccessAuthenticateV2(recruitmentMutationRoles),
+  recruitmentController.clearRejectedApplications
+);
+
 router.patch(
   "/applications/:id/status",
   requireAccessTokenWithDBCheck,

--- a/server-side/src/services/recruitment.service.ts
+++ b/server-side/src/services/recruitment.service.ts
@@ -49,6 +49,15 @@ const toPositiveInteger = (value: any, fallback: number) => {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 };
 
+const toStringList = (value: unknown) =>
+  (Array.isArray(value) ? value : [value])
+    .flatMap((item) => String(item ?? "").split(","))
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+const escapeRegex = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
 const toRequirementList = (value: any) =>
   String(value ?? "")
     .split("\n")
@@ -722,31 +731,230 @@ export class RecruitmentService {
     return obj;
   }
 
-  /** Admin: Get paginated applicant list with filters */
+  /** Admin: Get one filtered and sorted page of applicants. */
   async getApplicants(req: any) {
-    const { positionId, status, search, page = 1, limit = 10 } = req.query;
-    const query: any = {};
+    const page = toPositiveInteger(req.query.page, 1);
+    const limit = Math.min(toPositiveInteger(req.query.limit, 10), 50);
+    const positionId = String(req.query.positionId ?? "").trim();
+    const search = String(req.query.search ?? "").trim();
+    const statuses = toStringList(req.query.status);
+    const roles = toStringList(req.query.roles ?? req.query.role);
+    const courses = toStringList(req.query.courses ?? req.query.course);
+    const years = toStringList(req.query.years ?? req.query.year)
+      .map((year) => year.match(/\d/)?.[0])
+      .filter((year): year is string => Boolean(year));
+    const verificationOnly = toBooleanQuery(req.query.verificationOnly);
 
-    if (positionId) query.position = positionId;
-    if (status) query.status = status;
-    if (search)
-      query.$or = [
-        { "applicantSnapshot.name": { $regex: search, $options: "i" } },
-        { "applicantSnapshot.idNumber": { $regex: search, $options: "i" } },
-      ];
+    const statusMap: Record<string, string> = {
+      Pending: applicationStatus.SUBMITTED,
+      Scheduled: applicationStatus.INTERVIEW_SCHEDULED,
+      "Interview Completed": applicationStatus.INTERVIEWING,
+      Approved: applicationStatus.APPROVED,
+      Rejected: applicationStatus.REJECTED,
+      "For Verification": applicationStatus.APPROVED,
+    };
 
-    const applicants = await Application.find(query)
-      .populate("position", "title")
-      .populate("applicant", "name id_number email course year")
-      .sort({ createdAt: -1 })
-      .skip((parseInt(page) - 1) * parseInt(limit))
-      .limit(parseInt(limit));
+    const conditions: Record<string, any>[] = [];
+    const mappedStatuses = statuses
+      .map((status) => statusMap[status] ?? status)
+      .filter(Boolean);
 
-    const total = await Application.countDocuments(query);
+    if (positionId) conditions.push({ position: positionId });
+    if (mappedStatuses.length) conditions.push({ status: { $in: mappedStatuses } });
+    if (courses.length)
+      conditions.push({ "applicantSnapshot.course": { $in: courses } });
+    if (years.length) {
+      conditions.push({
+        $expr: {
+          $regexMatch: {
+            input: { $toString: { $ifNull: ["$applicantSnapshot.year", ""] } },
+            regex: `^[${years.join("")}]`,
+          },
+        },
+      });
+    }
+    if (search) {
+      const pattern = escapeRegex(search);
+      conditions.push({
+        $or: [
+          { "applicantSnapshot.name": { $regex: pattern, $options: "i" } },
+          {
+            "applicantSnapshot.idNumber": {
+              $regex: pattern,
+              $options: "i",
+            },
+          },
+          { "applicantSnapshot.email": { $regex: pattern, $options: "i" } },
+        ],
+      });
+    }
+    if (verificationOnly || statuses.includes("For Verification")) {
+      conditions.push({ status: applicationStatus.APPROVED });
+      conditions.push({ "volunteerAccount.username": { $exists: false } });
+    }
+
+    const applicationMatch =
+      conditions.length === 0
+        ? {}
+        : conditions.length === 1
+          ? conditions[0]
+          : { $and: conditions };
+
+    const sortField = String(req.query.sortField ?? "createdAt");
+    const sortDirection = req.query.sortDirection === "asc" ? 1 : -1;
+    const sort: Record<string, 1 | -1> = {};
+
+    switch (sortField) {
+      case "name":
+        sort["applicantSnapshot.name"] = sortDirection;
+        break;
+      case "id_number":
+        sort["applicantSnapshot.idNumber"] = sortDirection;
+        break;
+      case "courseYear":
+        sort["applicantSnapshot.course"] = sortDirection;
+        sort["applicantSnapshot.year"] = sortDirection;
+        break;
+      case "roleApplied":
+        sort["position.title"] = sortDirection;
+        break;
+      case "status":
+        sort.status = sortDirection;
+        break;
+      default:
+        sort.createdAt = -1;
+    }
+    sort._id = -1;
+
+    // Position is stored as a string in some older records and as an ObjectId
+    // in newer records. Comparing their string forms keeps both formats visible.
+    const positionLookup = [
+      {
+        $lookup: {
+          from: RecruitmentPosition.collection.name,
+          let: { applicationPositionId: { $toString: "$position" } },
+          pipeline: [
+            {
+              $match: {
+                $expr: {
+                  $eq: [
+                    { $toString: "$_id" },
+                    "$$applicationPositionId",
+                  ],
+                },
+              },
+            },
+            { $project: { title: 1 } },
+          ],
+          as: "positionDetails",
+        },
+      },
+      {
+        $set: {
+          position: { $arrayElemAt: ["$positionDetails", 0] },
+        },
+      },
+      { $unset: "positionDetails" },
+    ];
+
+    const roleMatch = roles.length
+      ? [{ $match: { "position.title": { $in: roles } } }]
+      : [];
+
+    const [pageResult, summaryRows, positionIds] = await Promise.all([
+      Application.aggregate([
+        { $match: applicationMatch },
+        ...positionLookup,
+        ...roleMatch,
+        {
+          $facet: {
+            applicants: [
+              { $sort: sort },
+              { $skip: (page - 1) * limit },
+              { $limit: limit },
+            ],
+            total: [{ $count: "count" }],
+          },
+        },
+      ]),
+      Application.aggregate([
+        {
+          $group: {
+            _id: null,
+            pending: {
+              $sum: {
+                $cond: [
+                  { $eq: ["$status", applicationStatus.SUBMITTED] },
+                  1,
+                  0,
+                ],
+              },
+            },
+            approved: {
+              $sum: {
+                $cond: [
+                  { $eq: ["$status", applicationStatus.APPROVED] },
+                  1,
+                  0,
+                ],
+              },
+            },
+            rejected: {
+              $sum: {
+                $cond: [
+                  { $eq: ["$status", applicationStatus.REJECTED] },
+                  1,
+                  0,
+                ],
+              },
+            },
+            verifications: {
+              $sum: {
+                $cond: [
+                  {
+                    $and: [
+                      { $eq: ["$status", applicationStatus.APPROVED] },
+                      {
+                        $eq: [
+                          { $ifNull: ["$volunteerAccount.username", null] },
+                          null,
+                        ],
+                      },
+                    ],
+                  },
+                  1,
+                  0,
+                ],
+              },
+            },
+          },
+        },
+      ]),
+      Application.distinct("position"),
+    ]);
+
+    const roleOptions = await RecruitmentPosition.distinct("title", {
+      _id: { $in: positionIds },
+    });
+    const result = pageResult[0] ?? { applicants: [], total: [] };
+    const total = Number(result.total?.[0]?.count ?? 0);
+    const summary = summaryRows[0] ?? {};
 
     return {
-      applicants,
-      pagination: { page, limit, total, totalPages: Math.ceil(total / limit) },
+      applicants: result.applicants,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.max(1, Math.ceil(total / limit)),
+      },
+      summary: {
+        pending: Number(summary.pending ?? 0),
+        approved: Number(summary.approved ?? 0),
+        rejected: Number(summary.rejected ?? 0),
+        verifications: Number(summary.verifications ?? 0),
+      },
+      filterOptions: { roles: roleOptions.sort() },
     };
   }
 
@@ -949,6 +1157,22 @@ export class RecruitmentService {
 
     await app.deleteOne();
     return { message: "Application deleted successfully" };
+  }
+
+  /** Admin: Delete every rejected application without loading them in the UI. */
+  async clearRejectedApplications(req: any) {
+    const adminId =
+      req.userV2?.sub || (req.admin ? req.admin._id.toString() : null);
+    if (!adminId) throw new AppError("Authentication required.", 401);
+
+    const result = await Application.deleteMany({
+      status: applicationStatus.REJECTED,
+    });
+
+    return {
+      message: "Rejected applications cleared successfully",
+      deletedCount: result.deletedCount ?? 0,
+    };
   }
 
   /** Update application status (admin only) */


### PR DESCRIPTION
## Summary

- Fix admin recruitment applicants showing only the first 10 records
- Fetch applicants page by page from the backend instead of loading all records
- Add server-side search, filters, sorting, and accurate total counts
- Paginate Applicants, Rejected, and Verification tabs
- Add compact page controls for large applicant lists
- Add a bulk endpoint to clear rejected applications without loading every record in the browser

