### PR TITLE
Enhance recruitment management with mobile tables and interview features

### DIFF
--- a/client-side-ts/src/api/recruitment.api.ts
+++ b/client-side-ts/src/api/recruitment.api.ts
@@ -112,6 +112,9 @@ export const updateApplicationStatus = (
 export const deleteApplication = (id: string) =>
   api.delete(`${BASE_PATH}/applications/${id}`);
 
+export const clearRejectedApplications = () =>
+  api.delete(`${BASE_PATH}/applicants/rejected`);
+
 export const createInterview = (
   applicationId: string,
   data: InterviewPayload

--- a/client-side-ts/src/features/admin/recruitment-management/components/ApplicantInfoModal.tsx
+++ b/client-side-ts/src/features/admin/recruitment-management/components/ApplicantInfoModal.tsx
@@ -12,6 +12,7 @@ interface ApplicantInfoModalProps {
   error: string | null;
   onClose: () => void;
   onSetSchedule: () => void;
+  onReschedule: () => void;
   onViewResume: (id: string) => void;
   onDownloadResume: (id: string) => void;
   isResumeLoading: boolean;
@@ -46,6 +47,7 @@ export const ApplicantInfoModal = ({
   error,
   onClose,
   onSetSchedule,
+  onReschedule,
   onViewResume,
   onDownloadResume,
   isResumeLoading,
@@ -239,16 +241,29 @@ export const ApplicantInfoModal = ({
         </div>
 
         {!isLoading && applicant && !error && (
-          <div className="mt-auto flex shrink-0 justify-center px-6 py-4">
-            {hasInterview || !canManageRecruitment ? (
-              <Button
-                type="button"
-                className="h-11 rounded-full bg-[#1c9dde] px-9 text-sm font-semibold hover:bg-[#168bc7]"
-                onClick={onClose}
-              >
-                Close
-              </Button>
-            ) : (
+          <div className="mt-auto flex shrink-0 justify-center gap-3 px-6 py-4">
+            {hasInterview ? (
+              <>
+                {canManageRecruitment && (
+                  <Button
+                    type="button"
+                    className="h-11 rounded-full bg-[#1c9dde] px-9 text-sm font-semibold hover:bg-[#168bc7]"
+                    onClick={onReschedule}
+                  >
+                    <CalendarClock className="mr-2 h-4 w-4" />
+                    Reschedule Interview
+                  </Button>
+                )}
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="h-11 rounded-full px-9 text-sm font-semibold"
+                  onClick={onClose}
+                >
+                  Close
+                </Button>
+              </>
+            ) : canManageRecruitment ? (
               <Button
                 type="button"
                 className="h-11 rounded-full bg-[#1c9dde] px-9 text-sm font-semibold hover:bg-[#168bc7]"
@@ -256,6 +271,14 @@ export const ApplicantInfoModal = ({
               >
                 <CalendarClock className="mr-2 h-4 w-4" />
                 Set Schedule
+              </Button>
+            ) : (
+              <Button
+                type="button"
+                className="h-11 rounded-full bg-[#1c9dde] px-9 text-sm font-semibold hover:bg-[#168bc7]"
+                onClick={onClose}
+              >
+                Close
               </Button>
             )}
           </div>

--- a/client-side-ts/src/features/admin/recruitment-management/components/InterviewSchedulingModal.tsx
+++ b/client-side-ts/src/features/admin/recruitment-management/components/InterviewSchedulingModal.tsx
@@ -44,6 +44,36 @@ function formatDateDisplay(date?: Date) {
   });
 }
 
+
+function toLocalDateString(date: Date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+// Derive the form's initial state from prefill values. Used as the initial
+// value for each useState so the modal remounts (via `key` from the parent)
+// with fresh state whenever it opens for a (different) applicant.
+function getInitialState(initialValues?: ScheduleInterviewValues | null) {
+  const parsedDate = initialValues?.date
+    ? new Date(`${initialValues.date}T00:00:00`)
+    : undefined;
+
+  return {
+    date:
+      parsedDate && !Number.isNaN(parsedDate.getTime())
+        ? parsedDate
+        : undefined,
+    startTime: initialValues?.startTime || "",
+    endTime: initialValues?.endTime || "",
+    officers: initialValues?.officer
+      ? initialValues.officer.split(", ").filter(Boolean)
+      : [],
+    interviewType: initialValues?.interviewType || "",
+  };
+}
+
 // Convert "HH:mm" (24h) to minutes since midnight for reliable comparison.
 function timeToMinutes(time24: string) {
   const [h, m] = time24.split(":").map(Number);
@@ -121,6 +151,7 @@ interface InterviewSchedulingModalProps {
   isSubmitting: boolean;
   onClose: () => void;
   onConfirm: (values: ScheduleInterviewValues) => void;
+  initialValues?: ScheduleInterviewValues | null;
 }
 
 export const InterviewSchedulingModal = ({
@@ -128,12 +159,14 @@ export const InterviewSchedulingModal = ({
   isSubmitting,
   onClose,
   onConfirm,
+  initialValues = null,
 }: InterviewSchedulingModalProps) => {
-  const [date, setDate] = useState<Date | undefined>(undefined);
-  const [startTime, setStartTime] = useState("");
-  const [endTime, setEndTime] = useState("");
-  const [officers, setOfficers] = useState<string[]>([]);
-  const [interviewType, setInterviewType] = useState("");
+  const initialState = getInitialState(initialValues);
+  const [date, setDate] = useState<Date | undefined>(initialState.date);
+  const [startTime, setStartTime] = useState(initialState.startTime);
+  const [endTime, setEndTime] = useState(initialState.endTime);
+  const [officers, setOfficers] = useState<string[]>(initialState.officers);
+  const [interviewType, setInterviewType] = useState(initialState.interviewType);
   const [saveSelection, setSaveSelection] = useState(false);
 
   const isValid =
@@ -142,7 +175,7 @@ export const InterviewSchedulingModal = ({
   const handleConfirm = () => {
     if (!isValid || !date) return;
     onConfirm({
-      date: date.toISOString().slice(0, 10),
+      date: toLocalDateString(date),
       startTime,
       endTime,
       officer: officers.join(", "),

--- a/client-side-ts/src/features/admin/recruitment-management/components/RecruitmentMobileTable.tsx
+++ b/client-side-ts/src/features/admin/recruitment-management/components/RecruitmentMobileTable.tsx
@@ -1,0 +1,414 @@
+import { useState } from "react";
+import {
+  Ban,
+  Check,
+  MoreHorizontal,
+  Pencil,
+  RotateCcw,
+  Trash2,
+  X,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import type {
+  RecruitmentApplicant,
+  RecruitmentPosition,
+} from "../types/Recruitment.types";
+
+/* ------------------------------------------------------------------ */
+/* Shared helpers                                                      */
+/* ------------------------------------------------------------------ */
+
+const STATUS_STYLES: Record<string, string> = {
+  Pending: "bg-amber-100 text-amber-700",
+  "For Verification": "bg-slate-100 text-slate-700",
+  Scheduled: "bg-blue-100 text-blue-700",
+  "Interview Completed": "bg-purple-100 text-purple-700",
+  Approved: "bg-emerald-100 text-emerald-700",
+  Rejected: "bg-red-100 text-red-700",
+};
+
+const POSITION_STATUS_STYLES: Record<string, string> = {
+  DRAFT: "bg-slate-100 text-slate-600",
+  OPEN: "bg-emerald-100 text-emerald-700",
+  CLOSED: "bg-red-100 text-red-700",
+};
+
+const AVATAR_COLORS = [
+  "bg-orange-400",
+  "bg-blue-400",
+  "bg-purple-400",
+  "bg-teal-400",
+  "bg-pink-400",
+];
+
+function getAvatarColor(name: string) {
+  return AVATAR_COLORS[name.charCodeAt(0) % AVATAR_COLORS.length];
+}
+
+function getInitial(name: string) {
+  return name.trim().charAt(0).toUpperCase() || "?";
+}
+
+/* ------------------------------------------------------------------ */
+/* ApplicantMobileCard — "Applicants" tab                              */
+/* ------------------------------------------------------------------ */
+
+interface ApplicantMobileCardProps {
+  applicant: RecruitmentApplicant;
+  selected: boolean;
+  onToggleSelect: (id: string) => void;
+  onViewDetails: (id: string) => void;
+  canManage?: boolean;
+  isMutating?: boolean;
+  onApprove?: (id: string) => void;
+  onReject?: (id: string) => void;
+}
+
+export const ApplicantMobileCard = ({
+  applicant,
+  selected,
+  onToggleSelect,
+  onViewDetails,
+  canManage = false,
+  isMutating = false,
+  onApprove,
+  onReject,
+}: ApplicantMobileCardProps) => {
+  const isFinal =
+    applicant.status === "Approved" || applicant.status === "Rejected";
+
+  return (
+    <div className="space-y-3 rounded-xl border border-[#ececec] p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex min-w-0 items-start gap-3">
+          <Checkbox
+            checked={selected}
+            onCheckedChange={() => onToggleSelect(applicant.id)}
+            className="mt-1 data-[state=checked]:border-[#1C9DDE] data-[state=checked]:bg-[#1C9DDE]"
+          />
+          <span
+            className={cn(
+              "flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-semibold text-white",
+              getAvatarColor(applicant.name || "?")
+            )}
+          >
+            {getInitial(applicant.name)}
+          </span>
+          <div className="min-w-0">
+            <p className="truncate font-medium text-slate-900">
+              {applicant.name || "—"}
+            </p>
+            <p className="text-muted-foreground truncate text-xs">
+              {applicant.email}
+            </p>
+          </div>
+        </div>
+        <span
+          className={cn(
+            "shrink-0 rounded-full px-2.5 py-1 text-xs font-medium",
+            STATUS_STYLES[applicant.status] ?? "bg-slate-100 text-slate-600"
+          )}
+        >
+          {applicant.status}
+        </span>
+      </div>
+
+      <div className="grid grid-cols-2 gap-y-2 text-sm">
+        <div>
+          <p className="text-muted-foreground text-xs">ID Number</p>
+          <p className="font-medium">{applicant.id_number || "—"}</p>
+        </div>
+        <div>
+          <p className="text-muted-foreground text-xs">Course / Year</p>
+          <p className="font-medium">
+            {[applicant.course, applicant.year].filter(Boolean).join(" • ") ||
+              "—"}
+          </p>
+        </div>
+        <div className="col-span-2">
+          <p className="text-muted-foreground text-xs">Role Applied</p>
+          <p className="font-medium">{applicant.roleApplied || "—"}</p>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 pt-1">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-8 flex-1 rounded-full"
+          onClick={() => onViewDetails(applicant.id)}
+        >
+          View Details
+        </Button>
+        {canManage && (
+          <>
+            <Button
+              type="button"
+              size="icon-sm"
+              variant="outline"
+              disabled={isMutating || isFinal}
+              onClick={() => onApprove?.(applicant.id)}
+              aria-label="Approve"
+              className="h-8 w-8 shrink-0 rounded-full border-emerald-200 text-emerald-600 hover:bg-emerald-50 disabled:opacity-40"
+            >
+              <Check className="h-4 w-4" />
+            </Button>
+            <Button
+              type="button"
+              size="icon-sm"
+              variant="outline"
+              disabled={isMutating || isFinal}
+              onClick={() => onReject?.(applicant.id)}
+              aria-label="Reject"
+              className="h-8 w-8 shrink-0 rounded-full border-red-200 text-red-600 hover:bg-red-50 disabled:opacity-40"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+/* ------------------------------------------------------------------ */
+/* RejectedApplicantMobileCard — "Rejected" tab                        */
+/* ------------------------------------------------------------------ */
+
+interface RejectedApplicantMobileCardProps {
+  applicant: RecruitmentApplicant;
+  selected: boolean;
+  onToggleSelect: (id: string) => void;
+  canManage?: boolean;
+  isMutating?: boolean;
+  onDelete: (applicant: RecruitmentApplicant) => void;
+}
+
+export const RejectedApplicantMobileCard = ({
+  applicant,
+  selected,
+  onToggleSelect,
+  canManage = false,
+  isMutating = false,
+  onDelete,
+}: RejectedApplicantMobileCardProps) => {
+  return (
+    <div className="space-y-3 rounded-xl border border-[#ececec] p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex min-w-0 items-start gap-3">
+          <Checkbox
+            checked={selected}
+            onCheckedChange={() => onToggleSelect(applicant.id)}
+            className="mt-1 data-[state=checked]:border-[#1C9DDE] data-[state=checked]:bg-[#1C9DDE]"
+          />
+          <span
+            className={cn(
+              "flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-semibold text-white",
+              getAvatarColor(applicant.name || "?")
+            )}
+          >
+            {getInitial(applicant.name)}
+          </span>
+          <div className="min-w-0">
+            <p className="truncate font-medium text-slate-900">
+              {applicant.name || "—"}
+            </p>
+            <p className="text-muted-foreground truncate text-xs">
+              {applicant.email}
+            </p>
+          </div>
+        </div>
+        {canManage && (
+          <Button
+            type="button"
+            size="icon-sm"
+            variant="ghost"
+            disabled={isMutating}
+            onClick={() => onDelete(applicant)}
+            aria-label={`Delete ${applicant.name}`}
+            className="h-8 w-8 shrink-0 rounded-full border text-red-500 hover:bg-red-50 hover:text-red-600"
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 gap-y-2 text-sm">
+        <div>
+          <p className="text-muted-foreground text-xs">ID Number</p>
+          <p className="font-medium">{applicant.id_number || "—"}</p>
+        </div>
+        <div>
+          <p className="text-muted-foreground text-xs">Course / Year</p>
+          <p className="font-medium">
+            {[applicant.course, applicant.year].filter(Boolean).join(" • ") ||
+              "—"}
+          </p>
+        </div>
+        <div className="col-span-2">
+          <p className="text-muted-foreground text-xs">Role Applied</p>
+          <p className="font-medium">{applicant.roleApplied || "—"}</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+/* ------------------------------------------------------------------ */
+/* PositionMobileCard — "Open Roles" tab                               */
+/* ------------------------------------------------------------------ */
+
+interface PositionMobileCardProps {
+  position: RecruitmentPosition;
+  selected: boolean;
+  onToggleSelect: (id: string) => void;
+  canManage?: boolean;
+  isMutating?: boolean;
+  onEdit: (position: RecruitmentPosition) => void;
+  onClose: (id: string) => void;
+  onReopen: (id: string) => void;
+  onDelete: (position: RecruitmentPosition) => void;
+}
+
+export const PositionMobileCard = ({
+  position,
+  selected,
+  onToggleSelect,
+  canManage = false,
+  isMutating = false,
+  onEdit,
+  onClose,
+  onReopen,
+  onDelete,
+}: PositionMobileCardProps) => {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  return (
+    <div className="space-y-3 rounded-xl border border-[#ececec] p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex min-w-0 items-start gap-3">
+          <Checkbox
+            checked={selected}
+            onCheckedChange={() => onToggleSelect(position._id)}
+            className="mt-1 data-[state=checked]:border-[#1C9DDE] data-[state=checked]:bg-[#1C9DDE]"
+          />
+          <div className="min-w-0">
+            <p className="truncate font-medium text-slate-900">
+              {position.title}
+            </p>
+            <span
+              className={cn(
+                "mt-1 inline-block rounded-full px-2.5 py-0.5 text-xs font-medium",
+                POSITION_STATUS_STYLES[position.hiringStatus] ??
+                  "bg-slate-100 text-slate-600"
+              )}
+            >
+              {position.hiringStatus}
+            </span>
+          </div>
+        </div>
+
+        {canManage && (
+          <Popover open={menuOpen} onOpenChange={setMenuOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                type="button"
+                size="icon-sm"
+                variant="ghost"
+                disabled={isMutating}
+                className="h-8 w-8 shrink-0 rounded-full border text-slate-500 hover:bg-slate-100"
+              >
+                <MoreHorizontal className="h-4 w-4" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent
+              align="end"
+              className="w-56 rounded-xl border-[#ececec] p-1.5 shadow-lg"
+            >
+              <button
+                type="button"
+                onClick={() => {
+                  onEdit(position);
+                  setMenuOpen(false);
+                }}
+                className="flex w-full cursor-pointer items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm hover:bg-slate-50"
+              >
+                <Pencil className="h-4 w-4 text-slate-500" />
+                Edit Role Application
+              </button>
+
+              {position.hiringStatus === "CLOSED" ? (
+                <button
+                  type="button"
+                  onClick={() => {
+                    onReopen(position._id);
+                    setMenuOpen(false);
+                  }}
+                  className="flex w-full cursor-pointer items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm text-emerald-600 hover:bg-slate-50"
+                >
+                  <RotateCcw className="h-4 w-4" />
+                  Reopen Role Application
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => {
+                    onClose(position._id);
+                    setMenuOpen(false);
+                  }}
+                  className="flex w-full cursor-pointer items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm text-red-600 hover:bg-slate-50"
+                >
+                  <Ban className="h-4 w-4" />
+                  Close Role Application
+                </button>
+              )}
+
+              {position.hiringStatus === "CLOSED" && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    onDelete(position);
+                    setMenuOpen(false);
+                  }}
+                  className="flex w-full cursor-pointer items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm text-red-600 hover:bg-slate-50"
+                >
+                  <Trash2 className="h-4 w-4" />
+                  Delete Role Application
+                </button>
+              )}
+            </PopoverContent>
+          </Popover>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 gap-y-2 text-sm">
+        <div>
+          <p className="text-muted-foreground text-xs">Slots</p>
+          <p className="font-medium">{position.slots ?? "—"}</p>
+        </div>
+        <div>
+          <p className="text-muted-foreground text-xs">Deadline</p>
+          <p className="font-medium">
+            {position.applicationDeadline
+              ? new Date(position.applicationDeadline).toLocaleDateString()
+              : "—"}
+          </p>
+        </div>
+        <div className="col-span-2">
+          <p className="text-muted-foreground text-xs">Created</p>
+          <p className="font-medium">
+            {new Date(position.createdAt).toLocaleDateString()}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/client-side-ts/src/features/admin/recruitment-management/components/RecuitmentViews.tsx
+++ b/client-side-ts/src/features/admin/recruitment-management/components/RecuitmentViews.tsx
@@ -57,6 +57,12 @@ import { AccountVerifiedModal } from "./AccountVerifiedModal";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { useAdminPermissions } from "@/features/admin/hooks/useAdminPermissions";
 
+import {
+  ApplicantMobileCard,
+  RejectedApplicantMobileCard,
+  PositionMobileCard,
+} from "./RecruitmentMobileTable";
+
 const courses = ["BSIT", "BSCS"];
 const years = ["1", "2", "3", "4"];
 
@@ -708,7 +714,7 @@ export const RecruitmentViews = () => {
 
           {/* Table / Verification cards */}
           {activeTab === "applications" ? (
-            <div className="overflow-x-auto">
+            <div>
               {selectedPositionIds.length > 0 && (
                 <div className="mb-3 flex items-center justify-between rounded-lg bg-slate-50 px-3 py-2 text-xs text-slate-600">
                   <span>
@@ -744,216 +750,253 @@ export const RecruitmentViews = () => {
                   </div>
                 </div>
               )}
-              <table className="w-full min-w-[820px] table-fixed border-collapse text-sm">
-                <thead>
-                  <tr className="rounded-md bg-[#efefef] text-[#2f2f2f]">
-                    <th className="w-[4%] rounded-l-md px-3 py-2 text-left">
-                      <Checkbox
-                        checked={allPositionsSelected}
-                        onCheckedChange={(checked) =>
-                          setSelectedPositionIds(
-                            checked ? positions.map((p) => p._id) : []
-                          )
-                        }
-                        aria-label="Select all positions"
-                        className="data-[state=checked]:border-[#1C9DDE] data-[state=checked]:bg-[#1C9DDE]"
-                      />
-                    </th>
+              <div className="hidden overflow-x-auto md:block">
+                <table className="w-full min-w-[820px] table-fixed border-collapse text-sm">
+                  <thead>
+                    <tr className="rounded-md bg-[#efefef] text-[#2f2f2f]">
+                      <th className="w-[4%] rounded-l-md px-3 py-2 text-left">
+                        <Checkbox
+                          checked={allPositionsSelected}
+                          onCheckedChange={(checked) =>
+                            setSelectedPositionIds(
+                              checked ? positions.map((p) => p._id) : []
+                            )
+                          }
+                          aria-label="Select all positions"
+                          className="data-[state=checked]:border-[#1C9DDE] data-[state=checked]:bg-[#1C9DDE]"
+                        />
+                      </th>
 
-                    <th className="w-[22%] px-3 py-2 text-left font-medium">
-                      Position
-                    </th>
+                      <th className="w-[22%] px-3 py-2 text-left font-medium">
+                        Position
+                      </th>
 
-                    <th className="w-[12%] px-3 py-2 text-left font-medium">
-                      Status
-                    </th>
+                      <th className="w-[12%] px-3 py-2 text-left font-medium">
+                        Status
+                      </th>
 
-                    <th className="w-[12%] px-3 py-2 text-left font-medium">
-                      Slots
-                    </th>
+                      <th className="w-[12%] px-3 py-2 text-left font-medium">
+                        Slots
+                      </th>
 
-                    <th className="w-[17%] px-3 py-2 text-left font-medium">
-                      Deadline
-                    </th>
+                      <th className="w-[17%] px-3 py-2 text-left font-medium">
+                        Deadline
+                      </th>
 
-                    <th className="w-[18%] px-3 py-2 text-left font-medium">
-                      Created
-                    </th>
+                      <th className="w-[18%] px-3 py-2 text-left font-medium">
+                        Created
+                      </th>
 
-                    <th className="w-[15%] rounded-r-md px-3 py-2 text-right font-medium">
-                      Actions
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {isPositionsLoading ? (
-                    Array.from({ length: 5 }, (_, row) => (
-                      <tr key={row} className="border-b border-[#ededed]">
-                        {Array.from({ length: 7 }, (_, cell) => (
-                          <td key={cell} className="px-3 py-3">
-                            <Skeleton className="h-4 w-full rounded-full" />
-                          </td>
-                        ))}
-                      </tr>
-                    ))
-                  ) : positionsError ? (
-                    <tr>
-                      <td
-                        colSpan={7}
-                        className="px-3 py-16 text-center text-sm text-red-600"
-                      >
-                        {positionsError}
-                      </td>
+                      <th className="w-[15%] rounded-r-md px-3 py-2 text-right font-medium">
+                        Actions
+                      </th>
                     </tr>
-                  ) : positions.length > 0 ? (
-                    positions.map((position) => (
-                      <tr
-                        key={position._id}
-                        className="border-b border-[#ededed] text-[#303030] hover:bg-slate-50"
-                      >
-                        {/* Checkbox */}
-                        <td className="px-3 py-3">
-                          <Checkbox
-                            checked={selectedPositionIds.includes(position._id)}
-                            onCheckedChange={() =>
-                              togglePositionSelection(position._id)
-                            }
-                            aria-label={`Select ${position.title}`}
-                            className="data-[state=checked]:border-[#1C9DDE] data-[state=checked]:bg-[#1C9DDE] data-[state=checked]:text-white"
-                          />
+                  </thead>
+                  <tbody>
+                    {isPositionsLoading ? (
+                      Array.from({ length: 5 }, (_, row) => (
+                        <tr key={row} className="border-b border-[#ededed]">
+                          {Array.from({ length: 7 }, (_, cell) => (
+                            <td key={cell} className="px-3 py-3">
+                              <Skeleton className="h-4 w-full rounded-full" />
+                            </td>
+                          ))}
+                        </tr>
+                      ))
+                    ) : positionsError ? (
+                      <tr>
+                        <td
+                          colSpan={7}
+                          className="px-3 py-16 text-center text-sm text-red-600"
+                        >
+                          {positionsError}
                         </td>
-
-                        {/* Position */}
-                        <td className="truncate px-3 py-3 font-medium text-slate-900">
-                          {position.title}
-                        </td>
-
-                        {/* Status */}
-                        <td className="px-3 py-3">
-                          <span
-                            className={cn(
-                              "rounded-full px-2.5 py-1 text-xs font-medium",
-                              POSITION_STATUS_STYLES[position.hiringStatus] ??
-                                "bg-slate-100 text-slate-600"
-                            )}
-                          >
-                            {position.hiringStatus}
-                          </span>
-                        </td>
-
-                        {/* Slots */}
-                        <td className="px-3 py-3">{position.slots ?? "—"}</td>
-
-                        {/* Deadline */}
-                        <td className="px-3 py-3">
-                          {position.applicationDeadline
-                            ? new Date(
-                                position.applicationDeadline
-                              ).toLocaleDateString()
-                            : "—"}
-                        </td>
-
-                        {/* Created */}
-                        <td className="px-3 py-3">
-                          {new Date(position.createdAt).toLocaleDateString()}
-                        </td>
-
-                        {/* Actions */}
-                        <td className="px-3 py-3 text-right">
-                          {canManageRecruitment && (
-                            <Popover
-                              open={openPositionMenuId === position._id}
-                              onOpenChange={(open) =>
-                                setOpenPositionMenuId(
-                                  open ? position._id : null
-                                )
+                      </tr>
+                    ) : positions.length > 0 ? (
+                      positions.map((position) => (
+                        <tr
+                          key={position._id}
+                          className="border-b border-[#ededed] text-[#303030] hover:bg-slate-50"
+                        >
+                          {/* Checkbox */}
+                          <td className="px-3 py-3">
+                            <Checkbox
+                              checked={selectedPositionIds.includes(
+                                position._id
+                              )}
+                              onCheckedChange={() =>
+                                togglePositionSelection(position._id)
                               }
+                              aria-label={`Select ${position.title}`}
+                              className="data-[state=checked]:border-[#1C9DDE] data-[state=checked]:bg-[#1C9DDE] data-[state=checked]:text-white"
+                            />
+                          </td>
+
+                          {/* Position */}
+                          <td className="truncate px-3 py-3 font-medium text-slate-900">
+                            {position.title}
+                          </td>
+
+                          {/* Status */}
+                          <td className="px-3 py-3">
+                            <span
+                              className={cn(
+                                "rounded-full px-2.5 py-1 text-xs font-medium",
+                                POSITION_STATUS_STYLES[position.hiringStatus] ??
+                                  "bg-slate-100 text-slate-600"
+                              )}
                             >
-                              <PopoverTrigger asChild>
-                                <Button
-                                  type="button"
-                                  size="icon-sm"
-                                  variant="ghost"
-                                  disabled={isMutating}
-                                  className="h-7 w-7 rounded-full border text-slate-500 hover:bg-slate-100"
-                                >
-                                  <MoreHorizontal className="h-4 w-4" />
-                                </Button>
-                              </PopoverTrigger>
+                              {position.hiringStatus}
+                            </span>
+                          </td>
 
-                              <PopoverContent
-                                align="end"
-                                className="w-56 rounded-xl border-[#ececec] p-1.5 shadow-lg"
+                          {/* Slots */}
+                          <td className="px-3 py-3">{position.slots ?? "—"}</td>
+
+                          {/* Deadline */}
+                          <td className="px-3 py-3">
+                            {position.applicationDeadline
+                              ? new Date(
+                                  position.applicationDeadline
+                                ).toLocaleDateString()
+                              : "—"}
+                          </td>
+
+                          {/* Created */}
+                          <td className="px-3 py-3">
+                            {new Date(position.createdAt).toLocaleDateString()}
+                          </td>
+
+                          {/* Actions */}
+                          <td className="px-3 py-3 text-right">
+                            {canManageRecruitment && (
+                              <Popover
+                                open={openPositionMenuId === position._id}
+                                onOpenChange={(open) =>
+                                  setOpenPositionMenuId(
+                                    open ? position._id : null
+                                  )
+                                }
                               >
-                                <button
-                                  type="button"
-                                  onClick={() => {
-                                    setEditingPosition(position);
-                                    setOpenPositionMenuId(null);
-                                  }}
-                                  className="flex w-full cursor-pointer items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm hover:bg-slate-50"
+                                <PopoverTrigger asChild>
+                                  <Button
+                                    type="button"
+                                    size="icon-sm"
+                                    variant="ghost"
+                                    disabled={isMutating}
+                                    className="h-7 w-7 rounded-full border text-slate-500 hover:bg-slate-100"
+                                  >
+                                    <MoreHorizontal className="h-4 w-4" />
+                                  </Button>
+                                </PopoverTrigger>
+
+                                <PopoverContent
+                                  align="end"
+                                  className="w-56 rounded-xl border-[#ececec] p-1.5 shadow-lg"
                                 >
-                                  <Pencil className="h-4 w-4 text-slate-500" />
-                                  Edit Role Application
-                                </button>
+                                  <button
+                                    type="button"
+                                    onClick={() => {
+                                      setEditingPosition(position);
+                                      setOpenPositionMenuId(null);
+                                    }}
+                                    className="flex w-full cursor-pointer items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm hover:bg-slate-50"
+                                  >
+                                    <Pencil className="h-4 w-4 text-slate-500" />
+                                    Edit Role Application
+                                  </button>
 
-                                {position.hiringStatus === "CLOSED" ? (
-                                  <button
-                                    type="button"
-                                    onClick={() => {
-                                      reopenPosition(position._id);
-                                      setOpenPositionMenuId(null);
-                                    }}
-                                    className="flex w-full cursor-pointer items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm text-emerald-600 hover:bg-slate-50"
-                                  >
-                                    <RotateCcw className="h-4 w-4" />
-                                    Reopen Role Application
-                                  </button>
-                                ) : (
-                                  <button
-                                    type="button"
-                                    onClick={() => {
-                                      closePosition(position._id);
-                                      setOpenPositionMenuId(null);
-                                    }}
-                                    className="flex w-full cursor-pointer items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm text-red-600 hover:bg-slate-50"
-                                  >
-                                    <Ban className="h-4 w-4" />
-                                    Close Role Application
-                                  </button>
-                                )}
+                                  {position.hiringStatus === "CLOSED" ? (
+                                    <button
+                                      type="button"
+                                      onClick={() => {
+                                        reopenPosition(position._id);
+                                        setOpenPositionMenuId(null);
+                                      }}
+                                      className="flex w-full cursor-pointer items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm text-emerald-600 hover:bg-slate-50"
+                                    >
+                                      <RotateCcw className="h-4 w-4" />
+                                      Reopen Role Application
+                                    </button>
+                                  ) : (
+                                    <button
+                                      type="button"
+                                      onClick={() => {
+                                        closePosition(position._id);
+                                        setOpenPositionMenuId(null);
+                                      }}
+                                      className="flex w-full cursor-pointer items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm text-red-600 hover:bg-slate-50"
+                                    >
+                                      <Ban className="h-4 w-4" />
+                                      Close Role Application
+                                    </button>
+                                  )}
 
-                                {position.hiringStatus === "CLOSED" && (
-                                  <button
-                                    type="button"
-                                    onClick={() => {
-                                      setPositionDeleteTarget(position);
-                                      setOpenPositionMenuId(null);
-                                    }}
-                                    className="flex w-full cursor-pointer items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm text-red-600 hover:bg-slate-50"
-                                  >
-                                    <Trash2 className="h-4 w-4" />
-                                    Delete Role Application
-                                  </button>
-                                )}
-                              </PopoverContent>
-                            </Popover>
-                          )}
+                                  {position.hiringStatus === "CLOSED" && (
+                                    <button
+                                      type="button"
+                                      onClick={() => {
+                                        setPositionDeleteTarget(position);
+                                        setOpenPositionMenuId(null);
+                                      }}
+                                      className="flex w-full cursor-pointer items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm text-red-600 hover:bg-slate-50"
+                                    >
+                                      <Trash2 className="h-4 w-4" />
+                                      Delete Role Application
+                                    </button>
+                                  )}
+                                </PopoverContent>
+                              </Popover>
+                            )}
+                          </td>
+                        </tr>
+                      ))
+                    ) : (
+                      <tr>
+                        <td
+                          colSpan={7}
+                          className="px-3 py-16 text-center text-sm text-[#777]"
+                        >
+                          No open roles yet.
                         </td>
                       </tr>
-                    ))
-                  ) : (
-                    <tr>
-                      <td
-                        colSpan={7}
-                        className="px-3 py-16 text-center text-sm text-[#777]"
-                      >
-                        No open roles yet.
-                      </td>
-                    </tr>
-                  )}
-                </tbody>
-              </table>
+                    )}
+                  </tbody>
+                </table>
+              </div>
+
+              {/* Mobile cards */}
+              <div className="block space-y-3 md:hidden">
+                {isPositionsLoading ? (
+                  Array.from({ length: 4 }, (_, i) => (
+                    <Skeleton key={i} className="h-40 w-full rounded-xl" />
+                  ))
+                ) : positionsError ? (
+                  <p className="py-16 text-center text-sm text-red-600">
+                    {positionsError}
+                  </p>
+                ) : positions.length > 0 ? (
+                  positions.map((position) => (
+                    <PositionMobileCard
+                      key={position._id}
+                      position={position}
+                      selected={selectedPositionIds.includes(position._id)}
+                      onToggleSelect={togglePositionSelection}
+                      canManage={canManageRecruitment}
+                      isMutating={isMutating}
+                      onEdit={setEditingPosition}
+                      onClose={closePosition}
+                      onReopen={reopenPosition}
+                      onDelete={setPositionDeleteTarget}
+                    />
+                  ))
+                ) : (
+                  <p className="py-16 text-center text-sm text-[#777]">
+                    No open roles yet.
+                  </p>
+                )}
+              </div>
+
               <div className="mt-4 flex flex-col gap-3 text-sm text-[#777] sm:flex-row sm:items-center sm:justify-between">
                 <span>
                   Showing {positionsStart} to {positionsEnd} of {positionsTotal}
@@ -994,224 +1037,264 @@ export const RecruitmentViews = () => {
               </div>
             </div>
           ) : activeTab === "applicants" ? (
-            <div className="overflow-x-auto">
-              {selectedIds.length > 0 && (
-                <div className="mb-3 flex items-center justify-between rounded-lg bg-slate-50 px-3 py-2 text-xs text-slate-600">
-                  <span>{selectedIds.length} selected</span>
-                  <button
-                    type="button"
-                    onClick={clearSelection}
-                    className="cursor-pointer font-medium text-[#1c9dde] hover:underline"
-                  >
-                    Clear selection
-                  </button>
-                </div>
-              )}
-              <table className="w-full min-w-[900px] table-fixed border-collapse text-sm">
-                <thead>
-                  <tr className="rounded-md bg-[#efefef] text-[#2f2f2f]">
-                    <th className="w-[4%] rounded-l-md px-3 py-2 text-left">
-                      <Checkbox
-                        checked={allOnPageSelected}
-                        onCheckedChange={toggleSelectAllOnPage}
-                        aria-label="Select all on page"
-                        className="data-[state=checked]:border-[#1C9DDE] data-[state=checked]:bg-[#1C9DDE] data-[state=checked]:text-white"
-                      />
-                    </th>
-                    <th className="w-[24%] px-3 py-2 text-left">
-                      <SortableHeader
-                        label="Applicant"
-                        field="name"
-                        sort={sort}
-                        onSort={toggleSort}
-                      />
-                    </th>
-                    <th className="w-[14%] px-3 py-2 text-left font-medium">
-                      ID Number
-                    </th>
-                    <th className="w-[14%] px-3 py-2 text-left">
-                      <SortableHeader
-                        label="Course / Year"
-                        field="courseYear"
-                        sort={sort}
-                        onSort={toggleSort}
-                      />
-                    </th>
-                    <th className="w-[16%] px-3 py-2 text-left">
-                      <SortableHeader
-                        label="Role Applied"
-                        field="roleApplied"
-                        sort={sort}
-                        onSort={toggleSort}
-                      />
-                    </th>
-                    <th className="w-[14%] px-3 py-2 text-left">
-                      <SortableHeader
-                        label="Status"
-                        field="status"
-                        sort={sort}
-                        onSort={toggleSort}
-                      />
-                    </th>
-                    <th className="w-[14%] rounded-r-md px-3 py-2 text-right font-medium">
-                      Actions
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {isLoading ? (
-                    Array.from({ length: 5 }, (_, index) => (
-                      <tr key={index} className="border-b border-[#ededed]">
-                        {Array.from({ length: 7 }, (_, cell) => (
-                          <td key={cell} className="px-3 py-3">
-                            <Skeleton className="h-4 w-full rounded-full" />
+            <>
+              <div className="hidden overflow-x-auto md:block">
+                {selectedIds.length > 0 && (
+                  <div className="mb-3 flex items-center justify-between rounded-lg bg-slate-50 px-3 py-2 text-xs text-slate-600">
+                    <span>{selectedIds.length} selected</span>
+                    <button
+                      type="button"
+                      onClick={clearSelection}
+                      className="cursor-pointer font-medium text-[#1c9dde] hover:underline"
+                    >
+                      Clear selection
+                    </button>
+                  </div>
+                )}
+                <table className="w-full min-w-[900px] table-fixed border-collapse text-sm">
+                  <thead>
+                    <tr className="rounded-md bg-[#efefef] text-[#2f2f2f]">
+                      <th className="w-[4%] rounded-l-md px-3 py-2 text-left">
+                        <Checkbox
+                          checked={allOnPageSelected}
+                          onCheckedChange={toggleSelectAllOnPage}
+                          aria-label="Select all on page"
+                          className="data-[state=checked]:border-[#1C9DDE] data-[state=checked]:bg-[#1C9DDE] data-[state=checked]:text-white"
+                        />
+                      </th>
+                      <th className="w-[24%] px-3 py-2 text-left">
+                        <SortableHeader
+                          label="Applicant"
+                          field="name"
+                          sort={sort}
+                          onSort={toggleSort}
+                        />
+                      </th>
+                      <th className="w-[14%] px-3 py-2 text-left font-medium">
+                        ID Number
+                      </th>
+                      <th className="w-[14%] px-3 py-2 text-left">
+                        <SortableHeader
+                          label="Course / Year"
+                          field="courseYear"
+                          sort={sort}
+                          onSort={toggleSort}
+                        />
+                      </th>
+                      <th className="w-[16%] px-3 py-2 text-left">
+                        <SortableHeader
+                          label="Role Applied"
+                          field="roleApplied"
+                          sort={sort}
+                          onSort={toggleSort}
+                        />
+                      </th>
+                      <th className="w-[14%] px-3 py-2 text-left">
+                        <SortableHeader
+                          label="Status"
+                          field="status"
+                          sort={sort}
+                          onSort={toggleSort}
+                        />
+                      </th>
+                      <th className="w-[14%] rounded-r-md px-3 py-2 text-right font-medium">
+                        Actions
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {isLoading ? (
+                      Array.from({ length: 5 }, (_, index) => (
+                        <tr key={index} className="border-b border-[#ededed]">
+                          {Array.from({ length: 7 }, (_, cell) => (
+                            <td key={cell} className="px-3 py-3">
+                              <Skeleton className="h-4 w-full rounded-full" />
+                            </td>
+                          ))}
+                        </tr>
+                      ))
+                    ) : pagedApplicants.length > 0 ? (
+                      pagedApplicants.map((applicant) => (
+                        <tr
+                          key={applicant.id}
+                          className="border-b border-[#ededed] text-[#303030] hover:bg-slate-50"
+                        >
+                          <td className="px-3 py-3">
+                            <Checkbox
+                              checked={selectedIds.includes(applicant.id)}
+                              onCheckedChange={() =>
+                                toggleApplicantSelection(applicant.id)
+                              }
+                              aria-label={`Select ${applicant.name}`}
+                              className="data-[state=checked]:border-[#1C9DDE] data-[state=checked]:bg-[#1C9DDE] data-[state=checked]:text-white"
+                            />
                           </td>
-                        ))}
-                      </tr>
-                    ))
-                  ) : pagedApplicants.length > 0 ? (
-                    pagedApplicants.map((applicant) => (
-                      <tr
-                        key={applicant.id}
-                        className="border-b border-[#ededed] text-[#303030] hover:bg-slate-50"
-                      >
-                        <td className="px-3 py-3">
-                          <Checkbox
-                            checked={selectedIds.includes(applicant.id)}
-                            onCheckedChange={() =>
-                              toggleApplicantSelection(applicant.id)
-                            }
-                            aria-label={`Select ${applicant.name}`}
-                            className="data-[state=checked]:border-[#1C9DDE] data-[state=checked]:bg-[#1C9DDE] data-[state=checked]:text-white"
-                          />
-                        </td>
-                        <td className="px-3 py-3">
-                          <div className="flex min-w-0 items-center gap-2.5">
+                          <td className="px-3 py-3">
+                            <div className="flex min-w-0 items-center gap-2.5">
+                              <span
+                                className={cn(
+                                  "flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-semibold text-white",
+                                  getAvatarColor(applicant.name || "?")
+                                )}
+                              >
+                                {getInitial(applicant.name)}
+                              </span>
+                              <div className="min-w-0">
+                                <p className="truncate font-medium text-slate-900">
+                                  {applicant.name || "—"}
+                                </p>
+                                <p className="truncate text-xs text-[#8a8a8a]">
+                                  {applicant.email}
+                                </p>
+                              </div>
+                            </div>
+                          </td>
+                          <td className="truncate px-3 py-3">
+                            {applicant.id_number || "—"}
+                          </td>
+                          <td className="truncate px-3 py-3">
+                            {[applicant.course, applicant.year]
+                              .filter(Boolean)
+                              .join(" • ") || "—"}
+                          </td>
+                          <td className="truncate px-3 py-3">
+                            {applicant.roleApplied || "—"}
+                          </td>
+                          <td className="px-3 py-3">
                             <span
                               className={cn(
-                                "flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-semibold text-white",
-                                getAvatarColor(applicant.name || "?")
+                                "rounded-full px-2.5 py-1 text-xs font-medium",
+                                STATUS_STYLES[applicant.status] ??
+                                  "bg-slate-100 text-slate-600"
                               )}
                             >
-                              {getInitial(applicant.name)}
+                              {applicant.status}
                             </span>
-                            <div className="min-w-0">
-                              <p className="truncate font-medium text-slate-900">
-                                {applicant.name || "—"}
-                              </p>
-                              <p className="truncate text-xs text-[#8a8a8a]">
-                                {applicant.email}
-                              </p>
-                            </div>
-                          </div>
-                        </td>
-                        <td className="truncate px-3 py-3">
-                          {applicant.id_number || "—"}
-                        </td>
-                        <td className="truncate px-3 py-3">
-                          {[applicant.course, applicant.year]
-                            .filter(Boolean)
-                            .join(" • ") || "—"}
-                        </td>
-                        <td className="truncate px-3 py-3">
-                          {applicant.roleApplied || "—"}
-                        </td>
-                        <td className="px-3 py-3">
-                          <span
-                            className={cn(
-                              "rounded-full px-2.5 py-1 text-xs font-medium",
-                              STATUS_STYLES[applicant.status] ??
-                                "bg-slate-100 text-slate-600"
-                            )}
-                          >
-                            {applicant.status}
-                          </span>
-                        </td>
-                        <td className="px-3 py-3 text-right">
-                          <Popover
-                            open={openMenuId === applicant.id}
-                            onOpenChange={(open) =>
-                              setOpenMenuId(open ? applicant.id : null)
-                            }
-                          >
-                            <PopoverTrigger asChild>
-                              <Button
-                                type="button"
-                                size="icon-sm"
-                                variant="ghost"
-                                disabled={isMutating}
-                                className="h-7 w-7 rounded-full border text-slate-500 hover:bg-slate-100"
-                              >
-                                <MoreHorizontal className="h-4 w-4" />
-                              </Button>
-                            </PopoverTrigger>
-                            <PopoverContent
-                              align="end"
-                              className="w-52 rounded-xl border-[#ececec] p-1.5 shadow-lg"
+                          </td>
+                          <td className="px-3 py-3 text-right">
+                            <Popover
+                              open={openMenuId === applicant.id}
+                              onOpenChange={(open) =>
+                                setOpenMenuId(open ? applicant.id : null)
+                              }
                             >
-                              <button
-                                type="button"
-                                onClick={() => {
-                                  viewApplicantDetails(applicant.id);
-                                  setOpenMenuId(null);
-                                }}
-                                className="flex w-full cursor-pointer items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm hover:bg-slate-50"
+                              <PopoverTrigger asChild>
+                                <Button
+                                  type="button"
+                                  size="icon-sm"
+                                  variant="ghost"
+                                  disabled={isMutating}
+                                  className="h-7 w-7 rounded-full border text-slate-500 hover:bg-slate-100"
+                                >
+                                  <MoreHorizontal className="h-4 w-4" />
+                                </Button>
+                              </PopoverTrigger>
+                              <PopoverContent
+                                align="end"
+                                className="w-52 rounded-xl border-[#ececec] p-1.5 shadow-lg"
                               >
-                                <UserPen className="h-4 w-4 text-slate-500" />
-                                View Details
-                              </button>
-                              {canManageRecruitment && (
-                                <>
-                                  <button
-                                    type="button"
-                                    disabled={
-                                      applicant.status === "Approved" ||
-                                      applicant.status === "Rejected"
-                                    }
-                                    onClick={() => {
-                                      approveApplicant(applicant.id);
-                                      setOpenMenuId(null);
-                                    }}
-                                    className="flex w-full cursor-pointer items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm text-emerald-600 hover:bg-slate-50 disabled:cursor-not-allowed disabled:text-slate-300"
-                                  >
-                                    <Check className="h-4 w-4" />
-                                    Approve
-                                  </button>
-                                  <button
-                                    type="button"
-                                    disabled={
-                                      applicant.status === "Approved" ||
-                                      applicant.status === "Rejected"
-                                    }
-                                    onClick={() => {
-                                      rejectApplicant(applicant.id);
-                                      setOpenMenuId(null);
-                                    }}
-                                    className="flex w-full cursor-pointer items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm text-red-600 hover:bg-slate-50 disabled:cursor-not-allowed disabled:text-slate-300"
-                                  >
-                                    <X className="h-4 w-4" />
-                                    Reject
-                                  </button>
-                                </>
-                              )}
-                            </PopoverContent>
-                          </Popover>
+                                <button
+                                  type="button"
+                                  onClick={() => {
+                                    viewApplicantDetails(applicant.id);
+                                    setOpenMenuId(null);
+                                  }}
+                                  className="flex w-full cursor-pointer items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm hover:bg-slate-50"
+                                >
+                                  <UserPen className="h-4 w-4 text-slate-500" />
+                                  View Details
+                                </button>
+                                {canManageRecruitment && (
+                                  <>
+                                    <button
+                                      type="button"
+                                      disabled={
+                                        applicant.status === "Approved" ||
+                                        applicant.status === "Rejected"
+                                      }
+                                      onClick={() => {
+                                        approveApplicant(applicant.id);
+                                        setOpenMenuId(null);
+                                      }}
+                                      className="flex w-full cursor-pointer items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm text-emerald-600 hover:bg-slate-50 disabled:cursor-not-allowed disabled:text-slate-300"
+                                    >
+                                      <Check className="h-4 w-4" />
+                                      Approve
+                                    </button>
+                                    <button
+                                      type="button"
+                                      disabled={
+                                        applicant.status === "Approved" ||
+                                        applicant.status === "Rejected"
+                                      }
+                                      onClick={() => {
+                                        rejectApplicant(applicant.id);
+                                        setOpenMenuId(null);
+                                      }}
+                                      className="flex w-full cursor-pointer items-center gap-2.5 rounded-md px-3 py-2 text-left text-sm text-red-600 hover:bg-slate-50 disabled:cursor-not-allowed disabled:text-slate-300"
+                                    >
+                                      <X className="h-4 w-4" />
+                                      Reject
+                                    </button>
+                                  </>
+                                )}
+                              </PopoverContent>
+                            </Popover>
+                          </td>
+                        </tr>
+                      ))
+                    ) : (
+                      <tr>
+                        <td
+                          colSpan={7}
+                          className="px-3 py-16 text-center text-sm text-[#777]"
+                        >
+                          No applicants found.
                         </td>
                       </tr>
-                    ))
-                  ) : (
-                    <tr>
-                      <td
-                        colSpan={7}
-                        className="px-3 py-16 text-center text-sm text-[#777]"
-                      >
-                        No applicants found.
-                      </td>
-                    </tr>
-                  )}
-                </tbody>
-              </table>
-            </div>
+                    )}
+                  </tbody>
+                </table>
+              </div>
+
+              <div className="block space-y-3 md:hidden">
+                {selectedIds.length > 0 && (
+                  <div className="mb-1 flex items-center justify-between rounded-lg bg-slate-50 px-3 py-2 text-xs text-slate-600">
+                    <span>{selectedIds.length} selected</span>
+                    <button
+                      type="button"
+                      onClick={clearSelection}
+                      className="font-medium text-[#1c9dde]"
+                    >
+                      Clear selection
+                    </button>
+                  </div>
+                )}
+                {isLoading ? (
+                  Array.from({ length: 4 }, (_, i) => (
+                    <Skeleton key={i} className="h-40 w-full rounded-xl" />
+                  ))
+                ) : pagedApplicants.length > 0 ? (
+                  pagedApplicants.map((applicant) => (
+                    <ApplicantMobileCard
+                      key={applicant.id}
+                      applicant={applicant}
+                      selected={selectedIds.includes(applicant.id)}
+                      onToggleSelect={toggleApplicantSelection}
+                      onViewDetails={viewApplicantDetails}
+                      canManage={canManageRecruitment}
+                      isMutating={isMutating}
+                      onApprove={approveApplicant}
+                      onReject={rejectApplicant}
+                    />
+                  ))
+                ) : (
+                  <p className="py-16 text-center text-sm text-[#777]">
+                    No applicants found.
+                  </p>
+                )}
+              </div>
+            </>
           ) : activeTab === "rejected" ? (
             <div>
               <div className="mb-4 flex items-center justify-between">
@@ -1231,6 +1314,20 @@ export const RecruitmentViews = () => {
                   </Button>
                 )}
               </div>
+
+              {selectedRejectedIds.length > 0 && (
+                <div className="mb-3 flex items-center justify-between rounded-lg bg-slate-50 px-3 py-2 text-xs text-slate-600">
+                  <span>{selectedRejectedIds.length} selected</span>
+                  <button
+                    type="button"
+                    onClick={() => setSelectedRejectedIds([])}
+                    className="cursor-pointer font-medium text-[#1c9dde] hover:underline"
+                  >
+                    Clear selection
+                  </button>
+                </div>
+              )}
+
               {isLoading ? (
                 <div className="space-y-2">
                   {Array.from({ length: 4 }, (_, i) => (
@@ -1238,122 +1335,101 @@ export const RecruitmentViews = () => {
                   ))}
                 </div>
               ) : rejectedApplicants.length > 0 ? (
-                <div className="overflow-x-auto">
-                  <table className="w-full min-w-[700px] table-fixed border-collapse text-sm">
-                    <thead>
-                      <tr className="rounded-md bg-[#efefef] text-[#2f2f2f]">
-                        <th className="w-[4%] rounded-l-md px-3 py-2 text-left">
-                          <Checkbox
-                            checked={allRejectedSelected}
-                            onCheckedChange={(checked) =>
-                              setSelectedRejectedIds(
-                                checked
-                                  ? rejectedApplicants.map((a) => a.id)
-                                  : []
-                              )
-                            }
-                            aria-label="Select all rejected applicants"
-                            className="data-[state=checked]:border-[#1C9DDE] data-[state=checked]:bg-[#1C9DDE]"
-                          />
-                        </th>
-                        <th className="w-[26%] px-3 py-2 text-left font-medium">
-                          Applicant
-                        </th>
-                        <th className="w-[15%] px-3 py-2 text-left font-medium">
-                          ID Number
-                        </th>
-                        <th className="w-[15%] px-3 py-2 text-left font-medium">
-                          Course / Year
-                        </th>
-                        <th className="w-[25%] px-3 py-2 text-left font-medium">
-                          Role Applied
-                        </th>
-                        <th className="w-[15%] rounded-r-md px-3 py-2 text-right font-medium">
-                          Actions
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {rejectedApplicants.map((applicant) => (
-                        <tr
-                          key={applicant.id}
-                          className="border-b border-[#ededed] text-[#303030] hover:bg-slate-50"
-                        >
-                          {/* Checkbox */}
-                          <td className="px-3 py-3">
+                <>
+                  {/* Desktop table */}
+                  <div className="hidden overflow-x-auto md:block">
+                    <table className="w-full min-w-[700px] table-fixed border-collapse text-sm">
+                      <thead>
+                        <tr className="rounded-md bg-[#efefef] text-[#2f2f2f]">
+                          <th className="w-[4%] rounded-l-md px-3 py-2 text-left">
                             <Checkbox
-                              checked={selectedRejectedIds.includes(
-                                applicant.id
-                              )}
-                              onCheckedChange={() =>
-                                toggleRejectedSelection(applicant.id)
+                              checked={allRejectedSelected}
+                              onCheckedChange={(checked) =>
+                                setSelectedRejectedIds(
+                                  checked
+                                    ? rejectedApplicants.map((a) => a.id)
+                                    : []
+                                )
                               }
-                              aria-label={`Select ${applicant.name}`}
+                              aria-label="Select all rejected applicants"
                               className="data-[state=checked]:border-[#1C9DDE] data-[state=checked]:bg-[#1C9DDE] data-[state=checked]:text-white"
                             />
-                          </td>
-
-                          {/* Applicant */}
-                          <td className="px-3 py-3">
-                            <div className="flex min-w-0 items-center gap-2.5">
-                              <span
-                                className={cn(
-                                  "flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-semibold text-white",
-                                  getAvatarColor(applicant.name || "?")
+                          </th>
+                          <th className="px-3 py-2 text-left font-medium">
+                            Applicant
+                          </th>
+                          <th className="px-3 py-2 text-left font-medium">
+                            Role Applied
+                          </th>
+                          <th className="rounded-r-md px-3 py-2 text-right font-medium">
+                            Actions
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {rejectedApplicants.map((applicant) => (
+                          <tr
+                            key={applicant.id}
+                            className="border-b border-[#ededed] text-[#303030] hover:bg-slate-50"
+                          >
+                            <td className="px-3 py-3">
+                              <Checkbox
+                                checked={selectedRejectedIds.includes(
+                                  applicant.id
                                 )}
-                              >
-                                {getInitial(applicant.name)}
-                              </span>
-
-                              <div className="min-w-0">
-                                <p className="truncate font-medium text-slate-900">
-                                  {applicant.name || "—"}
-                                </p>
-                                <p className="truncate text-xs text-[#8a8a8a]">
-                                  {applicant.email}
-                                </p>
-                              </div>
-                            </div>
-                          </td>
-
-                          {/* ID Number */}
-                          <td className="truncate px-3 py-3">
-                            {applicant.id_number || "—"}
-                          </td>
-
-                          {/* Course / Year */}
-                          <td className="truncate px-3 py-3">
-                            {[applicant.course, applicant.year]
-                              .filter(Boolean)
-                              .join(" • ") || "—"}
-                          </td>
-
-                          {/* Role Applied */}
-                          <td className="truncate px-3 py-3">
-                            {applicant.roleApplied || "—"}
-                          </td>
-
-                          {/* Actions */}
-                          <td className="px-3 py-3 text-right">
-                            {canManageRecruitment && (
+                                onCheckedChange={() =>
+                                  toggleRejectedSelection(applicant.id)
+                                }
+                                aria-label={`Select ${applicant.name}`}
+                                className="data-[state=checked]:border-[#1C9DDE] data-[state=checked]:bg-[#1C9DDE] data-[state=checked]:text-white"
+                              />
+                            </td>
+                            <td className="truncate px-3 py-3 font-medium">
+                              {applicant.name || "—"}
+                            </td>
+                            <td className="truncate px-3 py-3">
+                              {applicant.roleApplied || "—"}
+                            </td>                   
+                              <td className="px-3 py-3">
+                                {applicant.rejectedAt
+                                  ? new Date(
+                                      applicant.rejectedAt
+                                    ).toLocaleDateString()
+                                  : "—"}
+                              </td>                           
+                            <td className="px-3 py-3 text-right">
                               <Button
                                 type="button"
                                 size="icon-sm"
                                 variant="ghost"
                                 disabled={isMutating}
+                                className="h-7 w-7 rounded-full border text-red-500 hover:bg-red-50"
                                 onClick={() => setDeleteTarget(applicant)}
-                                className="h-7 w-7 rounded-full border text-red-500 hover:bg-red-50 hover:text-red-600"
-                                aria-label={`Delete ${applicant.name}`}
                               >
                                 <Trash2 className="h-4 w-4" />
                               </Button>
-                            )}
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+
+                  {/* Mobile cards */}
+                  <div className="block space-y-3 md:hidden">
+                    {rejectedApplicants.map((applicant) => (
+                      <RejectedApplicantMobileCard
+                        key={applicant.id}
+                        applicant={applicant}
+                        selected={selectedRejectedIds.includes(applicant.id)}
+                        onToggleSelect={toggleRejectedSelection}
+                        canManage={canManageRecruitment}
+                        isMutating={isMutating}
+                        onDelete={setDeleteTarget}
+                      />
+                    ))}
+                  </div>
+                </>
               ) : (
                 <p className="py-16 text-center text-sm text-[#777]">
                   No rejected applicants.

--- a/client-side-ts/src/features/admin/recruitment-management/components/RecuitmentViews.tsx
+++ b/client-side-ts/src/features/admin/recruitment-management/components/RecuitmentViews.tsx
@@ -34,7 +34,6 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import {
   useRecruitmentData,
-  ROWS_PER_PAGE,
   POSITIONS_PER_PAGE,
   DEFAULT_FILTERS,
 } from "../hooks/useRecruitmentData";
@@ -97,6 +96,26 @@ function getAvatarColor(name: string) {
 
 function getInitial(name: string) {
   return name.trim().charAt(0).toUpperCase() || "?";
+}
+
+function getPaginationItems(
+  currentPage: number,
+  totalPages: number
+): Array<number | "ellipsis"> {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, index) => index + 1);
+  }
+
+  const items: Array<number | "ellipsis"> = [1];
+  const start = Math.max(2, currentPage - 1);
+  const end = Math.min(totalPages - 1, currentPage + 1);
+
+  if (start > 2) items.push("ellipsis");
+  for (let page = start; page <= end; page += 1) items.push(page);
+  if (end < totalPages - 1) items.push("ellipsis");
+  items.push(totalPages);
+
+  return items;
 }
 
 // Convert an ISO timestamp to a local "YYYY-MM-DD" string for the date input.
@@ -181,7 +200,7 @@ const RecruitmentFilterPopover = ({
   const updateSingle = (field: "roles" | "courses" | "years", value: string) =>
     setDraft((current) => ({
       ...current,
-      [field]: value ? [value] : [],
+      [field]: value && value !== "all" ? [value] : [],
     }));
 
   const handleCancel = () => {
@@ -347,7 +366,6 @@ export const RecruitmentViews = () => {
     setActiveTab,
     applicants,
     pagedApplicants,
-    filteredApplicants,
     selectedIds,
     toggleApplicantSelection,
     clearSelection,
@@ -361,6 +379,8 @@ export const RecruitmentViews = () => {
     currentPage,
     totalPages,
     setPage,
+    applicantPagination,
+    applicantSummary,
     positionsPage,
     setPositionsPage,
     positionsTotalPages,
@@ -441,15 +461,16 @@ export const RecruitmentViews = () => {
     };
   }, [selectedApplicant]);
 
-  const counts = useMemo(() => {
-    return {
-      pending: applicants.filter((a) => a.status === "Pending").length,
-      approved: applicants.filter((a) => a.status === "Approved").length,
-      verifications: verificationApplicants.length,
-    };
-  }, [applicants, verificationApplicants]);
-
-  const total = filteredApplicants.length;
+  const counts = applicantSummary;
+  const total = applicantPagination.total;
+  const applicantStart =
+    total > 0 ? (currentPage - 1) * applicantPagination.limit + 1 : 0;
+  const applicantEnd =
+    total > 0 ? Math.min(applicantStart + applicants.length - 1, total) : 0;
+  const applicantPageItems = useMemo(
+    () => getPaginationItems(currentPage, totalPages),
+    [currentPage, totalPages]
+  );
 
   const allOnPageSelected =
     pagedApplicants.length > 0 &&
@@ -677,9 +698,9 @@ export const RecruitmentViews = () => {
                 }`}
               >
                 Rejected
-                {rejectedApplicants.length > 0 && (
+                {applicantSummary.rejected > 0 && (
                   <span className="ml-1.5 rounded-full bg-red-100 px-1.5 py-0.5 text-[10px] font-semibold text-red-600">
-                    {rejectedApplicants.length}
+                    {applicantSummary.rejected}
                   </span>
                 )}
               </button>
@@ -1343,7 +1364,7 @@ export const RecruitmentViews = () => {
                 <h2 className="text-base font-medium text-slate-700">
                   Rejected Applicants
                 </h2>
-                {rejectedApplicants.length > 0 && canManageRecruitment && (
+                {applicantSummary.rejected > 0 && canManageRecruitment && (
                   <Button
                     type="button"
                     variant="outline"
@@ -1513,11 +1534,12 @@ export const RecruitmentViews = () => {
 
           {/* Pagination (applicants tab only — the positions and
               verification tabs aren't paginated with these controls) */}
-          {activeTab === "applicants" && (
+          {(activeTab === "applicants" ||
+            activeTab === "rejected" ||
+            activeTab === "verification") && (
             <div className="mt-7 flex flex-col items-center justify-between gap-3 text-xs text-[#8a8a8a] sm:flex-row">
               <span>
-                Showing {total > 0 ? (currentPage - 1) * ROWS_PER_PAGE + 1 : 0}{" "}
-                to {Math.min(currentPage * ROWS_PER_PAGE, total)} of {total}
+                Showing {applicantStart} to {applicantEnd} of {total}
               </span>
               <div className="flex items-center gap-1">
                 <button
@@ -1528,20 +1550,27 @@ export const RecruitmentViews = () => {
                 >
                   Previous
                 </button>
-                {Array.from({ length: totalPages }, (_, i) => i + 1).map(
-                  (p) => (
+                {applicantPageItems.map((item, index) =>
+                  item === "ellipsis" ? (
+                    <span
+                      key={`ellipsis-${index}`}
+                      className="px-1 text-[#8a8a8a]"
+                    >
+                      ...
+                    </span>
+                  ) : (
                     <button
                       type="button"
-                      key={p}
-                      onClick={() => setPage(p)}
+                      key={item}
+                      onClick={() => setPage(item)}
                       className={cn(
                         "h-7 min-w-7 cursor-pointer rounded-full px-2",
-                        p === currentPage
+                        item === currentPage
                           ? "bg-[#1c9dde] text-white"
                           : "border border-[#eeeeee] bg-white text-[#696969]"
                       )}
                     >
-                      {p}
+                      {item}
                     </button>
                   )
                 )}
@@ -1762,10 +1791,10 @@ export const RecruitmentViews = () => {
             <p className="text-sm text-slate-500">
               This will permanently delete{" "}
               <span className="font-medium text-slate-700">
-                {rejectedApplicants.length}
+                {applicantSummary.rejected}
               </span>{" "}
               rejected application
-              {rejectedApplicants.length === 1 ? "" : "s"}. This action cannot
+              {applicantSummary.rejected === 1 ? "" : "s"}. This action cannot
               be undone.
             </p>
             <div className="mt-2 flex w-full justify-center gap-3">

--- a/client-side-ts/src/features/admin/recruitment-management/components/RecuitmentViews.tsx
+++ b/client-side-ts/src/features/admin/recruitment-management/components/RecuitmentViews.tsx
@@ -47,6 +47,7 @@ import type {
   OpenRecruitmentValues,
   RecruitmentOpeningConflict,
   RecruitmentOpeningConflictStrategy,
+  ScheduleInterviewValues,
 } from "../types/Recruitment.types";
 import { ApplicantInfoModal } from "./ApplicantInfoModal";
 import { InterviewSchedulingModal } from "./InterviewSchedulingModal";
@@ -96,6 +97,32 @@ function getAvatarColor(name: string) {
 
 function getInitial(name: string) {
   return name.trim().charAt(0).toUpperCase() || "?";
+}
+
+// Convert an ISO timestamp to a local "YYYY-MM-DD" string for the date input.
+function toLocalDateStringForInput(iso?: string) {
+  if (!iso) return "";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+// Convert "HH:mm AM/PM" (12h) → "HH:mm" (24h) for the TimePicker.
+function to24HourTime(time12?: string) {
+  if (!time12) return "";
+  const [time, meridiem] = time12.trim().split(/\s+/);
+  if (!time || !meridiem) return "";
+  const [hourText, minuteText] = time.split(":");
+  let hour = Number(hourText);
+  const minute = Number(minuteText || 0);
+  if (Number.isNaN(hour) || Number.isNaN(minute)) return "";
+  const isPM = meridiem.toUpperCase() === "PM";
+  if (isPM && hour < 12) hour += 12;
+  if (!isPM && hour === 12) hour = 0;
+  return `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
 }
 
 interface RecruitmentFilterPopoverProps {
@@ -354,6 +381,7 @@ export const RecruitmentViews = () => {
     closeApplicantDetails,
     viewResume,
     scheduleInterview,
+    rescheduleInterview,
     downloadResume,
     isResumeLoading,
     resumeError,
@@ -398,6 +426,20 @@ export const RecruitmentViews = () => {
 
   const [isBulkDeletePositionsOpen, setIsBulkDeletePositionsOpen] =
     useState(false);
+
+  // Pre-fill the scheduling modal with the selected applicant's current
+  // interview data (used when rescheduling) so the admin sees the existing
+  // schedule instead of a blank form.
+  const scheduleInitialValues: ScheduleInterviewValues | null = useMemo(() => {
+    if (!selectedApplicant) return null;
+    return {
+      date: toLocalDateStringForInput(selectedApplicant.interviewDate),
+      startTime: to24HourTime(selectedApplicant.interviewStart),
+      endTime: to24HourTime(selectedApplicant.interviewEnd),
+      officer: selectedApplicant.interviewOfficer || "",
+      interviewType: selectedApplicant.interviewType || "",
+    };
+  }, [selectedApplicant]);
 
   const counts = useMemo(() => {
     return {
@@ -1361,6 +1403,9 @@ export const RecruitmentViews = () => {
                           <th className="px-3 py-2 text-left font-medium">
                             Role Applied
                           </th>
+                          <th className="px-3 py-2 text-left font-medium">
+                            Rejected On
+                          </th>
                           <th className="rounded-r-md px-3 py-2 text-right font-medium">
                             Actions
                           </th>
@@ -1389,14 +1434,14 @@ export const RecruitmentViews = () => {
                             </td>
                             <td className="truncate px-3 py-3">
                               {applicant.roleApplied || "—"}
-                            </td>                   
-                              <td className="px-3 py-3">
-                                {applicant.rejectedAt
-                                  ? new Date(
-                                      applicant.rejectedAt
-                                    ).toLocaleDateString()
-                                  : "—"}
-                              </td>                           
+                            </td>
+                            <td className="px-3 py-3">
+                              {applicant.rejectedAt
+                                ? new Date(
+                                    applicant.rejectedAt
+                                  ).toLocaleDateString()
+                                : "—"}
+                            </td>
                             <td className="px-3 py-3 text-right">
                               <Button
                                 type="button"
@@ -1521,6 +1566,7 @@ export const RecruitmentViews = () => {
         error={detailsError}
         onClose={closeApplicantDetails}
         onSetSchedule={() => setIsScheduleOpen(true)}
+        onReschedule={() => setIsScheduleOpen(true)}
         onViewResume={viewResume}
         onDownloadResume={downloadResume}
         isResumeLoading={isResumeLoading}
@@ -1528,12 +1574,25 @@ export const RecruitmentViews = () => {
       />
 
       <InterviewSchedulingModal
+        key={`${selectedApplicant?.id ?? "schedule"}-${isScheduleOpen}`}
         open={isScheduleOpen}
         isSubmitting={isMutating}
+        initialValues={scheduleInitialValues}
         onClose={() => setIsScheduleOpen(false)}
         onConfirm={async (values) => {
           if (!selectedApplicant) return;
-          await scheduleInterview(selectedApplicant.id, values);
+          const hasInterview = Boolean(
+            selectedApplicant.interviewDate ||
+              selectedApplicant.interviewOfficer ||
+              selectedApplicant.interviewType ||
+              selectedApplicant.interviewStart ||
+              selectedApplicant.interviewEnd
+          );
+          if (hasInterview) {
+            await rescheduleInterview(selectedApplicant.id, values);
+          } else {
+            await scheduleInterview(selectedApplicant.id, values);
+          }
           setIsScheduleOpen(false);
         }}
       />

--- a/client-side-ts/src/features/admin/recruitment-management/hooks/useRecruitmentData.ts
+++ b/client-side-ts/src/features/admin/recruitment-management/hooks/useRecruitmentData.ts
@@ -1,1011 +1,1011 @@
-  // src/features/admin/recruitment-management/hooks/useRecruitmentData.ts
+// src/features/admin/recruitment-management/hooks/useRecruitmentData.ts
 
-  import { useCallback, useEffect, useMemo, useState } from "react";
-  import { useAdminPermissions } from "@/features/admin/hooks/useAdminPermissions";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useAdminPermissions } from "@/features/admin/hooks/useAdminPermissions";
 
-  import type {
-    RecruitmentApplicant,
-    RecruitmentFilters,
-    RecruitmentSort,
-    RecruitmentSortField,
-    RecruitmentTab,
-    ScheduleInterviewValues,
-    RecruitmentPosition,
-    OpenRecruitmentValues,
-    RecruitmentOpeningConflictError,
-  } from "../types/Recruitment.types";
+import type {
+  RecruitmentApplicant,
+  RecruitmentFilters,
+  RecruitmentSort,
+  RecruitmentSortField,
+  RecruitmentTab,
+  ScheduleInterviewValues,
+  RecruitmentPosition,
+  OpenRecruitmentValues,
+  RecruitmentOpeningConflictError,
+} from "../types/Recruitment.types";
 
-  import {
-    getApplicants,
-    getApplicationDetails,
-    updateApplicationStatus,
-    createInterview,
-    updateInterview,
-    getResumeUrl,
-    downloadResumeFile,
-    listPositions,
-    createOpening,
-    updatePosition as updatePositionApi,
-    toggleHiringStatus,
-    verifyApplicantAccount,
-    deleteApplication,
-    deletePosition as deletePositionApi,
-  } from "../../../../api/recruitment.api";
+import {
+  getApplicants,
+  getApplicationDetails,
+  updateApplicationStatus,
+  createInterview,
+  updateInterview,
+  getResumeUrl,
+  downloadResumeFile,
+  listPositions,
+  createOpening,
+  updatePosition as updatePositionApi,
+  toggleHiringStatus,
+  verifyApplicantAccount,
+  deleteApplication,
+  deletePosition as deletePositionApi,
+} from "../../../../api/recruitment.api";
 
-  export const ROWS_PER_PAGE = 8;
-  export const POSITIONS_PER_PAGE = 8;
+export const ROWS_PER_PAGE = 10;
+export const POSITIONS_PER_PAGE = 10;
 
-  export const DEFAULT_FILTERS: RecruitmentFilters = {
-    roles: [],
-    courses: [],
-    years: [],
-    status: "all",
+export const DEFAULT_FILTERS: RecruitmentFilters = {
+  roles: [],
+  courses: [],
+  years: [],
+  status: "all",
+};
+
+const DEFAULT_SORT: RecruitmentSort = {
+  field: "name",
+  direction: "asc",
+};
+
+interface RawApplicantRecord {
+  id?: string;
+  _id?: string;
+  id_number?: string;
+  studentId?: string;
+  name?: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  course?: string;
+  year?: string | number;
+  roleApplied?: string;
+  position?: { title?: string };
+  positionTitle?: string;
+  campus?: string;
+  status?: string;
+  resume?: string;
+  resumeUrl?: string;
+  aiSummary?: string;
+  interview?: {
+    scheduledAt?: string;
+    location?: string;
+    notes?: string;
   };
-
-  const DEFAULT_SORT: RecruitmentSort = {
-    field: "name",
-    direction: "asc",
-  };
-
-  interface RawApplicantRecord {
-    id?: string;
-    _id?: string;
-    id_number?: string;
-    studentId?: string;
+  interviewDate?: string;
+  interviewStart?: string;
+  interviewEnd?: string;
+  interviewOfficer?: string;
+  interviewType?: string;
+  applicantSnapshot?: {
     name?: string;
-    firstName?: string;
-    lastName?: string;
+    idNumber?: string;
     email?: string;
     course?: string;
     year?: string | number;
-    roleApplied?: string;
-    position?: { title?: string };
-    positionTitle?: string;
-    campus?: string;
-    status?: string;
-    resume?: string;
-    resumeUrl?: string;
-    aiSummary?: string;
-    interview?: {
-      scheduledAt?: string;
-      location?: string;
-      notes?: string;
-    };
-    interviewDate?: string;
-    interviewStart?: string;
-    interviewEnd?: string;
-    interviewOfficer?: string;
-    interviewType?: string;
-    applicantSnapshot?: {
-      name?: string;
-      idNumber?: string;
-      email?: string;
-      course?: string;
-      year?: string | number;
-    };
-    applicant?: {
-      email?: string;
-      course?: string;
-      year?: string | number;
-    };
-    documents?: {
-      resume?: {
-        storageKey?: string;
-        originalFilename?: string;
-        mimeType?: string;
-        size?: number;
-        uploadTimestamp?: string;
-        url?: string;
-      };
-    };
-    volunteerAccount?: {
-      username?: string;
-      tempPassword?: string;
-      createdAt?: string;
-    };
-    statusHistory?: Array<{
-      status?: string;
-      changedAt?: string;
-      changedBy?: string;
-      note?: string;
-    }>;
-  }
-
-  const STATUS_LABELS: Record<string, RecruitmentApplicant["status"]> = {
-    SUBMITTED: "Pending",
-    INTERVIEW_SCHEDULED: "Scheduled",
-    INTERVIEWING: "Interview Completed",
-    APPROVED: "Approved",
-    REJECTED: "Rejected",
-    WITHDRAWN: "Rejected",
   };
-
-  function formatTime12Hour(time24: string) {
-    const [time, meridiem] = time24.split(" ");
-    if (time && meridiem) return time24;
-
-    const [hourText, minuteText] = time24.split(":");
-    const hour = Number(hourText);
-    const minute = Number(minuteText || 0);
-
-    if (Number.isNaN(hour) || Number.isNaN(minute)) return time24;
-
-    const suffix = hour >= 12 ? "PM" : "AM";
-    const hour12 = hour % 12 === 0 ? 12 : hour % 12;
-    return `${String(hour12).padStart(2, "0")}:${String(minute).padStart(2, "0")} ${suffix}`;
-  }
-
-  function parseInterviewNotes(notes?: string) {
-    const officerMatch = notes?.match(/officer in charge:\s*(.+?)(?:;|$)/i);
-    const typeMatch = notes?.match(/interview type:\s*(.+?)(?:;|$)/i);
-    const startMatch = notes?.match(/starts\s*([^;]+?)(?:;|$)/i);
-    const endMatch = notes?.match(/ends\s*([^;]+?)(?:;|$)/i);
-
-    return {
-      officer: officerMatch?.[1]?.trim() ?? "",
-      type: typeMatch?.[1]?.trim() ?? "",
-      starts: startMatch?.[1]?.trim() ?? "",
-      ends: endMatch?.[1]?.trim() ?? "",
+  applicant?: {
+    email?: string;
+    course?: string;
+    year?: string | number;
+  };
+  documents?: {
+    resume?: {
+      storageKey?: string;
+      originalFilename?: string;
+      mimeType?: string;
+      size?: number;
+      uploadTimestamp?: string;
+      url?: string;
     };
-  }
+  };
+  volunteerAccount?: {
+    username?: string;
+    tempPassword?: string;
+    createdAt?: string;
+  };
+  statusHistory?: Array<{
+    status?: string;
+    changedAt?: string;
+    changedBy?: string;
+    note?: string;
+  }>;
+}
 
-  function mapApplication(raw: RawApplicantRecord): RecruitmentApplicant {
-    const interviewNotes = raw.interview?.notes ?? "";
-    const parsedInterviewNotes = parseInterviewNotes(interviewNotes);
+const STATUS_LABELS: Record<string, RecruitmentApplicant["status"]> = {
+  SUBMITTED: "Pending",
+  INTERVIEW_SCHEDULED: "Scheduled",
+  INTERVIEWING: "Interview Completed",
+  APPROVED: "Approved",
+  REJECTED: "Rejected",
+  WITHDRAWN: "Rejected",
+};
 
-    const rejectedAt = raw.statusHistory?.find(
-      (entry) => entry.status === "REJECTED"
-    )?.changedAt;
+function formatTime12Hour(time24: string) {
+  const [time, meridiem] = time24.split(" ");
+  if (time && meridiem) return time24;
 
-    return {
-      id: raw.id ?? raw._id ?? "",
-      id_number:
-        raw.applicantSnapshot?.idNumber ?? raw.id_number ?? raw.studentId ?? "",
-      name:
-        raw.applicantSnapshot?.name ??
-        raw.name ??
-        `${raw.firstName ?? ""} ${raw.lastName ?? ""}`.trim(),
-      email: raw.applicantSnapshot?.email ?? raw.email ?? "",
-      course: String(
-        raw.applicantSnapshot?.course ?? raw.applicant?.course ?? raw.course ?? ""
-      ),
-      year: String(
-        raw.applicantSnapshot?.year ?? raw.applicant?.year ?? raw.year ?? ""
-      ),
-      roleApplied:
-        raw.roleApplied ?? raw.position?.title ?? raw.positionTitle ?? "",
-      campus: raw.campus ?? "",
-      status:
-        STATUS_LABELS[raw.status as string] ??
-        (raw.status as RecruitmentApplicant["status"]),
-      resume:
-        raw.documents?.resume?.url ??
-        raw.documents?.resume?.storageKey ??
-        raw.resume ??
-        raw.resumeUrl,
-      resumeFilename: raw.documents?.resume?.originalFilename,
-      aiSummary: raw.aiSummary,
-      interviewDate: raw.interview?.scheduledAt ?? raw.interviewDate,
-      interviewStart: parsedInterviewNotes.starts || raw.interviewStart || "",
-      interviewEnd: parsedInterviewNotes.ends || raw.interviewEnd || "",
-      interviewOfficer:
-        parsedInterviewNotes.officer || raw.interviewOfficer || "",
-      interviewType: parsedInterviewNotes.type || raw.interviewType || "",
-      volunteerAccount: raw.volunteerAccount
-        ? {
-            username: raw.volunteerAccount.username ?? "",
-            tempPassword: raw.volunteerAccount.tempPassword ?? "",
-          }
-        : undefined,
-      rejectedAt,
-    };
-  }
+  const [hourText, minuteText] = time24.split(":");
+  const hour = Number(hourText);
+  const minute = Number(minuteText || 0);
 
-  function toInterviewPayload(values: ScheduleInterviewValues) {
-    return {
-      scheduledAt: new Date(
-        `${values.date}T${values.startTime}:00+08:00`
-      ).toISOString(),
-      location: "",
-      notes: `Interview type: ${values.interviewType}; officer in charge: ${values.officer}; starts ${formatTime12Hour(values.startTime)}; ends ${formatTime12Hour(values.endTime)}`,
-    };
-  }
+  if (Number.isNaN(hour) || Number.isNaN(minute)) return time24;
 
-  const STATUS = {
-    submitted: "SUBMITTED",
-    interviewScheduled: "INTERVIEW_SCHEDULED",
-    interviewing: "INTERVIEWING",
-    approved: "APPROVED",
-    rejected: "REJECTED",
-    withdrawn: "WITHDRAWN",
-  } as const;
+  const suffix = hour >= 12 ? "PM" : "AM";
+  const hour12 = hour % 12 === 0 ? 12 : hour % 12;
+  return `${String(hour12).padStart(2, "0")}:${String(minute).padStart(2, "0")} ${suffix}`;
+}
 
-  export const useRecruitmentData = () => {
-    const { canManageRecruitment } = useAdminPermissions();
-    const [activeTab, setActiveTab] = useState<RecruitmentTab>("applicants");
-    const [applicants, setApplicants] = useState<RecruitmentApplicant[]>([]);
-    const [selectedIds, setSelectedIds] = useState<string[]>([]);
-    const [search, setSearch] = useState("");
-    const [filters, setFilters] = useState<RecruitmentFilters>(DEFAULT_FILTERS);
-    const [sort, setSort] = useState<RecruitmentSort>(DEFAULT_SORT);
-    const [page, setPage] = useState(1);
-    const [isLoading, setIsLoading] = useState(true);
-    const [isMutating, setIsMutating] = useState(false);
-    const [error, setError] = useState<string | null>(null);
-    const [positions, setPositions] = useState<RecruitmentPosition[]>([]);
-    const [isPositionsLoading, setIsPositionsLoading] = useState(true);
-    const [positionsError, setPositionsError] = useState<string | null>(null);
-    const [positionsPage, setPositionsPage] = useState(1);
-    const [positionsTotalPages, setPositionsTotalPages] = useState(1);
-    const [positionsTotal, setPositionsTotal] = useState(0);
-    const [openPositionsCount, setOpenPositionsCount] = useState(0);
+function parseInterviewNotes(notes?: string) {
+  const officerMatch = notes?.match(/officer in charge:\s*(.+?)(?:;|$)/i);
+  const typeMatch = notes?.match(/interview type:\s*(.+?)(?:;|$)/i);
+  const startMatch = notes?.match(/starts\s*([^;]+?)(?:;|$)/i);
+  const endMatch = notes?.match(/ends\s*([^;]+?)(?:;|$)/i);
 
-    const [mutationError, setMutationError] = useState<string | null>(null);
+  return {
+    officer: officerMatch?.[1]?.trim() ?? "",
+    type: typeMatch?.[1]?.trim() ?? "",
+    starts: startMatch?.[1]?.trim() ?? "",
+    ends: endMatch?.[1]?.trim() ?? "",
+  };
+}
 
-    const clearMutationError = useCallback(() => setMutationError(null), []);
+function mapApplication(raw: RawApplicantRecord): RecruitmentApplicant {
+  const interviewNotes = raw.interview?.notes ?? "";
+  const parsedInterviewNotes = parseInterviewNotes(interviewNotes);
 
-    // ── Applicant details dialog state ────────────────────────────────────
-    const [selectedApplicant, setSelectedApplicant] =
-      useState<RecruitmentApplicant | null>(null);
+  const rejectedAt = raw.statusHistory?.find(
+    (entry) => entry.status === "REJECTED"
+  )?.changedAt;
 
-    const [isDetailsLoading, setIsDetailsLoading] = useState(false);
-
-    const [detailsError, setDetailsError] = useState<string | null>(null);
-
-    // ── Resume download state ──────────────────────────────────────────────
-    // Signed URLs expire quickly (5 min), so we never cache one — always
-    // fetch a fresh one right when the user tries to view/download.
-    const [isResumeLoading, setIsResumeLoading] = useState(false);
-
-    const [resumeError, setResumeError] = useState<string | null>(null);
-
-    const viewResume = useCallback(async (id: string) => {
-      setIsResumeLoading(true);
-      setResumeError(null);
-      try {
-        const res = await getResumeUrl(id);
-        const url = res.data.data.url;
-        window.open(url, "_blank", "noopener,noreferrer");
-      } catch (err) {
-        setResumeError(
-          err instanceof Error ? err.message : "Failed to load resume"
-        );
-      } finally {
-        setIsResumeLoading(false);
-      }
-    }, []);
-
-    const downloadResume = useCallback(async (id: string) => {
-      setIsResumeLoading(true);
-      setResumeError(null);
-      try {
-        const res = await downloadResumeFile(id);
-        const disposition = res.headers["content-disposition"] as
-          string | undefined;
-        const defaultFileName = "resume.pdf";
-        const match = disposition?.match(/filename\*?=(?:UTF-8'')?([^;]+)/i);
-        const fileName = match
-          ? decodeURIComponent(match[1].replace(/"/g, ""))
-          : defaultFileName;
-
-        const contentTypeHeader = res.headers["content-type"];
-        const blob = new Blob([res.data], {
-          type:
-            typeof contentTypeHeader === "string"
-              ? contentTypeHeader
-              : "application/octet-stream",
-        });
-        const downloadUrl = window.URL.createObjectURL(blob);
-        const anchor = document.createElement("a");
-
-        anchor.href = downloadUrl;
-        anchor.download = fileName || defaultFileName;
-        document.body.appendChild(anchor);
-        anchor.click();
-        anchor.remove();
-        window.URL.revokeObjectURL(downloadUrl);
-      } catch (err) {
-        setResumeError(
-          err instanceof Error ? err.message : "Failed to load resume"
-        );
-      } finally {
-        setIsResumeLoading(false);
-      }
-    }, []);
-
-    const fetchApplicants = useCallback(async () => {
-      setIsLoading(true);
-      setError(null);
-
-      try {
-        const res = await getApplicants({});
-        const list = res.data.data.applicants;
-        setApplicants(list.map(mapApplication));
-      } catch (err) {
-        setError(
-          err instanceof Error ? err.message : "Failed to load applicants"
-        );
-      } finally {
-        setIsLoading(false);
-      }
-    }, []);
-
-    const fetchPositions = useCallback(
-      async (pageNumber = positionsPage) => {
-        setIsPositionsLoading(true);
-        setPositionsError(null);
-        try {
-          const res = await listPositions({
-            page: pageNumber,
-            limit: POSITIONS_PER_PAGE,
-          });
-          const payload = res.data.data;
-          const pagination = payload.pagination;
-
-          setPositions(payload.positions || []);
-          setPositionsTotalPages(Number(pagination?.totalPages || 1));
-          setPositionsTotal(Number(pagination?.total || 0));
-        } catch (err) {
-          setPositionsError(
-            err instanceof Error ? err.message : "Failed to load positions"
-          );
-        } finally {
-          setIsPositionsLoading(false);
+  return {
+    id: raw.id ?? raw._id ?? "",
+    id_number:
+      raw.applicantSnapshot?.idNumber ?? raw.id_number ?? raw.studentId ?? "",
+    name:
+      raw.applicantSnapshot?.name ??
+      raw.name ??
+      `${raw.firstName ?? ""} ${raw.lastName ?? ""}`.trim(),
+    email: raw.applicantSnapshot?.email ?? raw.email ?? "",
+    course: String(
+      raw.applicantSnapshot?.course ?? raw.applicant?.course ?? raw.course ?? ""
+    ),
+    year: String(
+      raw.applicantSnapshot?.year ?? raw.applicant?.year ?? raw.year ?? ""
+    ),
+    roleApplied:
+      raw.roleApplied ?? raw.position?.title ?? raw.positionTitle ?? "",
+    campus: raw.campus ?? "",
+    status:
+      STATUS_LABELS[raw.status as string] ??
+      (raw.status as RecruitmentApplicant["status"]),
+    resume:
+      raw.documents?.resume?.url ??
+      raw.documents?.resume?.storageKey ??
+      raw.resume ??
+      raw.resumeUrl,
+    resumeFilename: raw.documents?.resume?.originalFilename,
+    aiSummary: raw.aiSummary,
+    interviewDate: raw.interview?.scheduledAt ?? raw.interviewDate,
+    interviewStart: parsedInterviewNotes.starts || raw.interviewStart || "",
+    interviewEnd: parsedInterviewNotes.ends || raw.interviewEnd || "",
+    interviewOfficer:
+      parsedInterviewNotes.officer || raw.interviewOfficer || "",
+    interviewType: parsedInterviewNotes.type || raw.interviewType || "",
+    volunteerAccount: raw.volunteerAccount
+      ? {
+          username: raw.volunteerAccount.username ?? "",
+          tempPassword: raw.volunteerAccount.tempPassword ?? "",
         }
-      },
-      [positionsPage]
-    );
+      : undefined,
+    rejectedAt,
+  };
+}
 
-    const fetchOpenPositionsCount = useCallback(async () => {
-      try {
-        const res = await listPositions({ status: "OPEN", limit: 1 });
-        setOpenPositionsCount(Number(res.data.data.pagination?.total || 0));
-      } catch {
-        // Non-critical — the stat card just won't update this cycle.
-      }
-    }, []);
+function toInterviewPayload(values: ScheduleInterviewValues) {
+  return {
+    scheduledAt: new Date(
+      `${values.date}T${values.startTime}:00+08:00`
+    ).toISOString(),
+    location: "",
+    notes: `Interview type: ${values.interviewType}; officer in charge: ${values.officer}; starts ${formatTime12Hour(values.startTime)}; ends ${formatTime12Hour(values.endTime)}`,
+  };
+}
 
-    useEffect(() => {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional fetch-on-mount; fetchPositions is also used for refetch, so its internal setIsPositionsLoading/setPositionsError calls are needed there
-      fetchPositions();
-    }, [fetchPositions]);
+const STATUS = {
+  submitted: "SUBMITTED",
+  interviewScheduled: "INTERVIEW_SCHEDULED",
+  interviewing: "INTERVIEWING",
+  approved: "APPROVED",
+  rejected: "REJECTED",
+  withdrawn: "WITHDRAWN",
+} as const;
 
-    useEffect(() => {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional fetch-on-mount
-      fetchOpenPositionsCount();
-    }, [fetchOpenPositionsCount]);
+export const useRecruitmentData = () => {
+  const { canManageRecruitment } = useAdminPermissions();
+  const [activeTab, setActiveTab] = useState<RecruitmentTab>("applicants");
+  const [applicants, setApplicants] = useState<RecruitmentApplicant[]>([]);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [search, setSearch] = useState("");
+  const [filters, setFilters] = useState<RecruitmentFilters>(DEFAULT_FILTERS);
+  const [sort, setSort] = useState<RecruitmentSort>(DEFAULT_SORT);
+  const [page, setPage] = useState(1);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isMutating, setIsMutating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [positions, setPositions] = useState<RecruitmentPosition[]>([]);
+  const [isPositionsLoading, setIsPositionsLoading] = useState(true);
+  const [positionsError, setPositionsError] = useState<string | null>(null);
+  const [positionsPage, setPositionsPage] = useState(1);
+  const [positionsTotalPages, setPositionsTotalPages] = useState(1);
+  const [positionsTotal, setPositionsTotal] = useState(0);
+  const [openPositionsCount, setOpenPositionsCount] = useState(0);
 
-    useEffect(() => {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional fetch-on-mount; fetchApplicants is also used for refetch, so its internal setIsLoading/setError calls are needed there
-      fetchApplicants();
-    }, [fetchApplicants]);
+  const [mutationError, setMutationError] = useState<string | null>(null);
 
-    useEffect(() => {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional fetch-on-mount; setIsLoading/setError also serve the exposed refetch() path
-      setPage(1);
-    }, [filters, search]);
+  const clearMutationError = useCallback(() => setMutationError(null), []);
 
-    const filteredApplicants = useMemo(() => {
-      const query = search.trim().toLowerCase();
+  // ── Applicant details dialog state ────────────────────────────────────
+  const [selectedApplicant, setSelectedApplicant] =
+    useState<RecruitmentApplicant | null>(null);
 
-      return applicants
-        .filter((applicant) => {
-          if (
-            query &&
-            ![
-              applicant.name,
-              applicant.id_number,
-              applicant.email,
-              applicant.course,
-              applicant.year,
-              applicant.roleApplied,
-              applicant.status,
-            ]
-              .join(" ")
-              .toLowerCase()
-              .includes(query)
-          ) {
-            return false;
-          }
+  const [isDetailsLoading, setIsDetailsLoading] = useState(false);
 
-          if (
-            filters.roles.length > 0 &&
-            !filters.roles.includes(applicant.roleApplied)
-          ) {
-            return false;
-          }
+  const [detailsError, setDetailsError] = useState<string | null>(null);
 
-          if (
-            filters.courses.length > 0 &&
-            !filters.courses.includes(applicant.course)
-          ) {
-            return false;
-          }
+  // ── Resume download state ──────────────────────────────────────────────
+  // Signed URLs expire quickly (5 min), so we never cache one — always
+  // fetch a fresh one right when the user tries to view/download.
+  const [isResumeLoading, setIsResumeLoading] = useState(false);
 
-          if (filters.years.length > 0) {
-            // applicant.year may be "1st Year", "2", etc. — normalize to the
-            // leading digit so the filter values ("1".."4") match.
-            const yearDigit = String(applicant.year).match(/\d+/)?.[0] ?? "";
-            if (!filters.years.includes(yearDigit)) {
-              return false;
-            }
-          }
+  const [resumeError, setResumeError] = useState<string | null>(null);
 
-          if (filters.status !== "all" && applicant.status !== filters.status) {
-            return false;
-          }
-
-          return true;
-        })
-        .sort((left, right) => {
-          let leftValue = "";
-          let rightValue = "";
-
-          switch (sort.field) {
-            case "courseYear":
-              leftValue = `${left.course} ${left.year}`;
-              rightValue = `${right.course} ${right.year}`;
-              break;
-
-            case "roleApplied":
-              leftValue = left.roleApplied;
-              rightValue = right.roleApplied;
-              break;
-
-            default:
-              leftValue = String(
-                left[sort.field as keyof RecruitmentApplicant] ?? ""
-              );
-
-              rightValue = String(
-                right[sort.field as keyof RecruitmentApplicant] ?? ""
-              );
-          }
-
-          const result = leftValue.localeCompare(rightValue, undefined, {
-            numeric: true,
-            sensitivity: "base",
-          });
-
-          return sort.direction === "asc" ? result : -result;
-        });
-    }, [applicants, search, filters, sort]);
-
-    const totalPages = Math.max(
-      1,
-      Math.ceil(filteredApplicants.length / ROWS_PER_PAGE)
-    );
-
-    const currentPage = Math.min(page, totalPages);
-
-    const pagedApplicants = filteredApplicants.slice(
-      (currentPage - 1) * ROWS_PER_PAGE,
-      currentPage * ROWS_PER_PAGE
-    );
-
-    const roleOptions = useMemo(
-      () =>
-        Array.from(
-          new Set(
-            applicants.map((applicant) => applicant.roleApplied).filter(Boolean)
-          )
-        ).sort(),
-      [applicants]
-    );
-
-    const toggleSort = (field: RecruitmentSortField) => {
-      setSort((current) =>
-        current.field === field
-          ? {
-              field,
-              direction: current.direction === "asc" ? "desc" : "asc",
-            }
-          : {
-              field,
-              direction: "asc",
-            }
+  const viewResume = useCallback(async (id: string) => {
+    setIsResumeLoading(true);
+    setResumeError(null);
+    try {
+      const res = await getResumeUrl(id);
+      const url = res.data.data.url;
+      window.open(url, "_blank", "noopener,noreferrer");
+    } catch (err) {
+      setResumeError(
+        err instanceof Error ? err.message : "Failed to load resume"
       );
-    };
+    } finally {
+      setIsResumeLoading(false);
+    }
+  }, []);
 
-    const toggleApplicantSelection = (id: string) => {
-      setSelectedIds((current) =>
-        current.includes(id)
-          ? current.filter((item) => item !== id)
-          : [...current, id]
+  const downloadResume = useCallback(async (id: string) => {
+    setIsResumeLoading(true);
+    setResumeError(null);
+    try {
+      const res = await downloadResumeFile(id);
+      const disposition = res.headers["content-disposition"] as
+        string | undefined;
+      const defaultFileName = "resume.pdf";
+      const match = disposition?.match(/filename\*?=(?:UTF-8'')?([^;]+)/i);
+      const fileName = match
+        ? decodeURIComponent(match[1].replace(/"/g, ""))
+        : defaultFileName;
+
+      const contentTypeHeader = res.headers["content-type"];
+      const blob = new Blob([res.data], {
+        type:
+          typeof contentTypeHeader === "string"
+            ? contentTypeHeader
+            : "application/octet-stream",
+      });
+      const downloadUrl = window.URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+
+      anchor.href = downloadUrl;
+      anchor.download = fileName || defaultFileName;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      window.URL.revokeObjectURL(downloadUrl);
+    } catch (err) {
+      setResumeError(
+        err instanceof Error ? err.message : "Failed to load resume"
       );
-    };
+    } finally {
+      setIsResumeLoading(false);
+    }
+  }, []);
 
-    const clearSelection = () => {
-      setSelectedIds([]);
-    };
+  const fetchApplicants = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
 
-    // ── Applicant details (view modal) ─────────────────────────────────────
-    const viewApplicantDetails = useCallback(async (id: string) => {
-      setIsDetailsLoading(true);
-      setDetailsError(null);
-      setSelectedApplicant(null);
+    try {
+      const res = await getApplicants({});
+      const list = res.data.data.applicants;
+      setApplicants(list.map(mapApplication));
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load applicants"
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
 
+  const fetchPositions = useCallback(
+    async (pageNumber = positionsPage) => {
+      setIsPositionsLoading(true);
+      setPositionsError(null);
       try {
-        const res = await getApplicationDetails(id);
-        setSelectedApplicant(mapApplication(res.data.data));
-      } catch (err) {
-        setDetailsError(
-          err instanceof Error ? err.message : "Failed to load applicant details"
-        );
-      } finally {
-        setIsDetailsLoading(false);
-      }
-    }, []);
-
-    const closeApplicantDetails = useCallback(() => {
-      setSelectedApplicant(null);
-      setDetailsError(null);
-    }, []);
-
-    const rejectApplicant = async (id: string) => {
-      if (!canManageRecruitment) {
-        setMutationError("You don't have permission to reject applicants.");
-        return;
-      }
-      setIsMutating(true);
-      setMutationError(null);
-      try {
-        const res = await updateApplicationStatus(id, {
-          status: STATUS.rejected,
+        const res = await listPositions({
+          page: pageNumber,
+          limit: POSITIONS_PER_PAGE,
         });
-        const updated = mapApplication(res.data.data);
-        setApplicants((current) =>
-          current.map((a) => (a.id === id ? updated : a))
-        );
-        setSelectedApplicant((current) =>
-          current?.id === id ? updated : current
-        );
-        Promise.all([
-          fetchPositions(positionsPage),
-          fetchOpenPositionsCount(),
-        ]).catch(() => {});
+        const payload = res.data.data;
+        const pagination = payload.pagination;
+
+        setPositions(payload.positions || []);
+        setPositionsTotalPages(Number(pagination?.totalPages || 1));
+        setPositionsTotal(Number(pagination?.total || 0));
       } catch (err) {
-        setMutationError(
-          err instanceof Error ? err.message : "Failed to reject applicant"
+        setPositionsError(
+          err instanceof Error ? err.message : "Failed to load positions"
         );
       } finally {
-        setIsMutating(false);
+        setIsPositionsLoading(false);
       }
-    };
+    },
+    [positionsPage]
+  );
 
-    // SUBMITTED → INTERVIEW_SCHEDULED (was "verifyApplicant" — renamed to match reality)
-    const moveToInterviewScheduled = async (id: string) => {
-      setIsMutating(true);
-      setMutationError(null);
-      try {
-        const res = await updateApplicationStatus(id, {
-          status: STATUS.interviewScheduled,
-        });
-        const updated = mapApplication(res.data.data);
-        setApplicants((current) =>
-          current.map((a) => (a.id === id ? updated : a))
-        );
-        setSelectedApplicant((current) =>
-          current?.id === id ? updated : current
-        );
-      } catch (err) {
-        setMutationError(
-          err instanceof Error ? err.message : "Failed to update applicant"
-        );
-      } finally {
-        setIsMutating(false);
-      }
-    };
+  const fetchOpenPositionsCount = useCallback(async () => {
+    try {
+      const res = await listPositions({ status: "OPEN", limit: 1 });
+      setOpenPositionsCount(Number(res.data.data.pagination?.total || 0));
+    } catch {
+      // Non-critical — the stat card just won't update this cycle.
+    }
+  }, []);
 
-    // INTERVIEW_SCHEDULED → INTERVIEWING
-    const moveToInterviewing = async (id: string) => {
-      setIsMutating(true);
-      setMutationError(null);
-      try {
-        const res = await updateApplicationStatus(id, {
-          status: STATUS.interviewing,
-        });
-        const updated = mapApplication(res.data.data);
-        setApplicants((current) =>
-          current.map((a) => (a.id === id ? updated : a))
-        );
-        setSelectedApplicant((current) =>
-          current?.id === id ? updated : current
-        );
-      } catch (err) {
-        setMutationError(
-          err instanceof Error ? err.message : "Failed to update applicant"
-        );
-      } finally {
-        setIsMutating(false);
-      }
-    };
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional fetch-on-mount; fetchPositions is also used for refetch, so its internal setIsPositionsLoading/setPositionsError calls are needed there
+    fetchPositions();
+  }, [fetchPositions]);
 
-    // INTERVIEWING → APPROVED (only valid step for real "Approve")
-    const approveApplicant = async (id: string) => {
-      if (!canManageRecruitment) {
-        setMutationError("You don't have permission to approve applicants.");
-        return;
-      }
-      setIsMutating(true);
-      setMutationError(null);
-      try {
-        const res = await updateApplicationStatus(id, {
-          status: STATUS.approved,
-        });
-        const updated = mapApplication(res.data.data);
-        setApplicants((current) =>
-          current.map((a) => (a.id === id ? updated : a))
-        );
-        setSelectedApplicant((current) =>
-          current?.id === id ? updated : current
-        );
-        Promise.all([
-          fetchPositions(positionsPage),
-          fetchOpenPositionsCount(),
-        ]).catch(() => {});
-      } catch (err) {
-        setMutationError(
-          err instanceof Error ? err.message : "Failed to approve applicant"
-        );
-      } finally {
-        setIsMutating(false);
-      }
-    };
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional fetch-on-mount
+    fetchOpenPositionsCount();
+  }, [fetchOpenPositionsCount]);
 
-    // Create a new interview for an applicant (uses createInterview API)
-    const scheduleInterview = async (
-      id: string,
-      values: ScheduleInterviewValues
-    ) => {
-      setIsMutating(true);
-      setMutationError(null);
-      try {
-        const res = await createInterview(id, toInterviewPayload(values));
-        const updated = mapApplication(res.data.data);
-        setApplicants((current) =>
-          current.map((a) => (a.id === id ? updated : a))
-        );
-        setSelectedApplicant((current) =>
-          current?.id === id ? updated : current
-        );
-      } catch (err) {
-        setMutationError(
-          err instanceof Error ? err.message : "Failed to schedule interview"
-        );
-      } finally {
-        setIsMutating(false);
-      }
-    };
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional fetch-on-mount; fetchApplicants is also used for refetch, so its internal setIsLoading/setError calls are needed there
+    fetchApplicants();
+  }, [fetchApplicants]);
 
-    const openRoleApplication = async (data: OpenRecruitmentValues) => {
-      setIsMutating(true);
-      setMutationError(null);
-      try {
-        await createOpening({
-          ...data,
-          roleRequirements: data.roleRequirements ?? "",
-        });
-        setPositionsPage(1);
-        await fetchPositions(1);
-        await fetchOpenPositionsCount();
-      } catch (err) {
-        const response = (
-          err as {
-            response?: {
-              status?: number;
-              data?: {
-                code?: string;
-                message?: string;
-                data?: {
-                  conflicts?: RecruitmentOpeningConflictError["conflicts"];
-                };
-              };
-            };
-          }
-        ).response;
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional fetch-on-mount; setIsLoading/setError also serve the exposed refetch() path
+    setPage(1);
+  }, [filters, search]);
+
+  const filteredApplicants = useMemo(() => {
+    const query = search.trim().toLowerCase();
+
+    return applicants
+      .filter((applicant) => {
+        if (
+          query &&
+          ![
+            applicant.name,
+            applicant.id_number,
+            applicant.email,
+            applicant.course,
+            applicant.year,
+            applicant.roleApplied,
+            applicant.status,
+          ]
+            .join(" ")
+            .toLowerCase()
+            .includes(query)
+        ) {
+          return false;
+        }
 
         if (
-          response?.status === 409 &&
-          response.data?.code === "RECRUITMENT_POSITION_CONFLICT"
+          filters.roles.length > 0 &&
+          !filters.roles.includes(applicant.roleApplied)
         ) {
-          const conflictError = new Error(
-            response.data.message ||
-              "Some selected role applications already exist."
-          ) as RecruitmentOpeningConflictError;
-          conflictError.code = "RECRUITMENT_POSITION_CONFLICT";
-          conflictError.conflicts = response.data.data?.conflicts ?? [];
-          setMutationError(conflictError.message);
-          throw conflictError;
+          return false;
         }
 
-        setMutationError(
-          err instanceof Error ? err.message : "Failed to open role application"
-        );
-        throw err;
-      } finally {
-        setIsMutating(false);
-      }
-    };
-
-    const updatePosition = async (
-      id: string,
-      data: Partial<
-        Pick<
-          RecruitmentPosition,
-          "title" | "slots" | "applicationDeadline" | "requirements"
-        >
-      >
-    ) => {
-      setIsMutating(true);
-      setMutationError(null);
-      try {
-        const res = await updatePositionApi(id, data);
-        const updated = res.data.data;
-        setPositions((current) =>
-          current.map((p) => (p._id === id ? updated : p))
-        );
-      } catch (err) {
-        setMutationError(
-          err instanceof Error ? err.message : "Failed to update position"
-        );
-        throw err;
-      } finally {
-        setIsMutating(false);
-      }
-    };
-
-    const closePosition = async (id: string) => {
-      setIsMutating(true);
-      setMutationError(null);
-      try {
-        const res = await toggleHiringStatus(id, "CLOSED");
-        const updated = res.data.data;
-        setPositions((current) =>
-          current.map((p) => (p._id === id ? updated : p))
-        );
-        await fetchOpenPositionsCount();
-      } catch (err) {
-        setMutationError(
-          err instanceof Error ? err.message : "Failed to close role"
-        );
-      } finally {
-        setIsMutating(false);
-      }
-    };
-
-    const reopenPosition = async (id: string) => {
-      setIsMutating(true);
-      setMutationError(null);
-      try {
-        const res = await toggleHiringStatus(id, "OPEN");
-        const updated = res.data.data;
-        setPositions((current) =>
-          current.map((p) => (p._id === id ? updated : p))
-        );
-        await fetchOpenPositionsCount();
-      } catch (err) {
-        setMutationError(
-          err instanceof Error ? err.message : "Failed to reopen role"
-        );
-      } finally {
-        setIsMutating(false);
-      }
-    };
-    // Delete a position (only for CLOSED roles — the UI gates this).
-    // The backend hard-deletes if no applications exist, otherwise
-    // soft-disables (isActive = false).
-    const deletePosition = async (id: string) => {
-      setIsMutating(true);
-      setMutationError(null);
-      try {
-        await deletePositionApi(id);
-        const nextPage =
-          positions.length === 1 && positionsPage > 1
-            ? positionsPage - 1
-            : positionsPage;
-
-        if (nextPage !== positionsPage) {
-          setPositionsPage(nextPage);
+        if (
+          filters.courses.length > 0 &&
+          !filters.courses.includes(applicant.course)
+        ) {
+          return false;
         }
 
-        await fetchPositions(nextPage);
-        await fetchOpenPositionsCount();
-      } catch (err) {
-        setMutationError(
-          err instanceof Error ? err.message : "Failed to delete position"
-        );
-      } finally {
-        setIsMutating(false);
-      }
-    };
+        if (filters.years.length > 0) {
+          // applicant.year may be "1st Year", "2", etc. — normalize to the
+          // leading digit so the filter values ("1".."4") match.
+          const yearDigit = String(applicant.year).match(/\d+/)?.[0] ?? "";
+          if (!filters.years.includes(yearDigit)) {
+            return false;
+          }
+        }
 
-    // Update an existing interview for an applicant (uses updateInterview API)
-    const rescheduleInterview = async (
-      id: string,
-      values: ScheduleInterviewValues
-    ) => {
-      setIsMutating(true);
-      setMutationError(null);
-      try {
-        const res = await updateInterview(id, toInterviewPayload(values));
-        const updated = mapApplication(res.data.data);
-        setApplicants((current) =>
-          current.map((a) => (a.id === id ? updated : a))
-        );
-        setSelectedApplicant((current) =>
-          current?.id === id ? updated : current
-        );
-      } catch (err) {
-        setMutationError(
-          err instanceof Error ? err.message : "Failed to reschedule interview"
-        );
-      } finally {
-        setIsMutating(false);
-      }
-    };
+        if (filters.status !== "all" && applicant.status !== filters.status) {
+          return false;
+        }
 
-    // ── Verification (approve → auto-create volunteer account) ────────────
-    // "For Verification" applicants are Approved applicants who don't have a
-    // volunteerAccount yet. verifyApplicantAccount calls the backend endpoint
-    // that creates the account and returns { username, tempPassword }.
-    const [verifiedAccount, setVerifiedAccount] = useState<{
-      name: string;
-      role: string;
-      username: string;
-      tempPassword: string;
-    } | null>(null);
+        return true;
+      })
+      .sort((left, right) => {
+        let leftValue = "";
+        let rightValue = "";
 
-    const verificationApplicants = useMemo(
-      () =>
-        applicants.filter((a) => a.status === "Approved" && !a.volunteerAccount),
-      [applicants]
+        switch (sort.field) {
+          case "courseYear":
+            leftValue = `${left.course} ${left.year}`;
+            rightValue = `${right.course} ${right.year}`;
+            break;
+
+          case "roleApplied":
+            leftValue = left.roleApplied;
+            rightValue = right.roleApplied;
+            break;
+
+          default:
+            leftValue = String(
+              left[sort.field as keyof RecruitmentApplicant] ?? ""
+            );
+
+            rightValue = String(
+              right[sort.field as keyof RecruitmentApplicant] ?? ""
+            );
+        }
+
+        const result = leftValue.localeCompare(rightValue, undefined, {
+          numeric: true,
+          sensitivity: "base",
+        });
+
+        return sort.direction === "asc" ? result : -result;
+      });
+  }, [applicants, search, filters, sort]);
+
+  const totalPages = Math.max(
+    1,
+    Math.ceil(filteredApplicants.length / ROWS_PER_PAGE)
+  );
+
+  const currentPage = Math.min(page, totalPages);
+
+  const pagedApplicants = filteredApplicants.slice(
+    (currentPage - 1) * ROWS_PER_PAGE,
+    currentPage * ROWS_PER_PAGE
+  );
+
+  const roleOptions = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          applicants.map((applicant) => applicant.roleApplied).filter(Boolean)
+        )
+      ).sort(),
+    [applicants]
+  );
+
+  const toggleSort = (field: RecruitmentSortField) => {
+    setSort((current) =>
+      current.field === field
+        ? {
+            field,
+            direction: current.direction === "asc" ? "desc" : "asc",
+          }
+        : {
+            field,
+            direction: "asc",
+          }
     );
-
-    const verifyApplicant = useCallback(
-      async (id: string) => {
-        if (!canManageRecruitment) {
-          setMutationError("You don't have permission to verify applicants.");
-          return;
-        }
-        setIsMutating(true);
-        setMutationError(null);
-        try {
-          const applicant = applicants.find((a) => a.id === id);
-          if (!applicant) throw new Error("Applicant not found");
-
-          const res = await verifyApplicantAccount(id);
-          const account = res.data.data; // { username, tempPassword } from backend
-
-          setApplicants((current) =>
-            current.map((a) =>
-              a.id === id ? { ...a, volunteerAccount: account } : a
-            )
-          );
-          setVerifiedAccount({
-            name: applicant.name,
-            role: applicant.roleApplied,
-            username: account.username,
-            tempPassword: account.tempPassword,
-          });
-        } catch (err) {
-          setMutationError(
-            err instanceof Error ? err.message : "Failed to verify applicant"
-          );
-        } finally {
-          setIsMutating(false);
-        }
-      },
-      [applicants, canManageRecruitment]
-    );
-
-    // ── Rejected applicants (delete) ───────────────────────────────────────
-    const rejectedApplicants = useMemo(
-      () => applicants.filter((a) => a.status === "Rejected"),
-      [applicants]
-    );
-
-    const deleteRejectedApplicant = async (id: string) => {
-      setIsMutating(true);
-      setMutationError(null);
-      try {
-        await deleteApplication(id);
-        setApplicants((current) => current.filter((a) => a.id !== id));
-        setSelectedApplicant((current) => (current?.id === id ? null : current));
-      } catch (err) {
-        setMutationError(
-          err instanceof Error ? err.message : "Failed to delete applicant"
-        );
-      } finally {
-        setIsMutating(false);
-      }
-    };
-
-    const clearAllRejectedApplicants = async () => {
-      setIsMutating(true);
-      setMutationError(null);
-      try {
-        const ids = rejectedApplicants.map((a) => a.id);
-        await Promise.all(ids.map((id) => deleteApplication(id)));
-        setApplicants((current) =>
-          current.filter((a) => a.status !== "Rejected")
-        );
-      } catch (err) {
-        setMutationError(
-          err instanceof Error
-            ? err.message
-            : "Failed to clear rejected applicants"
-        );
-        // Refetch to reconcile partial failures
-        await fetchApplicants();
-      } finally {
-        setIsMutating(false);
-      }
-    };
-
-    const clearVerifiedAccount = useCallback(() => setVerifiedAccount(null), []);
-
-    return {
-      activeTab,
-      setActiveTab,
-      applicants,
-      filteredApplicants,
-      pagedApplicants,
-      selectedIds,
-      search,
-      setSearch,
-      filters,
-      setFilters,
-      sort,
-      setSort,
-      page,
-      setPage,
-      totalPages,
-      currentPage,
-      positionsPage,
-      setPositionsPage,
-      positionsTotalPages,
-      positionsTotal,
-      openPositionsCount,
-      isLoading,
-      isMutating,
-      error,
-      mutationError,
-      clearMutationError,
-      roleOptions,
-      toggleSort,
-      toggleApplicantSelection,
-      clearSelection,
-      approveApplicant,
-      rejectApplicant,
-      moveToInterviewScheduled,
-      moveToInterviewing,
-      scheduleInterview,
-      rescheduleInterview,
-      refetch: fetchApplicants,
-      selectedApplicant,
-      isDetailsLoading,
-      detailsError,
-      viewApplicantDetails,
-      closeApplicantDetails,
-      viewResume,
-      downloadResume,
-      isResumeLoading,
-      resumeError,
-      positions,
-      isPositionsLoading,
-      positionsError,
-      openRoleApplication,
-      updatePosition,
-      closePosition,
-      reopenPosition,
-      deletePosition,
-      verificationApplicants,
-      verifyApplicant,
-      verifiedAccount,
-      clearVerifiedAccount,
-      rejectedApplicants,
-      deleteRejectedApplicant,
-      clearAllRejectedApplicants,
-    };
   };
+
+  const toggleApplicantSelection = (id: string) => {
+    setSelectedIds((current) =>
+      current.includes(id)
+        ? current.filter((item) => item !== id)
+        : [...current, id]
+    );
+  };
+
+  const clearSelection = () => {
+    setSelectedIds([]);
+  };
+
+  // ── Applicant details (view modal) ─────────────────────────────────────
+  const viewApplicantDetails = useCallback(async (id: string) => {
+    setIsDetailsLoading(true);
+    setDetailsError(null);
+    setSelectedApplicant(null);
+
+    try {
+      const res = await getApplicationDetails(id);
+      setSelectedApplicant(mapApplication(res.data.data));
+    } catch (err) {
+      setDetailsError(
+        err instanceof Error ? err.message : "Failed to load applicant details"
+      );
+    } finally {
+      setIsDetailsLoading(false);
+    }
+  }, []);
+
+  const closeApplicantDetails = useCallback(() => {
+    setSelectedApplicant(null);
+    setDetailsError(null);
+  }, []);
+
+  const rejectApplicant = async (id: string) => {
+    if (!canManageRecruitment) {
+      setMutationError("You don't have permission to reject applicants.");
+      return;
+    }
+    setIsMutating(true);
+    setMutationError(null);
+    try {
+      const res = await updateApplicationStatus(id, {
+        status: STATUS.rejected,
+      });
+      const updated = mapApplication(res.data.data);
+      setApplicants((current) =>
+        current.map((a) => (a.id === id ? updated : a))
+      );
+      setSelectedApplicant((current) =>
+        current?.id === id ? updated : current
+      );
+      Promise.all([
+        fetchPositions(positionsPage),
+        fetchOpenPositionsCount(),
+      ]).catch(() => {});
+    } catch (err) {
+      setMutationError(
+        err instanceof Error ? err.message : "Failed to reject applicant"
+      );
+    } finally {
+      setIsMutating(false);
+    }
+  };
+
+  // SUBMITTED → INTERVIEW_SCHEDULED (was "verifyApplicant" — renamed to match reality)
+  const moveToInterviewScheduled = async (id: string) => {
+    setIsMutating(true);
+    setMutationError(null);
+    try {
+      const res = await updateApplicationStatus(id, {
+        status: STATUS.interviewScheduled,
+      });
+      const updated = mapApplication(res.data.data);
+      setApplicants((current) =>
+        current.map((a) => (a.id === id ? updated : a))
+      );
+      setSelectedApplicant((current) =>
+        current?.id === id ? updated : current
+      );
+    } catch (err) {
+      setMutationError(
+        err instanceof Error ? err.message : "Failed to update applicant"
+      );
+    } finally {
+      setIsMutating(false);
+    }
+  };
+
+  // INTERVIEW_SCHEDULED → INTERVIEWING
+  const moveToInterviewing = async (id: string) => {
+    setIsMutating(true);
+    setMutationError(null);
+    try {
+      const res = await updateApplicationStatus(id, {
+        status: STATUS.interviewing,
+      });
+      const updated = mapApplication(res.data.data);
+      setApplicants((current) =>
+        current.map((a) => (a.id === id ? updated : a))
+      );
+      setSelectedApplicant((current) =>
+        current?.id === id ? updated : current
+      );
+    } catch (err) {
+      setMutationError(
+        err instanceof Error ? err.message : "Failed to update applicant"
+      );
+    } finally {
+      setIsMutating(false);
+    }
+  };
+
+  // INTERVIEWING → APPROVED (only valid step for real "Approve")
+  const approveApplicant = async (id: string) => {
+    if (!canManageRecruitment) {
+      setMutationError("You don't have permission to approve applicants.");
+      return;
+    }
+    setIsMutating(true);
+    setMutationError(null);
+    try {
+      const res = await updateApplicationStatus(id, {
+        status: STATUS.approved,
+      });
+      const updated = mapApplication(res.data.data);
+      setApplicants((current) =>
+        current.map((a) => (a.id === id ? updated : a))
+      );
+      setSelectedApplicant((current) =>
+        current?.id === id ? updated : current
+      );
+      Promise.all([
+        fetchPositions(positionsPage),
+        fetchOpenPositionsCount(),
+      ]).catch(() => {});
+    } catch (err) {
+      setMutationError(
+        err instanceof Error ? err.message : "Failed to approve applicant"
+      );
+    } finally {
+      setIsMutating(false);
+    }
+  };
+
+  // Create a new interview for an applicant (uses createInterview API)
+  const scheduleInterview = async (
+    id: string,
+    values: ScheduleInterviewValues
+  ) => {
+    setIsMutating(true);
+    setMutationError(null);
+    try {
+      const res = await createInterview(id, toInterviewPayload(values));
+      const updated = mapApplication(res.data.data);
+      setApplicants((current) =>
+        current.map((a) => (a.id === id ? updated : a))
+      );
+      setSelectedApplicant((current) =>
+        current?.id === id ? updated : current
+      );
+    } catch (err) {
+      setMutationError(
+        err instanceof Error ? err.message : "Failed to schedule interview"
+      );
+    } finally {
+      setIsMutating(false);
+    }
+  };
+
+  const openRoleApplication = async (data: OpenRecruitmentValues) => {
+    setIsMutating(true);
+    setMutationError(null);
+    try {
+      await createOpening({
+        ...data,
+        roleRequirements: data.roleRequirements ?? "",
+      });
+      setPositionsPage(1);
+      await fetchPositions(1);
+      await fetchOpenPositionsCount();
+    } catch (err) {
+      const response = (
+        err as {
+          response?: {
+            status?: number;
+            data?: {
+              code?: string;
+              message?: string;
+              data?: {
+                conflicts?: RecruitmentOpeningConflictError["conflicts"];
+              };
+            };
+          };
+        }
+      ).response;
+
+      if (
+        response?.status === 409 &&
+        response.data?.code === "RECRUITMENT_POSITION_CONFLICT"
+      ) {
+        const conflictError = new Error(
+          response.data.message ||
+            "Some selected role applications already exist."
+        ) as RecruitmentOpeningConflictError;
+        conflictError.code = "RECRUITMENT_POSITION_CONFLICT";
+        conflictError.conflicts = response.data.data?.conflicts ?? [];
+        setMutationError(conflictError.message);
+        throw conflictError;
+      }
+
+      setMutationError(
+        err instanceof Error ? err.message : "Failed to open role application"
+      );
+      throw err;
+    } finally {
+      setIsMutating(false);
+    }
+  };
+
+  const updatePosition = async (
+    id: string,
+    data: Partial<
+      Pick<
+        RecruitmentPosition,
+        "title" | "slots" | "applicationDeadline" | "requirements"
+      >
+    >
+  ) => {
+    setIsMutating(true);
+    setMutationError(null);
+    try {
+      const res = await updatePositionApi(id, data);
+      const updated = res.data.data;
+      setPositions((current) =>
+        current.map((p) => (p._id === id ? updated : p))
+      );
+    } catch (err) {
+      setMutationError(
+        err instanceof Error ? err.message : "Failed to update position"
+      );
+      throw err;
+    } finally {
+      setIsMutating(false);
+    }
+  };
+
+  const closePosition = async (id: string) => {
+    setIsMutating(true);
+    setMutationError(null);
+    try {
+      const res = await toggleHiringStatus(id, "CLOSED");
+      const updated = res.data.data;
+      setPositions((current) =>
+        current.map((p) => (p._id === id ? updated : p))
+      );
+      await fetchOpenPositionsCount();
+    } catch (err) {
+      setMutationError(
+        err instanceof Error ? err.message : "Failed to close role"
+      );
+    } finally {
+      setIsMutating(false);
+    }
+  };
+
+  const reopenPosition = async (id: string) => {
+    setIsMutating(true);
+    setMutationError(null);
+    try {
+      const res = await toggleHiringStatus(id, "OPEN");
+      const updated = res.data.data;
+      setPositions((current) =>
+        current.map((p) => (p._id === id ? updated : p))
+      );
+      await fetchOpenPositionsCount();
+    } catch (err) {
+      setMutationError(
+        err instanceof Error ? err.message : "Failed to reopen role"
+      );
+    } finally {
+      setIsMutating(false);
+    }
+  };
+  // Delete a position (only for CLOSED roles — the UI gates this).
+  // The backend hard-deletes if no applications exist, otherwise
+  // soft-disables (isActive = false).
+  const deletePosition = async (id: string) => {
+    setIsMutating(true);
+    setMutationError(null);
+    try {
+      await deletePositionApi(id);
+      const nextPage =
+        positions.length === 1 && positionsPage > 1
+          ? positionsPage - 1
+          : positionsPage;
+
+      if (nextPage !== positionsPage) {
+        setPositionsPage(nextPage);
+      }
+
+      await fetchPositions(nextPage);
+      await fetchOpenPositionsCount();
+    } catch (err) {
+      setMutationError(
+        err instanceof Error ? err.message : "Failed to delete position"
+      );
+    } finally {
+      setIsMutating(false);
+    }
+  };
+
+  // Update an existing interview for an applicant (uses updateInterview API)
+  const rescheduleInterview = async (
+    id: string,
+    values: ScheduleInterviewValues
+  ) => {
+    setIsMutating(true);
+    setMutationError(null);
+    try {
+      const res = await updateInterview(id, toInterviewPayload(values));
+      const updated = mapApplication(res.data.data);
+      setApplicants((current) =>
+        current.map((a) => (a.id === id ? updated : a))
+      );
+      setSelectedApplicant((current) =>
+        current?.id === id ? updated : current
+      );
+    } catch (err) {
+      setMutationError(
+        err instanceof Error ? err.message : "Failed to reschedule interview"
+      );
+    } finally {
+      setIsMutating(false);
+    }
+  };
+
+  // ── Verification (approve → auto-create volunteer account) ────────────
+  // "For Verification" applicants are Approved applicants who don't have a
+  // volunteerAccount yet. verifyApplicantAccount calls the backend endpoint
+  // that creates the account and returns { username, tempPassword }.
+  const [verifiedAccount, setVerifiedAccount] = useState<{
+    name: string;
+    role: string;
+    username: string;
+    tempPassword: string;
+  } | null>(null);
+
+  const verificationApplicants = useMemo(
+    () =>
+      applicants.filter((a) => a.status === "Approved" && !a.volunteerAccount),
+    [applicants]
+  );
+
+  const verifyApplicant = useCallback(
+    async (id: string) => {
+      if (!canManageRecruitment) {
+        setMutationError("You don't have permission to verify applicants.");
+        return;
+      }
+      setIsMutating(true);
+      setMutationError(null);
+      try {
+        const applicant = applicants.find((a) => a.id === id);
+        if (!applicant) throw new Error("Applicant not found");
+
+        const res = await verifyApplicantAccount(id);
+        const account = res.data.data; // { username, tempPassword } from backend
+
+        setApplicants((current) =>
+          current.map((a) =>
+            a.id === id ? { ...a, volunteerAccount: account } : a
+          )
+        );
+        setVerifiedAccount({
+          name: applicant.name,
+          role: applicant.roleApplied,
+          username: account.username,
+          tempPassword: account.tempPassword,
+        });
+      } catch (err) {
+        setMutationError(
+          err instanceof Error ? err.message : "Failed to verify applicant"
+        );
+      } finally {
+        setIsMutating(false);
+      }
+    },
+    [applicants, canManageRecruitment]
+  );
+
+  // ── Rejected applicants (delete) ───────────────────────────────────────
+  const rejectedApplicants = useMemo(
+    () => applicants.filter((a) => a.status === "Rejected"),
+    [applicants]
+  );
+
+  const deleteRejectedApplicant = async (id: string) => {
+    setIsMutating(true);
+    setMutationError(null);
+    try {
+      await deleteApplication(id);
+      setApplicants((current) => current.filter((a) => a.id !== id));
+      setSelectedApplicant((current) => (current?.id === id ? null : current));
+    } catch (err) {
+      setMutationError(
+        err instanceof Error ? err.message : "Failed to delete applicant"
+      );
+    } finally {
+      setIsMutating(false);
+    }
+  };
+
+  const clearAllRejectedApplicants = async () => {
+    setIsMutating(true);
+    setMutationError(null);
+    try {
+      const ids = rejectedApplicants.map((a) => a.id);
+      await Promise.all(ids.map((id) => deleteApplication(id)));
+      setApplicants((current) =>
+        current.filter((a) => a.status !== "Rejected")
+      );
+    } catch (err) {
+      setMutationError(
+        err instanceof Error
+          ? err.message
+          : "Failed to clear rejected applicants"
+      );
+      // Refetch to reconcile partial failures
+      await fetchApplicants();
+    } finally {
+      setIsMutating(false);
+    }
+  };
+
+  const clearVerifiedAccount = useCallback(() => setVerifiedAccount(null), []);
+
+  return {
+    activeTab,
+    setActiveTab,
+    applicants,
+    filteredApplicants,
+    pagedApplicants,
+    selectedIds,
+    search,
+    setSearch,
+    filters,
+    setFilters,
+    sort,
+    setSort,
+    page,
+    setPage,
+    totalPages,
+    currentPage,
+    positionsPage,
+    setPositionsPage,
+    positionsTotalPages,
+    positionsTotal,
+    openPositionsCount,
+    isLoading,
+    isMutating,
+    error,
+    mutationError,
+    clearMutationError,
+    roleOptions,
+    toggleSort,
+    toggleApplicantSelection,
+    clearSelection,
+    approveApplicant,
+    rejectApplicant,
+    moveToInterviewScheduled,
+    moveToInterviewing,
+    scheduleInterview,
+    rescheduleInterview,
+    refetch: fetchApplicants,
+    selectedApplicant,
+    isDetailsLoading,
+    detailsError,
+    viewApplicantDetails,
+    closeApplicantDetails,
+    viewResume,
+    downloadResume,
+    isResumeLoading,
+    resumeError,
+    positions,
+    isPositionsLoading,
+    positionsError,
+    openRoleApplication,
+    updatePosition,
+    closePosition,
+    reopenPosition,
+    deletePosition,
+    verificationApplicants,
+    verifyApplicant,
+    verifiedAccount,
+    clearVerifiedAccount,
+    rejectedApplicants,
+    deleteRejectedApplicant,
+    clearAllRejectedApplicants,
+  };
+};

--- a/client-side-ts/src/features/admin/recruitment-management/hooks/useRecruitmentData.ts
+++ b/client-side-ts/src/features/admin/recruitment-management/hooks/useRecruitmentData.ts
@@ -133,8 +133,8 @@ function formatTime12Hour(time24: string) {
 function parseInterviewNotes(notes?: string) {
   const officerMatch = notes?.match(/officer in charge:\s*(.+?)(?:;|$)/i);
   const typeMatch = notes?.match(/interview type:\s*(.+?)(?:;|$)/i);
-  const startMatch = notes?.match(/starts\s*([^;]+)$/i);
-  const endMatch = notes?.match(/ends\s*([^;]+)$/i);
+  const startMatch = notes?.match(/starts\s*([^;]+?)(?:;|$)/i);
+  const endMatch = notes?.match(/ends\s*([^;]+?)(?:;|$)/i);
 
   return {
     officer: officerMatch?.[1]?.trim() ?? "",
@@ -177,8 +177,8 @@ function mapApplication(raw: RawApplicantRecord): RecruitmentApplicant {
     resumeFilename: raw.documents?.resume?.originalFilename,
     aiSummary: raw.aiSummary,
     interviewDate: raw.interview?.scheduledAt ?? raw.interviewDate,
-    interviewStart: raw.interviewStart,
-    interviewEnd: raw.interviewEnd,
+    interviewStart: parsedInterviewNotes.starts || raw.interviewStart || "",
+    interviewEnd: parsedInterviewNotes.ends || raw.interviewEnd || "",
     interviewOfficer:
       parsedInterviewNotes.officer || raw.interviewOfficer || "",
     interviewType: parsedInterviewNotes.type || raw.interviewType || "",
@@ -191,15 +191,11 @@ function mapApplication(raw: RawApplicantRecord): RecruitmentApplicant {
   };
 }
 
-// createInterview/updateInterview on the backend expect {scheduledAt,
-// location, notes} (see InterviewPayload in recruitment.api.ts), not the
-// {date, startTime, endTime, officer, interviewType} shape the scheduling
-// dialog collects. Keep `location` empty and carry the officer/type/end time
-// in `notes` so the UI can render a proper interview summary without
-// mislabeling the officer as the interview venue.
 function toInterviewPayload(values: ScheduleInterviewValues) {
   return {
-    scheduledAt: new Date(`${values.date}T${values.startTime}`).toISOString(),
+    scheduledAt: new Date(
+      `${values.date}T${values.startTime}:00+08:00`
+    ).toISOString(),
     location: "",
     notes: `Interview type: ${values.interviewType}; officer in charge: ${values.officer}; starts ${formatTime12Hour(values.startTime)}; ends ${formatTime12Hour(values.endTime)}`,
   };

--- a/client-side-ts/src/features/admin/recruitment-management/hooks/useRecruitmentData.ts
+++ b/client-side-ts/src/features/admin/recruitment-management/hooks/useRecruitmentData.ts
@@ -1,6 +1,6 @@
 // src/features/admin/recruitment-management/hooks/useRecruitmentData.ts
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAdminPermissions } from "@/features/admin/hooks/useAdminPermissions";
 
 import type {
@@ -29,6 +29,7 @@ import {
   toggleHiringStatus,
   verifyApplicantAccount,
   deleteApplication,
+  clearRejectedApplications,
   deletePosition as deletePositionApi,
 } from "../../../../api/recruitment.api";
 
@@ -45,6 +46,27 @@ export const DEFAULT_FILTERS: RecruitmentFilters = {
 const DEFAULT_SORT: RecruitmentSort = {
   field: "name",
   direction: "asc",
+};
+
+type ApplicantPagination = {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+};
+
+type ApplicantSummary = {
+  pending: number;
+  approved: number;
+  rejected: number;
+  verifications: number;
+};
+
+const EMPTY_APPLICANT_SUMMARY: ApplicantSummary = {
+  pending: 0,
+  approved: 0,
+  rejected: 0,
+  verifications: 0,
 };
 
 interface RawApplicantRecord {
@@ -222,13 +244,26 @@ const STATUS = {
 
 export const useRecruitmentData = () => {
   const { canManageRecruitment } = useAdminPermissions();
-  const [activeTab, setActiveTab] = useState<RecruitmentTab>("applicants");
+  const [activeTab, setActiveTabState] =
+    useState<RecruitmentTab>("applicants");
   const [applicants, setApplicants] = useState<RecruitmentApplicant[]>([]);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
   const [filters, setFilters] = useState<RecruitmentFilters>(DEFAULT_FILTERS);
   const [sort, setSort] = useState<RecruitmentSort>(DEFAULT_SORT);
   const [page, setPage] = useState(1);
+  const [applicantPagination, setApplicantPagination] =
+    useState<ApplicantPagination>({
+      page: 1,
+      limit: ROWS_PER_PAGE,
+      total: 0,
+      totalPages: 1,
+    });
+  const [applicantSummary, setApplicantSummary] =
+    useState<ApplicantSummary>(EMPTY_APPLICANT_SUMMARY);
+  const [roleOptions, setRoleOptions] = useState<string[]>([]);
+  const applicantRequestId = useRef(0);
   const [isLoading, setIsLoading] = useState(true);
   const [isMutating, setIsMutating] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -243,6 +278,12 @@ export const useRecruitmentData = () => {
   const [mutationError, setMutationError] = useState<string | null>(null);
 
   const clearMutationError = useCallback(() => setMutationError(null), []);
+
+  const setActiveTab = useCallback((tab: RecruitmentTab) => {
+    setActiveTabState(tab);
+    setPage(1);
+    setSelectedIds([]);
+  }, []);
 
   // ── Applicant details dialog state ────────────────────────────────────
   const [selectedApplicant, setSelectedApplicant] =
@@ -314,21 +355,57 @@ export const useRecruitmentData = () => {
   }, []);
 
   const fetchApplicants = useCallback(async () => {
+    const requestId = ++applicantRequestId.current;
     setIsLoading(true);
     setError(null);
 
     try {
-      const res = await getApplicants({});
-      const list = res.data.data.applicants;
-      setApplicants(list.map(mapApplication));
+      const tabStatus =
+        activeTab === "rejected"
+          ? "Rejected"
+          : activeTab === "verification"
+            ? undefined
+            : filters.status === "all"
+              ? undefined
+              : filters.status;
+      const res = await getApplicants({
+        page,
+        limit: ROWS_PER_PAGE,
+        search: debouncedSearch || undefined,
+        status: tabStatus,
+        role: filters.roles[0],
+        course: filters.courses[0],
+        year: filters.years[0],
+        sortField: sort.field,
+        sortDirection: sort.direction,
+        verificationOnly: activeTab === "verification" || undefined,
+      });
+
+      if (requestId !== applicantRequestId.current) return;
+
+      const payload = res.data.data;
+      const pagination = payload.pagination ?? {};
+      setApplicants((payload.applicants ?? []).map(mapApplication));
+      setApplicantPagination({
+        page: Number(pagination.page ?? page),
+        limit: Number(pagination.limit ?? ROWS_PER_PAGE),
+        total: Number(pagination.total ?? 0),
+        totalPages: Math.max(1, Number(pagination.totalPages ?? 1)),
+      });
+      setApplicantSummary({
+        ...EMPTY_APPLICANT_SUMMARY,
+        ...(payload.summary ?? {}),
+      });
+      setRoleOptions(payload.filterOptions?.roles ?? []);
     } catch (err) {
+      if (requestId !== applicantRequestId.current) return;
       setError(
         err instanceof Error ? err.message : "Failed to load applicants"
       );
     } finally {
-      setIsLoading(false);
+      if (requestId === applicantRequestId.current) setIsLoading(false);
     }
-  }, []);
+  }, [activeTab, debouncedSearch, filters, page, sort]);
 
   const fetchPositions = useCallback(
     async (pageNumber = positionsPage) => {
@@ -376,122 +453,24 @@ export const useRecruitmentData = () => {
   }, [fetchOpenPositionsCount]);
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional fetch-on-mount; fetchApplicants is also used for refetch, so its internal setIsLoading/setError calls are needed there
+    const timeoutId = window.setTimeout(() => {
+      setDebouncedSearch(search.trim());
+    }, 300);
+    return () => window.clearTimeout(timeoutId);
+  }, [search]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [filters, debouncedSearch, sort]);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- fetches only the current server page.
     fetchApplicants();
   }, [fetchApplicants]);
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional fetch-on-mount; setIsLoading/setError also serve the exposed refetch() path
-    setPage(1);
-  }, [filters, search]);
-
-  const filteredApplicants = useMemo(() => {
-    const query = search.trim().toLowerCase();
-
-    return applicants
-      .filter((applicant) => {
-        if (
-          query &&
-          ![
-            applicant.name,
-            applicant.id_number,
-            applicant.email,
-            applicant.course,
-            applicant.year,
-            applicant.roleApplied,
-            applicant.status,
-          ]
-            .join(" ")
-            .toLowerCase()
-            .includes(query)
-        ) {
-          return false;
-        }
-
-        if (
-          filters.roles.length > 0 &&
-          !filters.roles.includes(applicant.roleApplied)
-        ) {
-          return false;
-        }
-
-        if (
-          filters.courses.length > 0 &&
-          !filters.courses.includes(applicant.course)
-        ) {
-          return false;
-        }
-
-        if (filters.years.length > 0) {
-          // applicant.year may be "1st Year", "2", etc. — normalize to the
-          // leading digit so the filter values ("1".."4") match.
-          const yearDigit = String(applicant.year).match(/\d+/)?.[0] ?? "";
-          if (!filters.years.includes(yearDigit)) {
-            return false;
-          }
-        }
-
-        if (filters.status !== "all" && applicant.status !== filters.status) {
-          return false;
-        }
-
-        return true;
-      })
-      .sort((left, right) => {
-        let leftValue = "";
-        let rightValue = "";
-
-        switch (sort.field) {
-          case "courseYear":
-            leftValue = `${left.course} ${left.year}`;
-            rightValue = `${right.course} ${right.year}`;
-            break;
-
-          case "roleApplied":
-            leftValue = left.roleApplied;
-            rightValue = right.roleApplied;
-            break;
-
-          default:
-            leftValue = String(
-              left[sort.field as keyof RecruitmentApplicant] ?? ""
-            );
-
-            rightValue = String(
-              right[sort.field as keyof RecruitmentApplicant] ?? ""
-            );
-        }
-
-        const result = leftValue.localeCompare(rightValue, undefined, {
-          numeric: true,
-          sensitivity: "base",
-        });
-
-        return sort.direction === "asc" ? result : -result;
-      });
-  }, [applicants, search, filters, sort]);
-
-  const totalPages = Math.max(
-    1,
-    Math.ceil(filteredApplicants.length / ROWS_PER_PAGE)
-  );
-
-  const currentPage = Math.min(page, totalPages);
-
-  const pagedApplicants = filteredApplicants.slice(
-    (currentPage - 1) * ROWS_PER_PAGE,
-    currentPage * ROWS_PER_PAGE
-  );
-
-  const roleOptions = useMemo(
-    () =>
-      Array.from(
-        new Set(
-          applicants.map((applicant) => applicant.roleApplied).filter(Boolean)
-        )
-      ).sort(),
-    [applicants]
-  );
+  const pagedApplicants = applicants;
+  const totalPages = applicantPagination.totalPages;
+  const currentPage = applicantPagination.page;
 
   const toggleSort = (field: RecruitmentSortField) => {
     setSort((current) =>
@@ -560,6 +539,7 @@ export const useRecruitmentData = () => {
       setSelectedApplicant((current) =>
         current?.id === id ? updated : current
       );
+      await fetchApplicants();
       Promise.all([
         fetchPositions(positionsPage),
         fetchOpenPositionsCount(),
@@ -588,6 +568,7 @@ export const useRecruitmentData = () => {
       setSelectedApplicant((current) =>
         current?.id === id ? updated : current
       );
+      await fetchApplicants();
     } catch (err) {
       setMutationError(
         err instanceof Error ? err.message : "Failed to update applicant"
@@ -612,6 +593,7 @@ export const useRecruitmentData = () => {
       setSelectedApplicant((current) =>
         current?.id === id ? updated : current
       );
+      await fetchApplicants();
     } catch (err) {
       setMutationError(
         err instanceof Error ? err.message : "Failed to update applicant"
@@ -640,6 +622,7 @@ export const useRecruitmentData = () => {
       setSelectedApplicant((current) =>
         current?.id === id ? updated : current
       );
+      await fetchApplicants();
       Promise.all([
         fetchPositions(positionsPage),
         fetchOpenPositionsCount(),
@@ -669,6 +652,7 @@ export const useRecruitmentData = () => {
       setSelectedApplicant((current) =>
         current?.id === id ? updated : current
       );
+      await fetchApplicants();
     } catch (err) {
       setMutationError(
         err instanceof Error ? err.message : "Failed to schedule interview"
@@ -836,6 +820,7 @@ export const useRecruitmentData = () => {
       setSelectedApplicant((current) =>
         current?.id === id ? updated : current
       );
+      await fetchApplicants();
     } catch (err) {
       setMutationError(
         err instanceof Error ? err.message : "Failed to reschedule interview"
@@ -858,8 +843,13 @@ export const useRecruitmentData = () => {
 
   const verificationApplicants = useMemo(
     () =>
-      applicants.filter((a) => a.status === "Approved" && !a.volunteerAccount),
-    [applicants]
+      activeTab === "verification"
+        ? applicants.filter(
+            (applicant) =>
+              applicant.status === "Approved" && !applicant.volunteerAccount
+          )
+        : [],
+    [activeTab, applicants]
   );
 
   const verifyApplicant = useCallback(
@@ -888,6 +878,7 @@ export const useRecruitmentData = () => {
           username: account.username,
           tempPassword: account.tempPassword,
         });
+        await fetchApplicants();
       } catch (err) {
         setMutationError(
           err instanceof Error ? err.message : "Failed to verify applicant"
@@ -896,13 +887,16 @@ export const useRecruitmentData = () => {
         setIsMutating(false);
       }
     },
-    [applicants, canManageRecruitment]
+    [applicants, canManageRecruitment, fetchApplicants]
   );
 
   // ── Rejected applicants (delete) ───────────────────────────────────────
   const rejectedApplicants = useMemo(
-    () => applicants.filter((a) => a.status === "Rejected"),
-    [applicants]
+    () =>
+      activeTab === "rejected"
+        ? applicants.filter((applicant) => applicant.status === "Rejected")
+        : [],
+    [activeTab, applicants]
   );
 
   const deleteRejectedApplicant = async (id: string) => {
@@ -912,6 +906,11 @@ export const useRecruitmentData = () => {
       await deleteApplication(id);
       setApplicants((current) => current.filter((a) => a.id !== id));
       setSelectedApplicant((current) => (current?.id === id ? null : current));
+      if (applicants.length === 1 && page > 1) {
+        setPage(page - 1);
+      } else {
+        await fetchApplicants();
+      }
     } catch (err) {
       setMutationError(
         err instanceof Error ? err.message : "Failed to delete applicant"
@@ -925,11 +924,10 @@ export const useRecruitmentData = () => {
     setIsMutating(true);
     setMutationError(null);
     try {
-      const ids = rejectedApplicants.map((a) => a.id);
-      await Promise.all(ids.map((id) => deleteApplication(id)));
-      setApplicants((current) =>
-        current.filter((a) => a.status !== "Rejected")
-      );
+      await clearRejectedApplications();
+      setSelectedIds([]);
+      setPage(1);
+      if (page === 1) await fetchApplicants();
     } catch (err) {
       setMutationError(
         err instanceof Error
@@ -949,7 +947,6 @@ export const useRecruitmentData = () => {
     activeTab,
     setActiveTab,
     applicants,
-    filteredApplicants,
     pagedApplicants,
     selectedIds,
     search,
@@ -962,6 +959,8 @@ export const useRecruitmentData = () => {
     setPage,
     totalPages,
     currentPage,
+    applicantPagination,
+    applicantSummary,
     positionsPage,
     setPositionsPage,
     positionsTotalPages,

--- a/client-side-ts/src/features/admin/recruitment-management/hooks/useRecruitmentData.ts
+++ b/client-side-ts/src/features/admin/recruitment-management/hooks/useRecruitmentData.ts
@@ -1,993 +1,1011 @@
-// src/features/admin/recruitment-management/hooks/useRecruitmentData.ts
+  // src/features/admin/recruitment-management/hooks/useRecruitmentData.ts
 
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { useAdminPermissions } from "@/features/admin/hooks/useAdminPermissions";
+  import { useCallback, useEffect, useMemo, useState } from "react";
+  import { useAdminPermissions } from "@/features/admin/hooks/useAdminPermissions";
 
-import type {
-  RecruitmentApplicant,
-  RecruitmentFilters,
-  RecruitmentSort,
-  RecruitmentSortField,
-  RecruitmentTab,
-  ScheduleInterviewValues,
-  RecruitmentPosition,
-  OpenRecruitmentValues,
-  RecruitmentOpeningConflictError,
-} from "../types/Recruitment.types";
+  import type {
+    RecruitmentApplicant,
+    RecruitmentFilters,
+    RecruitmentSort,
+    RecruitmentSortField,
+    RecruitmentTab,
+    ScheduleInterviewValues,
+    RecruitmentPosition,
+    OpenRecruitmentValues,
+    RecruitmentOpeningConflictError,
+  } from "../types/Recruitment.types";
 
-import {
-  getApplicants,
-  getApplicationDetails,
-  updateApplicationStatus,
-  createInterview,
-  updateInterview,
-  getResumeUrl,
-  downloadResumeFile,
-  listPositions,
-  createOpening,
-  updatePosition as updatePositionApi,
-  toggleHiringStatus,
-  verifyApplicantAccount,
-  deleteApplication,
-  deletePosition as deletePositionApi,
-} from "../../../../api/recruitment.api";
+  import {
+    getApplicants,
+    getApplicationDetails,
+    updateApplicationStatus,
+    createInterview,
+    updateInterview,
+    getResumeUrl,
+    downloadResumeFile,
+    listPositions,
+    createOpening,
+    updatePosition as updatePositionApi,
+    toggleHiringStatus,
+    verifyApplicantAccount,
+    deleteApplication,
+    deletePosition as deletePositionApi,
+  } from "../../../../api/recruitment.api";
 
-export const ROWS_PER_PAGE = 8;
-export const POSITIONS_PER_PAGE = 8;
+  export const ROWS_PER_PAGE = 8;
+  export const POSITIONS_PER_PAGE = 8;
 
-export const DEFAULT_FILTERS: RecruitmentFilters = {
-  roles: [],
-  courses: [],
-  years: [],
-  status: "all",
-};
-
-const DEFAULT_SORT: RecruitmentSort = {
-  field: "name",
-  direction: "asc",
-};
-
-interface RawApplicantRecord {
-  id?: string;
-  _id?: string;
-  id_number?: string;
-  studentId?: string;
-  name?: string;
-  firstName?: string;
-  lastName?: string;
-  email?: string;
-  course?: string;
-  year?: string | number;
-  roleApplied?: string;
-  position?: { title?: string };
-  positionTitle?: string;
-  campus?: string;
-  status?: string;
-  resume?: string;
-  resumeUrl?: string;
-  aiSummary?: string;
-  interview?: {
-    scheduledAt?: string;
-    location?: string;
-    notes?: string;
+  export const DEFAULT_FILTERS: RecruitmentFilters = {
+    roles: [],
+    courses: [],
+    years: [],
+    status: "all",
   };
-  interviewDate?: string;
-  interviewStart?: string;
-  interviewEnd?: string;
-  interviewOfficer?: string;
-  interviewType?: string;
-  // Populated variant returned by getApplicationDetails
-  applicantSnapshot?: {
+
+  const DEFAULT_SORT: RecruitmentSort = {
+    field: "name",
+    direction: "asc",
+  };
+
+  interface RawApplicantRecord {
+    id?: string;
+    _id?: string;
+    id_number?: string;
+    studentId?: string;
     name?: string;
-    idNumber?: string;
+    firstName?: string;
+    lastName?: string;
     email?: string;
     course?: string;
     year?: string | number;
-  };
-  applicant?: {
-    email?: string;
-    course?: string;
-    year?: string | number;
-  };
-  documents?: {
-    resume?: {
-      storageKey?: string;
-      originalFilename?: string;
-      mimeType?: string;
-      size?: number;
-      uploadTimestamp?: string;
-      url?: string;
+    roleApplied?: string;
+    position?: { title?: string };
+    positionTitle?: string;
+    campus?: string;
+    status?: string;
+    resume?: string;
+    resumeUrl?: string;
+    aiSummary?: string;
+    interview?: {
+      scheduledAt?: string;
+      location?: string;
+      notes?: string;
     };
+    interviewDate?: string;
+    interviewStart?: string;
+    interviewEnd?: string;
+    interviewOfficer?: string;
+    interviewType?: string;
+    applicantSnapshot?: {
+      name?: string;
+      idNumber?: string;
+      email?: string;
+      course?: string;
+      year?: string | number;
+    };
+    applicant?: {
+      email?: string;
+      course?: string;
+      year?: string | number;
+    };
+    documents?: {
+      resume?: {
+        storageKey?: string;
+        originalFilename?: string;
+        mimeType?: string;
+        size?: number;
+        uploadTimestamp?: string;
+        url?: string;
+      };
+    };
+    volunteerAccount?: {
+      username?: string;
+      tempPassword?: string;
+      createdAt?: string;
+    };
+    statusHistory?: Array<{
+      status?: string;
+      changedAt?: string;
+      changedBy?: string;
+      note?: string;
+    }>;
+  }
+
+  const STATUS_LABELS: Record<string, RecruitmentApplicant["status"]> = {
+    SUBMITTED: "Pending",
+    INTERVIEW_SCHEDULED: "Scheduled",
+    INTERVIEWING: "Interview Completed",
+    APPROVED: "Approved",
+    REJECTED: "Rejected",
+    WITHDRAWN: "Rejected",
   };
-  volunteerAccount?: {
-    username?: string;
-    tempPassword?: string;
-    createdAt?: string;
-  };
-}
 
-const STATUS_LABELS: Record<string, RecruitmentApplicant["status"]> = {
-  SUBMITTED: "Pending",
-  INTERVIEW_SCHEDULED: "Scheduled",
-  INTERVIEWING: "Interview Completed",
-  APPROVED: "Approved",
-  REJECTED: "Rejected",
-  WITHDRAWN: "Rejected",
-};
+  function formatTime12Hour(time24: string) {
+    const [time, meridiem] = time24.split(" ");
+    if (time && meridiem) return time24;
 
-function formatTime12Hour(time24: string) {
-  const [time, meridiem] = time24.split(" ");
-  if (time && meridiem) return time24;
+    const [hourText, minuteText] = time24.split(":");
+    const hour = Number(hourText);
+    const minute = Number(minuteText || 0);
 
-  const [hourText, minuteText] = time24.split(":");
-  const hour = Number(hourText);
-  const minute = Number(minuteText || 0);
+    if (Number.isNaN(hour) || Number.isNaN(minute)) return time24;
 
-  if (Number.isNaN(hour) || Number.isNaN(minute)) return time24;
+    const suffix = hour >= 12 ? "PM" : "AM";
+    const hour12 = hour % 12 === 0 ? 12 : hour % 12;
+    return `${String(hour12).padStart(2, "0")}:${String(minute).padStart(2, "0")} ${suffix}`;
+  }
 
-  const suffix = hour >= 12 ? "PM" : "AM";
-  const hour12 = hour % 12 === 0 ? 12 : hour % 12;
-  return `${String(hour12).padStart(2, "0")}:${String(minute).padStart(2, "0")} ${suffix}`;
-}
+  function parseInterviewNotes(notes?: string) {
+    const officerMatch = notes?.match(/officer in charge:\s*(.+?)(?:;|$)/i);
+    const typeMatch = notes?.match(/interview type:\s*(.+?)(?:;|$)/i);
+    const startMatch = notes?.match(/starts\s*([^;]+?)(?:;|$)/i);
+    const endMatch = notes?.match(/ends\s*([^;]+?)(?:;|$)/i);
 
-function parseInterviewNotes(notes?: string) {
-  const officerMatch = notes?.match(/officer in charge:\s*(.+?)(?:;|$)/i);
-  const typeMatch = notes?.match(/interview type:\s*(.+?)(?:;|$)/i);
-  const startMatch = notes?.match(/starts\s*([^;]+?)(?:;|$)/i);
-  const endMatch = notes?.match(/ends\s*([^;]+?)(?:;|$)/i);
+    return {
+      officer: officerMatch?.[1]?.trim() ?? "",
+      type: typeMatch?.[1]?.trim() ?? "",
+      starts: startMatch?.[1]?.trim() ?? "",
+      ends: endMatch?.[1]?.trim() ?? "",
+    };
+  }
 
-  return {
-    officer: officerMatch?.[1]?.trim() ?? "",
-    type: typeMatch?.[1]?.trim() ?? "",
-    starts: startMatch?.[1]?.trim() ?? "",
-    ends: endMatch?.[1]?.trim() ?? "",
-  };
-}
+  function mapApplication(raw: RawApplicantRecord): RecruitmentApplicant {
+    const interviewNotes = raw.interview?.notes ?? "";
+    const parsedInterviewNotes = parseInterviewNotes(interviewNotes);
 
-function mapApplication(raw: RawApplicantRecord): RecruitmentApplicant {
-  const interviewNotes = raw.interview?.notes ?? "";
-  const parsedInterviewNotes = parseInterviewNotes(interviewNotes);
+    const rejectedAt = raw.statusHistory?.find(
+      (entry) => entry.status === "REJECTED"
+    )?.changedAt;
 
-  return {
-    id: raw.id ?? raw._id ?? "",
-    id_number:
-      raw.applicantSnapshot?.idNumber ?? raw.id_number ?? raw.studentId ?? "",
-    name:
-      raw.applicantSnapshot?.name ??
-      raw.name ??
-      `${raw.firstName ?? ""} ${raw.lastName ?? ""}`.trim(),
-    email: raw.applicantSnapshot?.email ?? raw.email ?? "",
-    course: String(
-      raw.applicantSnapshot?.course ?? raw.applicant?.course ?? raw.course ?? ""
-    ),
-    year: String(
-      raw.applicantSnapshot?.year ?? raw.applicant?.year ?? raw.year ?? ""
-    ),
-    roleApplied:
-      raw.roleApplied ?? raw.position?.title ?? raw.positionTitle ?? "",
-    campus: raw.campus ?? "",
-    status:
-      STATUS_LABELS[raw.status as string] ??
-      (raw.status as RecruitmentApplicant["status"]),
-    resume:
-      raw.documents?.resume?.url ??
-      raw.documents?.resume?.storageKey ??
-      raw.resume ??
-      raw.resumeUrl,
-    resumeFilename: raw.documents?.resume?.originalFilename,
-    aiSummary: raw.aiSummary,
-    interviewDate: raw.interview?.scheduledAt ?? raw.interviewDate,
-    interviewStart: parsedInterviewNotes.starts || raw.interviewStart || "",
-    interviewEnd: parsedInterviewNotes.ends || raw.interviewEnd || "",
-    interviewOfficer:
-      parsedInterviewNotes.officer || raw.interviewOfficer || "",
-    interviewType: parsedInterviewNotes.type || raw.interviewType || "",
-    volunteerAccount: raw.volunteerAccount
-      ? {
-          username: raw.volunteerAccount.username ?? "",
-          tempPassword: raw.volunteerAccount.tempPassword ?? "",
-        }
-      : undefined,
-  };
-}
+    return {
+      id: raw.id ?? raw._id ?? "",
+      id_number:
+        raw.applicantSnapshot?.idNumber ?? raw.id_number ?? raw.studentId ?? "",
+      name:
+        raw.applicantSnapshot?.name ??
+        raw.name ??
+        `${raw.firstName ?? ""} ${raw.lastName ?? ""}`.trim(),
+      email: raw.applicantSnapshot?.email ?? raw.email ?? "",
+      course: String(
+        raw.applicantSnapshot?.course ?? raw.applicant?.course ?? raw.course ?? ""
+      ),
+      year: String(
+        raw.applicantSnapshot?.year ?? raw.applicant?.year ?? raw.year ?? ""
+      ),
+      roleApplied:
+        raw.roleApplied ?? raw.position?.title ?? raw.positionTitle ?? "",
+      campus: raw.campus ?? "",
+      status:
+        STATUS_LABELS[raw.status as string] ??
+        (raw.status as RecruitmentApplicant["status"]),
+      resume:
+        raw.documents?.resume?.url ??
+        raw.documents?.resume?.storageKey ??
+        raw.resume ??
+        raw.resumeUrl,
+      resumeFilename: raw.documents?.resume?.originalFilename,
+      aiSummary: raw.aiSummary,
+      interviewDate: raw.interview?.scheduledAt ?? raw.interviewDate,
+      interviewStart: parsedInterviewNotes.starts || raw.interviewStart || "",
+      interviewEnd: parsedInterviewNotes.ends || raw.interviewEnd || "",
+      interviewOfficer:
+        parsedInterviewNotes.officer || raw.interviewOfficer || "",
+      interviewType: parsedInterviewNotes.type || raw.interviewType || "",
+      volunteerAccount: raw.volunteerAccount
+        ? {
+            username: raw.volunteerAccount.username ?? "",
+            tempPassword: raw.volunteerAccount.tempPassword ?? "",
+          }
+        : undefined,
+      rejectedAt,
+    };
+  }
 
-function toInterviewPayload(values: ScheduleInterviewValues) {
-  return {
-    scheduledAt: new Date(
-      `${values.date}T${values.startTime}:00+08:00`
-    ).toISOString(),
-    location: "",
-    notes: `Interview type: ${values.interviewType}; officer in charge: ${values.officer}; starts ${formatTime12Hour(values.startTime)}; ends ${formatTime12Hour(values.endTime)}`,
-  };
-}
+  function toInterviewPayload(values: ScheduleInterviewValues) {
+    return {
+      scheduledAt: new Date(
+        `${values.date}T${values.startTime}:00+08:00`
+      ).toISOString(),
+      location: "",
+      notes: `Interview type: ${values.interviewType}; officer in charge: ${values.officer}; starts ${formatTime12Hour(values.startTime)}; ends ${formatTime12Hour(values.endTime)}`,
+    };
+  }
 
-const STATUS = {
-  submitted: "SUBMITTED",
-  interviewScheduled: "INTERVIEW_SCHEDULED",
-  interviewing: "INTERVIEWING",
-  approved: "APPROVED",
-  rejected: "REJECTED",
-  withdrawn: "WITHDRAWN",
-} as const;
+  const STATUS = {
+    submitted: "SUBMITTED",
+    interviewScheduled: "INTERVIEW_SCHEDULED",
+    interviewing: "INTERVIEWING",
+    approved: "APPROVED",
+    rejected: "REJECTED",
+    withdrawn: "WITHDRAWN",
+  } as const;
 
-export const useRecruitmentData = () => {
-  const { canManageRecruitment } = useAdminPermissions();
-  const [activeTab, setActiveTab] = useState<RecruitmentTab>("applicants");
-  const [applicants, setApplicants] = useState<RecruitmentApplicant[]>([]);
-  const [selectedIds, setSelectedIds] = useState<string[]>([]);
-  const [search, setSearch] = useState("");
-  const [filters, setFilters] = useState<RecruitmentFilters>(DEFAULT_FILTERS);
-  const [sort, setSort] = useState<RecruitmentSort>(DEFAULT_SORT);
-  const [page, setPage] = useState(1);
-  const [isLoading, setIsLoading] = useState(true);
-  const [isMutating, setIsMutating] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [positions, setPositions] = useState<RecruitmentPosition[]>([]);
-  const [isPositionsLoading, setIsPositionsLoading] = useState(true);
-  const [positionsError, setPositionsError] = useState<string | null>(null);
-  const [positionsPage, setPositionsPage] = useState(1);
-  const [positionsTotalPages, setPositionsTotalPages] = useState(1);
-  const [positionsTotal, setPositionsTotal] = useState(0);
-  const [openPositionsCount, setOpenPositionsCount] = useState(0);
+  export const useRecruitmentData = () => {
+    const { canManageRecruitment } = useAdminPermissions();
+    const [activeTab, setActiveTab] = useState<RecruitmentTab>("applicants");
+    const [applicants, setApplicants] = useState<RecruitmentApplicant[]>([]);
+    const [selectedIds, setSelectedIds] = useState<string[]>([]);
+    const [search, setSearch] = useState("");
+    const [filters, setFilters] = useState<RecruitmentFilters>(DEFAULT_FILTERS);
+    const [sort, setSort] = useState<RecruitmentSort>(DEFAULT_SORT);
+    const [page, setPage] = useState(1);
+    const [isLoading, setIsLoading] = useState(true);
+    const [isMutating, setIsMutating] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [positions, setPositions] = useState<RecruitmentPosition[]>([]);
+    const [isPositionsLoading, setIsPositionsLoading] = useState(true);
+    const [positionsError, setPositionsError] = useState<string | null>(null);
+    const [positionsPage, setPositionsPage] = useState(1);
+    const [positionsTotalPages, setPositionsTotalPages] = useState(1);
+    const [positionsTotal, setPositionsTotal] = useState(0);
+    const [openPositionsCount, setOpenPositionsCount] = useState(0);
 
-  const [mutationError, setMutationError] = useState<string | null>(null);
+    const [mutationError, setMutationError] = useState<string | null>(null);
 
-  const clearMutationError = useCallback(() => setMutationError(null), []);
+    const clearMutationError = useCallback(() => setMutationError(null), []);
 
-  // ── Applicant details dialog state ────────────────────────────────────
-  const [selectedApplicant, setSelectedApplicant] =
-    useState<RecruitmentApplicant | null>(null);
+    // ── Applicant details dialog state ────────────────────────────────────
+    const [selectedApplicant, setSelectedApplicant] =
+      useState<RecruitmentApplicant | null>(null);
 
-  const [isDetailsLoading, setIsDetailsLoading] = useState(false);
+    const [isDetailsLoading, setIsDetailsLoading] = useState(false);
 
-  const [detailsError, setDetailsError] = useState<string | null>(null);
+    const [detailsError, setDetailsError] = useState<string | null>(null);
 
-  // ── Resume download state ──────────────────────────────────────────────
-  // Signed URLs expire quickly (5 min), so we never cache one — always
-  // fetch a fresh one right when the user tries to view/download.
-  const [isResumeLoading, setIsResumeLoading] = useState(false);
+    // ── Resume download state ──────────────────────────────────────────────
+    // Signed URLs expire quickly (5 min), so we never cache one — always
+    // fetch a fresh one right when the user tries to view/download.
+    const [isResumeLoading, setIsResumeLoading] = useState(false);
 
-  const [resumeError, setResumeError] = useState<string | null>(null);
+    const [resumeError, setResumeError] = useState<string | null>(null);
 
-  const viewResume = useCallback(async (id: string) => {
-    setIsResumeLoading(true);
-    setResumeError(null);
-    try {
-      const res = await getResumeUrl(id);
-      const url = res.data.data.url;
-      window.open(url, "_blank", "noopener,noreferrer");
-    } catch (err) {
-      setResumeError(
-        err instanceof Error ? err.message : "Failed to load resume"
-      );
-    } finally {
-      setIsResumeLoading(false);
-    }
-  }, []);
-
-  const downloadResume = useCallback(async (id: string) => {
-    setIsResumeLoading(true);
-    setResumeError(null);
-    try {
-      const res = await downloadResumeFile(id);
-      const disposition = res.headers["content-disposition"] as
-        string | undefined;
-      const defaultFileName = "resume.pdf";
-      const match = disposition?.match(/filename\*?=(?:UTF-8'')?([^;]+)/i);
-      const fileName = match
-        ? decodeURIComponent(match[1].replace(/"/g, ""))
-        : defaultFileName;
-
-      const contentTypeHeader = res.headers["content-type"];
-      const blob = new Blob([res.data], {
-        type:
-          typeof contentTypeHeader === "string"
-            ? contentTypeHeader
-            : "application/octet-stream",
-      });
-      const downloadUrl = window.URL.createObjectURL(blob);
-      const anchor = document.createElement("a");
-
-      anchor.href = downloadUrl;
-      anchor.download = fileName || defaultFileName;
-      document.body.appendChild(anchor);
-      anchor.click();
-      anchor.remove();
-      window.URL.revokeObjectURL(downloadUrl);
-    } catch (err) {
-      setResumeError(
-        err instanceof Error ? err.message : "Failed to load resume"
-      );
-    } finally {
-      setIsResumeLoading(false);
-    }
-  }, []);
-
-  const fetchApplicants = useCallback(async () => {
-    setIsLoading(true);
-    setError(null);
-
-    try {
-      const res = await getApplicants({});
-      const list = res.data.data.applicants;
-      setApplicants(list.map(mapApplication));
-    } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Failed to load applicants"
-      );
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
-
-  const fetchPositions = useCallback(
-    async (pageNumber = positionsPage) => {
-      setIsPositionsLoading(true);
-      setPositionsError(null);
+    const viewResume = useCallback(async (id: string) => {
+      setIsResumeLoading(true);
+      setResumeError(null);
       try {
-        const res = await listPositions({
-          page: pageNumber,
-          limit: POSITIONS_PER_PAGE,
-        });
-        const payload = res.data.data;
-        const pagination = payload.pagination;
-
-        setPositions(payload.positions || []);
-        setPositionsTotalPages(Number(pagination?.totalPages || 1));
-        setPositionsTotal(Number(pagination?.total || 0));
+        const res = await getResumeUrl(id);
+        const url = res.data.data.url;
+        window.open(url, "_blank", "noopener,noreferrer");
       } catch (err) {
-        setPositionsError(
-          err instanceof Error ? err.message : "Failed to load positions"
+        setResumeError(
+          err instanceof Error ? err.message : "Failed to load resume"
         );
       } finally {
-        setIsPositionsLoading(false);
+        setIsResumeLoading(false);
       }
-    },
-    [positionsPage]
-  );
+    }, []);
 
-  const fetchOpenPositionsCount = useCallback(async () => {
-    try {
-      const res = await listPositions({ status: "OPEN", limit: 1 });
-      setOpenPositionsCount(Number(res.data.data.pagination?.total || 0));
-    } catch {
-      // Non-critical — the stat card just won't update this cycle.
-    }
-  }, []);
+    const downloadResume = useCallback(async (id: string) => {
+      setIsResumeLoading(true);
+      setResumeError(null);
+      try {
+        const res = await downloadResumeFile(id);
+        const disposition = res.headers["content-disposition"] as
+          string | undefined;
+        const defaultFileName = "resume.pdf";
+        const match = disposition?.match(/filename\*?=(?:UTF-8'')?([^;]+)/i);
+        const fileName = match
+          ? decodeURIComponent(match[1].replace(/"/g, ""))
+          : defaultFileName;
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional fetch-on-mount; fetchPositions is also used for refetch, so its internal setIsPositionsLoading/setPositionsError calls are needed there
-    fetchPositions();
-  }, [fetchPositions]);
+        const contentTypeHeader = res.headers["content-type"];
+        const blob = new Blob([res.data], {
+          type:
+            typeof contentTypeHeader === "string"
+              ? contentTypeHeader
+              : "application/octet-stream",
+        });
+        const downloadUrl = window.URL.createObjectURL(blob);
+        const anchor = document.createElement("a");
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional fetch-on-mount
-    fetchOpenPositionsCount();
-  }, [fetchOpenPositionsCount]);
+        anchor.href = downloadUrl;
+        anchor.download = fileName || defaultFileName;
+        document.body.appendChild(anchor);
+        anchor.click();
+        anchor.remove();
+        window.URL.revokeObjectURL(downloadUrl);
+      } catch (err) {
+        setResumeError(
+          err instanceof Error ? err.message : "Failed to load resume"
+        );
+      } finally {
+        setIsResumeLoading(false);
+      }
+    }, []);
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional fetch-on-mount; fetchApplicants is also used for refetch, so its internal setIsLoading/setError calls are needed there
-    fetchApplicants();
-  }, [fetchApplicants]);
+    const fetchApplicants = useCallback(async () => {
+      setIsLoading(true);
+      setError(null);
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional fetch-on-mount; setIsLoading/setError also serve the exposed refetch() path
-    setPage(1);
-  }, [filters, search]);
+      try {
+        const res = await getApplicants({});
+        const list = res.data.data.applicants;
+        setApplicants(list.map(mapApplication));
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "Failed to load applicants"
+        );
+      } finally {
+        setIsLoading(false);
+      }
+    }, []);
 
-  const filteredApplicants = useMemo(() => {
-    const query = search.trim().toLowerCase();
+    const fetchPositions = useCallback(
+      async (pageNumber = positionsPage) => {
+        setIsPositionsLoading(true);
+        setPositionsError(null);
+        try {
+          const res = await listPositions({
+            page: pageNumber,
+            limit: POSITIONS_PER_PAGE,
+          });
+          const payload = res.data.data;
+          const pagination = payload.pagination;
 
-    return applicants
-      .filter((applicant) => {
-        if (
-          query &&
-          ![
-            applicant.name,
-            applicant.id_number,
-            applicant.email,
-            applicant.course,
-            applicant.year,
-            applicant.roleApplied,
-            applicant.status,
-          ]
-            .join(" ")
-            .toLowerCase()
-            .includes(query)
-        ) {
-          return false;
+          setPositions(payload.positions || []);
+          setPositionsTotalPages(Number(pagination?.totalPages || 1));
+          setPositionsTotal(Number(pagination?.total || 0));
+        } catch (err) {
+          setPositionsError(
+            err instanceof Error ? err.message : "Failed to load positions"
+          );
+        } finally {
+          setIsPositionsLoading(false);
         }
+      },
+      [positionsPage]
+    );
 
-        if (
-          filters.roles.length > 0 &&
-          !filters.roles.includes(applicant.roleApplied)
-        ) {
-          return false;
-        }
+    const fetchOpenPositionsCount = useCallback(async () => {
+      try {
+        const res = await listPositions({ status: "OPEN", limit: 1 });
+        setOpenPositionsCount(Number(res.data.data.pagination?.total || 0));
+      } catch {
+        // Non-critical — the stat card just won't update this cycle.
+      }
+    }, []);
 
-        if (
-          filters.courses.length > 0 &&
-          !filters.courses.includes(applicant.course)
-        ) {
-          return false;
-        }
+    useEffect(() => {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional fetch-on-mount; fetchPositions is also used for refetch, so its internal setIsPositionsLoading/setPositionsError calls are needed there
+      fetchPositions();
+    }, [fetchPositions]);
 
-        if (filters.years.length > 0) {
-          // applicant.year may be "1st Year", "2", etc. — normalize to the
-          // leading digit so the filter values ("1".."4") match.
-          const yearDigit = String(applicant.year).match(/\d+/)?.[0] ?? "";
-          if (!filters.years.includes(yearDigit)) {
+    useEffect(() => {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional fetch-on-mount
+      fetchOpenPositionsCount();
+    }, [fetchOpenPositionsCount]);
+
+    useEffect(() => {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional fetch-on-mount; fetchApplicants is also used for refetch, so its internal setIsLoading/setError calls are needed there
+      fetchApplicants();
+    }, [fetchApplicants]);
+
+    useEffect(() => {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional fetch-on-mount; setIsLoading/setError also serve the exposed refetch() path
+      setPage(1);
+    }, [filters, search]);
+
+    const filteredApplicants = useMemo(() => {
+      const query = search.trim().toLowerCase();
+
+      return applicants
+        .filter((applicant) => {
+          if (
+            query &&
+            ![
+              applicant.name,
+              applicant.id_number,
+              applicant.email,
+              applicant.course,
+              applicant.year,
+              applicant.roleApplied,
+              applicant.status,
+            ]
+              .join(" ")
+              .toLowerCase()
+              .includes(query)
+          ) {
             return false;
           }
-        }
 
-        if (filters.status !== "all" && applicant.status !== filters.status) {
-          return false;
-        }
+          if (
+            filters.roles.length > 0 &&
+            !filters.roles.includes(applicant.roleApplied)
+          ) {
+            return false;
+          }
 
-        return true;
-      })
-      .sort((left, right) => {
-        let leftValue = "";
-        let rightValue = "";
+          if (
+            filters.courses.length > 0 &&
+            !filters.courses.includes(applicant.course)
+          ) {
+            return false;
+          }
 
-        switch (sort.field) {
-          case "courseYear":
-            leftValue = `${left.course} ${left.year}`;
-            rightValue = `${right.course} ${right.year}`;
-            break;
+          if (filters.years.length > 0) {
+            // applicant.year may be "1st Year", "2", etc. — normalize to the
+            // leading digit so the filter values ("1".."4") match.
+            const yearDigit = String(applicant.year).match(/\d+/)?.[0] ?? "";
+            if (!filters.years.includes(yearDigit)) {
+              return false;
+            }
+          }
 
-          case "roleApplied":
-            leftValue = left.roleApplied;
-            rightValue = right.roleApplied;
-            break;
+          if (filters.status !== "all" && applicant.status !== filters.status) {
+            return false;
+          }
 
-          default:
-            leftValue = String(
-              left[sort.field as keyof RecruitmentApplicant] ?? ""
-            );
+          return true;
+        })
+        .sort((left, right) => {
+          let leftValue = "";
+          let rightValue = "";
 
-            rightValue = String(
-              right[sort.field as keyof RecruitmentApplicant] ?? ""
-            );
-        }
+          switch (sort.field) {
+            case "courseYear":
+              leftValue = `${left.course} ${left.year}`;
+              rightValue = `${right.course} ${right.year}`;
+              break;
 
-        const result = leftValue.localeCompare(rightValue, undefined, {
-          numeric: true,
-          sensitivity: "base",
+            case "roleApplied":
+              leftValue = left.roleApplied;
+              rightValue = right.roleApplied;
+              break;
+
+            default:
+              leftValue = String(
+                left[sort.field as keyof RecruitmentApplicant] ?? ""
+              );
+
+              rightValue = String(
+                right[sort.field as keyof RecruitmentApplicant] ?? ""
+              );
+          }
+
+          const result = leftValue.localeCompare(rightValue, undefined, {
+            numeric: true,
+            sensitivity: "base",
+          });
+
+          return sort.direction === "asc" ? result : -result;
         });
+    }, [applicants, search, filters, sort]);
 
-        return sort.direction === "asc" ? result : -result;
-      });
-  }, [applicants, search, filters, sort]);
-
-  const totalPages = Math.max(
-    1,
-    Math.ceil(filteredApplicants.length / ROWS_PER_PAGE)
-  );
-
-  const currentPage = Math.min(page, totalPages);
-
-  const pagedApplicants = filteredApplicants.slice(
-    (currentPage - 1) * ROWS_PER_PAGE,
-    currentPage * ROWS_PER_PAGE
-  );
-
-  const roleOptions = useMemo(
-    () =>
-      Array.from(
-        new Set(
-          applicants.map((applicant) => applicant.roleApplied).filter(Boolean)
-        )
-      ).sort(),
-    [applicants]
-  );
-
-  const toggleSort = (field: RecruitmentSortField) => {
-    setSort((current) =>
-      current.field === field
-        ? {
-            field,
-            direction: current.direction === "asc" ? "desc" : "asc",
-          }
-        : {
-            field,
-            direction: "asc",
-          }
+    const totalPages = Math.max(
+      1,
+      Math.ceil(filteredApplicants.length / ROWS_PER_PAGE)
     );
-  };
 
-  const toggleApplicantSelection = (id: string) => {
-    setSelectedIds((current) =>
-      current.includes(id)
-        ? current.filter((item) => item !== id)
-        : [...current, id]
+    const currentPage = Math.min(page, totalPages);
+
+    const pagedApplicants = filteredApplicants.slice(
+      (currentPage - 1) * ROWS_PER_PAGE,
+      currentPage * ROWS_PER_PAGE
     );
-  };
 
-  const clearSelection = () => {
-    setSelectedIds([]);
-  };
+    const roleOptions = useMemo(
+      () =>
+        Array.from(
+          new Set(
+            applicants.map((applicant) => applicant.roleApplied).filter(Boolean)
+          )
+        ).sort(),
+      [applicants]
+    );
 
-  // ── Applicant details (view modal) ─────────────────────────────────────
-  const viewApplicantDetails = useCallback(async (id: string) => {
-    setIsDetailsLoading(true);
-    setDetailsError(null);
-    setSelectedApplicant(null);
+    const toggleSort = (field: RecruitmentSortField) => {
+      setSort((current) =>
+        current.field === field
+          ? {
+              field,
+              direction: current.direction === "asc" ? "desc" : "asc",
+            }
+          : {
+              field,
+              direction: "asc",
+            }
+      );
+    };
 
-    try {
-      const res = await getApplicationDetails(id);
-      setSelectedApplicant(mapApplication(res.data.data));
-    } catch (err) {
-      setDetailsError(
-        err instanceof Error ? err.message : "Failed to load applicant details"
+    const toggleApplicantSelection = (id: string) => {
+      setSelectedIds((current) =>
+        current.includes(id)
+          ? current.filter((item) => item !== id)
+          : [...current, id]
       );
-    } finally {
-      setIsDetailsLoading(false);
-    }
-  }, []);
+    };
 
-  const closeApplicantDetails = useCallback(() => {
-    setSelectedApplicant(null);
-    setDetailsError(null);
-  }, []);
+    const clearSelection = () => {
+      setSelectedIds([]);
+    };
 
-  const rejectApplicant = async (id: string) => {
-    if (!canManageRecruitment) {
-      setMutationError("You don't have permission to reject applicants.");
-      return;
-    }
-    setIsMutating(true);
-    setMutationError(null);
-    try {
-      const res = await updateApplicationStatus(id, {
-        status: STATUS.rejected,
-      });
-      const updated = mapApplication(res.data.data);
-      setApplicants((current) =>
-        current.map((a) => (a.id === id ? updated : a))
-      );
-      setSelectedApplicant((current) =>
-        current?.id === id ? updated : current
-      );
-    } catch (err) {
-      setMutationError(
-        err instanceof Error ? err.message : "Failed to reject applicant"
-      );
-    } finally {
-      setIsMutating(false);
-    }
-  };
+    // ── Applicant details (view modal) ─────────────────────────────────────
+    const viewApplicantDetails = useCallback(async (id: string) => {
+      setIsDetailsLoading(true);
+      setDetailsError(null);
+      setSelectedApplicant(null);
 
-  // SUBMITTED → INTERVIEW_SCHEDULED (was "verifyApplicant" — renamed to match reality)
-  const moveToInterviewScheduled = async (id: string) => {
-    setIsMutating(true);
-    setMutationError(null);
-    try {
-      const res = await updateApplicationStatus(id, {
-        status: STATUS.interviewScheduled,
-      });
-      const updated = mapApplication(res.data.data);
-      setApplicants((current) =>
-        current.map((a) => (a.id === id ? updated : a))
-      );
-      setSelectedApplicant((current) =>
-        current?.id === id ? updated : current
-      );
-    } catch (err) {
-      setMutationError(
-        err instanceof Error ? err.message : "Failed to update applicant"
-      );
-    } finally {
-      setIsMutating(false);
-    }
-  };
-
-  // INTERVIEW_SCHEDULED → INTERVIEWING
-  const moveToInterviewing = async (id: string) => {
-    setIsMutating(true);
-    setMutationError(null);
-    try {
-      const res = await updateApplicationStatus(id, {
-        status: STATUS.interviewing,
-      });
-      const updated = mapApplication(res.data.data);
-      setApplicants((current) =>
-        current.map((a) => (a.id === id ? updated : a))
-      );
-      setSelectedApplicant((current) =>
-        current?.id === id ? updated : current
-      );
-    } catch (err) {
-      setMutationError(
-        err instanceof Error ? err.message : "Failed to update applicant"
-      );
-    } finally {
-      setIsMutating(false);
-    }
-  };
-
-  // INTERVIEWING → APPROVED (only valid step for real "Approve")
-  const approveApplicant = async (id: string) => {
-    if (!canManageRecruitment) {
-      setMutationError("You don't have permission to approve applicants.");
-      return;
-    }
-    setIsMutating(true);
-    setMutationError(null);
-    try {
-      const res = await updateApplicationStatus(id, {
-        status: STATUS.approved,
-      });
-      const updated = mapApplication(res.data.data);
-      setApplicants((current) =>
-        current.map((a) => (a.id === id ? updated : a))
-      );
-      setSelectedApplicant((current) =>
-        current?.id === id ? updated : current
-      );
-    } catch (err) {
-      setMutationError(
-        err instanceof Error ? err.message : "Failed to approve applicant"
-      );
-    } finally {
-      setIsMutating(false);
-    }
-  };
-
-  // Create a new interview for an applicant (uses createInterview API)
-  const scheduleInterview = async (
-    id: string,
-    values: ScheduleInterviewValues
-  ) => {
-    setIsMutating(true);
-    setMutationError(null);
-    try {
-      const res = await createInterview(id, toInterviewPayload(values));
-      const updated = mapApplication(res.data.data);
-      setApplicants((current) =>
-        current.map((a) => (a.id === id ? updated : a))
-      );
-      setSelectedApplicant((current) =>
-        current?.id === id ? updated : current
-      );
-    } catch (err) {
-      setMutationError(
-        err instanceof Error ? err.message : "Failed to schedule interview"
-      );
-    } finally {
-      setIsMutating(false);
-    }
-  };
-
-  const openRoleApplication = async (data: OpenRecruitmentValues) => {
-    setIsMutating(true);
-    setMutationError(null);
-    try {
-      await createOpening({
-        ...data,
-        roleRequirements: data.roleRequirements ?? "",
-      });
-      setPositionsPage(1);
-      await fetchPositions(1);
-      await fetchOpenPositionsCount();
-    } catch (err) {
-      const response = (
-        err as {
-          response?: {
-            status?: number;
-            data?: {
-              code?: string;
-              message?: string;
-              data?: {
-                conflicts?: RecruitmentOpeningConflictError["conflicts"];
-              };
-            };
-          };
-        }
-      ).response;
-
-      if (
-        response?.status === 409 &&
-        response.data?.code === "RECRUITMENT_POSITION_CONFLICT"
-      ) {
-        const conflictError = new Error(
-          response.data.message ||
-            "Some selected role applications already exist."
-        ) as RecruitmentOpeningConflictError;
-        conflictError.code = "RECRUITMENT_POSITION_CONFLICT";
-        conflictError.conflicts = response.data.data?.conflicts ?? [];
-        setMutationError(conflictError.message);
-        throw conflictError;
+      try {
+        const res = await getApplicationDetails(id);
+        setSelectedApplicant(mapApplication(res.data.data));
+      } catch (err) {
+        setDetailsError(
+          err instanceof Error ? err.message : "Failed to load applicant details"
+        );
+      } finally {
+        setIsDetailsLoading(false);
       }
+    }, []);
 
-      setMutationError(
-        err instanceof Error ? err.message : "Failed to open role application"
-      );
-      throw err;
-    } finally {
-      setIsMutating(false);
-    }
-  };
+    const closeApplicantDetails = useCallback(() => {
+      setSelectedApplicant(null);
+      setDetailsError(null);
+    }, []);
 
-  const updatePosition = async (
-    id: string,
-    data: Partial<
-      Pick<
-        RecruitmentPosition,
-        "title" | "slots" | "applicationDeadline" | "requirements"
-      >
-    >
-  ) => {
-    setIsMutating(true);
-    setMutationError(null);
-    try {
-      const res = await updatePositionApi(id, data);
-      const updated = res.data.data;
-      setPositions((current) =>
-        current.map((p) => (p._id === id ? updated : p))
-      );
-    } catch (err) {
-      setMutationError(
-        err instanceof Error ? err.message : "Failed to update position"
-      );
-      throw err;
-    } finally {
-      setIsMutating(false);
-    }
-  };
-
-  const closePosition = async (id: string) => {
-    setIsMutating(true);
-    setMutationError(null);
-    try {
-      const res = await toggleHiringStatus(id, "CLOSED");
-      const updated = res.data.data;
-      setPositions((current) =>
-        current.map((p) => (p._id === id ? updated : p))
-      );
-      await fetchOpenPositionsCount();
-    } catch (err) {
-      setMutationError(
-        err instanceof Error ? err.message : "Failed to close role"
-      );
-    } finally {
-      setIsMutating(false);
-    }
-  };
-
-  const reopenPosition = async (id: string) => {
-    setIsMutating(true);
-    setMutationError(null);
-    try {
-      const res = await toggleHiringStatus(id, "OPEN");
-      const updated = res.data.data;
-      setPositions((current) =>
-        current.map((p) => (p._id === id ? updated : p))
-      );
-      await fetchOpenPositionsCount();
-    } catch (err) {
-      setMutationError(
-        err instanceof Error ? err.message : "Failed to reopen role"
-      );
-    } finally {
-      setIsMutating(false);
-    }
-  };
-  // Delete a position (only for CLOSED roles — the UI gates this).
-  // The backend hard-deletes if no applications exist, otherwise
-  // soft-disables (isActive = false).
-  const deletePosition = async (id: string) => {
-    setIsMutating(true);
-    setMutationError(null);
-    try {
-      await deletePositionApi(id);
-      const nextPage =
-        positions.length === 1 && positionsPage > 1
-          ? positionsPage - 1
-          : positionsPage;
-
-      if (nextPage !== positionsPage) {
-        setPositionsPage(nextPage);
-      }
-
-      await fetchPositions(nextPage);
-      await fetchOpenPositionsCount();
-    } catch (err) {
-      setMutationError(
-        err instanceof Error ? err.message : "Failed to delete position"
-      );
-    } finally {
-      setIsMutating(false);
-    }
-  };
-
-  // Update an existing interview for an applicant (uses updateInterview API)
-  const rescheduleInterview = async (
-    id: string,
-    values: ScheduleInterviewValues
-  ) => {
-    setIsMutating(true);
-    setMutationError(null);
-    try {
-      const res = await updateInterview(id, toInterviewPayload(values));
-      const updated = mapApplication(res.data.data);
-      setApplicants((current) =>
-        current.map((a) => (a.id === id ? updated : a))
-      );
-      setSelectedApplicant((current) =>
-        current?.id === id ? updated : current
-      );
-    } catch (err) {
-      setMutationError(
-        err instanceof Error ? err.message : "Failed to reschedule interview"
-      );
-    } finally {
-      setIsMutating(false);
-    }
-  };
-
-  // ── Verification (approve → auto-create volunteer account) ────────────
-  // "For Verification" applicants are Approved applicants who don't have a
-  // volunteerAccount yet. verifyApplicantAccount calls the backend endpoint
-  // that creates the account and returns { username, tempPassword }.
-  const [verifiedAccount, setVerifiedAccount] = useState<{
-    name: string;
-    role: string;
-    username: string;
-    tempPassword: string;
-  } | null>(null);
-
-  const verificationApplicants = useMemo(
-    () =>
-      applicants.filter((a) => a.status === "Approved" && !a.volunteerAccount),
-    [applicants]
-  );
-
-  const verifyApplicant = useCallback(
-    async (id: string) => {
+    const rejectApplicant = async (id: string) => {
       if (!canManageRecruitment) {
-        setMutationError("You don't have permission to verify applicants.");
+        setMutationError("You don't have permission to reject applicants.");
         return;
       }
       setIsMutating(true);
       setMutationError(null);
       try {
-        const applicant = applicants.find((a) => a.id === id);
-        if (!applicant) throw new Error("Applicant not found");
-
-        const res = await verifyApplicantAccount(id);
-        const account = res.data.data; // { username, tempPassword } from backend
-
-        setApplicants((current) =>
-          current.map((a) =>
-            a.id === id ? { ...a, volunteerAccount: account } : a
-          )
-        );
-        setVerifiedAccount({
-          name: applicant.name,
-          role: applicant.roleApplied,
-          username: account.username,
-          tempPassword: account.tempPassword,
+        const res = await updateApplicationStatus(id, {
+          status: STATUS.rejected,
         });
+        const updated = mapApplication(res.data.data);
+        setApplicants((current) =>
+          current.map((a) => (a.id === id ? updated : a))
+        );
+        setSelectedApplicant((current) =>
+          current?.id === id ? updated : current
+        );
+        Promise.all([
+          fetchPositions(positionsPage),
+          fetchOpenPositionsCount(),
+        ]).catch(() => {});
       } catch (err) {
         setMutationError(
-          err instanceof Error ? err.message : "Failed to verify applicant"
+          err instanceof Error ? err.message : "Failed to reject applicant"
         );
       } finally {
         setIsMutating(false);
       }
-    },
-    [applicants, canManageRecruitment]
-  );
+    };
 
-  // ── Rejected applicants (delete) ───────────────────────────────────────
-  const rejectedApplicants = useMemo(
-    () => applicants.filter((a) => a.status === "Rejected"),
-    [applicants]
-  );
+    // SUBMITTED → INTERVIEW_SCHEDULED (was "verifyApplicant" — renamed to match reality)
+    const moveToInterviewScheduled = async (id: string) => {
+      setIsMutating(true);
+      setMutationError(null);
+      try {
+        const res = await updateApplicationStatus(id, {
+          status: STATUS.interviewScheduled,
+        });
+        const updated = mapApplication(res.data.data);
+        setApplicants((current) =>
+          current.map((a) => (a.id === id ? updated : a))
+        );
+        setSelectedApplicant((current) =>
+          current?.id === id ? updated : current
+        );
+      } catch (err) {
+        setMutationError(
+          err instanceof Error ? err.message : "Failed to update applicant"
+        );
+      } finally {
+        setIsMutating(false);
+      }
+    };
 
-  const deleteRejectedApplicant = async (id: string) => {
-    setIsMutating(true);
-    setMutationError(null);
-    try {
-      await deleteApplication(id);
-      setApplicants((current) => current.filter((a) => a.id !== id));
-      setSelectedApplicant((current) => (current?.id === id ? null : current));
-    } catch (err) {
-      setMutationError(
-        err instanceof Error ? err.message : "Failed to delete applicant"
-      );
-    } finally {
-      setIsMutating(false);
-    }
+    // INTERVIEW_SCHEDULED → INTERVIEWING
+    const moveToInterviewing = async (id: string) => {
+      setIsMutating(true);
+      setMutationError(null);
+      try {
+        const res = await updateApplicationStatus(id, {
+          status: STATUS.interviewing,
+        });
+        const updated = mapApplication(res.data.data);
+        setApplicants((current) =>
+          current.map((a) => (a.id === id ? updated : a))
+        );
+        setSelectedApplicant((current) =>
+          current?.id === id ? updated : current
+        );
+      } catch (err) {
+        setMutationError(
+          err instanceof Error ? err.message : "Failed to update applicant"
+        );
+      } finally {
+        setIsMutating(false);
+      }
+    };
+
+    // INTERVIEWING → APPROVED (only valid step for real "Approve")
+    const approveApplicant = async (id: string) => {
+      if (!canManageRecruitment) {
+        setMutationError("You don't have permission to approve applicants.");
+        return;
+      }
+      setIsMutating(true);
+      setMutationError(null);
+      try {
+        const res = await updateApplicationStatus(id, {
+          status: STATUS.approved,
+        });
+        const updated = mapApplication(res.data.data);
+        setApplicants((current) =>
+          current.map((a) => (a.id === id ? updated : a))
+        );
+        setSelectedApplicant((current) =>
+          current?.id === id ? updated : current
+        );
+        Promise.all([
+          fetchPositions(positionsPage),
+          fetchOpenPositionsCount(),
+        ]).catch(() => {});
+      } catch (err) {
+        setMutationError(
+          err instanceof Error ? err.message : "Failed to approve applicant"
+        );
+      } finally {
+        setIsMutating(false);
+      }
+    };
+
+    // Create a new interview for an applicant (uses createInterview API)
+    const scheduleInterview = async (
+      id: string,
+      values: ScheduleInterviewValues
+    ) => {
+      setIsMutating(true);
+      setMutationError(null);
+      try {
+        const res = await createInterview(id, toInterviewPayload(values));
+        const updated = mapApplication(res.data.data);
+        setApplicants((current) =>
+          current.map((a) => (a.id === id ? updated : a))
+        );
+        setSelectedApplicant((current) =>
+          current?.id === id ? updated : current
+        );
+      } catch (err) {
+        setMutationError(
+          err instanceof Error ? err.message : "Failed to schedule interview"
+        );
+      } finally {
+        setIsMutating(false);
+      }
+    };
+
+    const openRoleApplication = async (data: OpenRecruitmentValues) => {
+      setIsMutating(true);
+      setMutationError(null);
+      try {
+        await createOpening({
+          ...data,
+          roleRequirements: data.roleRequirements ?? "",
+        });
+        setPositionsPage(1);
+        await fetchPositions(1);
+        await fetchOpenPositionsCount();
+      } catch (err) {
+        const response = (
+          err as {
+            response?: {
+              status?: number;
+              data?: {
+                code?: string;
+                message?: string;
+                data?: {
+                  conflicts?: RecruitmentOpeningConflictError["conflicts"];
+                };
+              };
+            };
+          }
+        ).response;
+
+        if (
+          response?.status === 409 &&
+          response.data?.code === "RECRUITMENT_POSITION_CONFLICT"
+        ) {
+          const conflictError = new Error(
+            response.data.message ||
+              "Some selected role applications already exist."
+          ) as RecruitmentOpeningConflictError;
+          conflictError.code = "RECRUITMENT_POSITION_CONFLICT";
+          conflictError.conflicts = response.data.data?.conflicts ?? [];
+          setMutationError(conflictError.message);
+          throw conflictError;
+        }
+
+        setMutationError(
+          err instanceof Error ? err.message : "Failed to open role application"
+        );
+        throw err;
+      } finally {
+        setIsMutating(false);
+      }
+    };
+
+    const updatePosition = async (
+      id: string,
+      data: Partial<
+        Pick<
+          RecruitmentPosition,
+          "title" | "slots" | "applicationDeadline" | "requirements"
+        >
+      >
+    ) => {
+      setIsMutating(true);
+      setMutationError(null);
+      try {
+        const res = await updatePositionApi(id, data);
+        const updated = res.data.data;
+        setPositions((current) =>
+          current.map((p) => (p._id === id ? updated : p))
+        );
+      } catch (err) {
+        setMutationError(
+          err instanceof Error ? err.message : "Failed to update position"
+        );
+        throw err;
+      } finally {
+        setIsMutating(false);
+      }
+    };
+
+    const closePosition = async (id: string) => {
+      setIsMutating(true);
+      setMutationError(null);
+      try {
+        const res = await toggleHiringStatus(id, "CLOSED");
+        const updated = res.data.data;
+        setPositions((current) =>
+          current.map((p) => (p._id === id ? updated : p))
+        );
+        await fetchOpenPositionsCount();
+      } catch (err) {
+        setMutationError(
+          err instanceof Error ? err.message : "Failed to close role"
+        );
+      } finally {
+        setIsMutating(false);
+      }
+    };
+
+    const reopenPosition = async (id: string) => {
+      setIsMutating(true);
+      setMutationError(null);
+      try {
+        const res = await toggleHiringStatus(id, "OPEN");
+        const updated = res.data.data;
+        setPositions((current) =>
+          current.map((p) => (p._id === id ? updated : p))
+        );
+        await fetchOpenPositionsCount();
+      } catch (err) {
+        setMutationError(
+          err instanceof Error ? err.message : "Failed to reopen role"
+        );
+      } finally {
+        setIsMutating(false);
+      }
+    };
+    // Delete a position (only for CLOSED roles — the UI gates this).
+    // The backend hard-deletes if no applications exist, otherwise
+    // soft-disables (isActive = false).
+    const deletePosition = async (id: string) => {
+      setIsMutating(true);
+      setMutationError(null);
+      try {
+        await deletePositionApi(id);
+        const nextPage =
+          positions.length === 1 && positionsPage > 1
+            ? positionsPage - 1
+            : positionsPage;
+
+        if (nextPage !== positionsPage) {
+          setPositionsPage(nextPage);
+        }
+
+        await fetchPositions(nextPage);
+        await fetchOpenPositionsCount();
+      } catch (err) {
+        setMutationError(
+          err instanceof Error ? err.message : "Failed to delete position"
+        );
+      } finally {
+        setIsMutating(false);
+      }
+    };
+
+    // Update an existing interview for an applicant (uses updateInterview API)
+    const rescheduleInterview = async (
+      id: string,
+      values: ScheduleInterviewValues
+    ) => {
+      setIsMutating(true);
+      setMutationError(null);
+      try {
+        const res = await updateInterview(id, toInterviewPayload(values));
+        const updated = mapApplication(res.data.data);
+        setApplicants((current) =>
+          current.map((a) => (a.id === id ? updated : a))
+        );
+        setSelectedApplicant((current) =>
+          current?.id === id ? updated : current
+        );
+      } catch (err) {
+        setMutationError(
+          err instanceof Error ? err.message : "Failed to reschedule interview"
+        );
+      } finally {
+        setIsMutating(false);
+      }
+    };
+
+    // ── Verification (approve → auto-create volunteer account) ────────────
+    // "For Verification" applicants are Approved applicants who don't have a
+    // volunteerAccount yet. verifyApplicantAccount calls the backend endpoint
+    // that creates the account and returns { username, tempPassword }.
+    const [verifiedAccount, setVerifiedAccount] = useState<{
+      name: string;
+      role: string;
+      username: string;
+      tempPassword: string;
+    } | null>(null);
+
+    const verificationApplicants = useMemo(
+      () =>
+        applicants.filter((a) => a.status === "Approved" && !a.volunteerAccount),
+      [applicants]
+    );
+
+    const verifyApplicant = useCallback(
+      async (id: string) => {
+        if (!canManageRecruitment) {
+          setMutationError("You don't have permission to verify applicants.");
+          return;
+        }
+        setIsMutating(true);
+        setMutationError(null);
+        try {
+          const applicant = applicants.find((a) => a.id === id);
+          if (!applicant) throw new Error("Applicant not found");
+
+          const res = await verifyApplicantAccount(id);
+          const account = res.data.data; // { username, tempPassword } from backend
+
+          setApplicants((current) =>
+            current.map((a) =>
+              a.id === id ? { ...a, volunteerAccount: account } : a
+            )
+          );
+          setVerifiedAccount({
+            name: applicant.name,
+            role: applicant.roleApplied,
+            username: account.username,
+            tempPassword: account.tempPassword,
+          });
+        } catch (err) {
+          setMutationError(
+            err instanceof Error ? err.message : "Failed to verify applicant"
+          );
+        } finally {
+          setIsMutating(false);
+        }
+      },
+      [applicants, canManageRecruitment]
+    );
+
+    // ── Rejected applicants (delete) ───────────────────────────────────────
+    const rejectedApplicants = useMemo(
+      () => applicants.filter((a) => a.status === "Rejected"),
+      [applicants]
+    );
+
+    const deleteRejectedApplicant = async (id: string) => {
+      setIsMutating(true);
+      setMutationError(null);
+      try {
+        await deleteApplication(id);
+        setApplicants((current) => current.filter((a) => a.id !== id));
+        setSelectedApplicant((current) => (current?.id === id ? null : current));
+      } catch (err) {
+        setMutationError(
+          err instanceof Error ? err.message : "Failed to delete applicant"
+        );
+      } finally {
+        setIsMutating(false);
+      }
+    };
+
+    const clearAllRejectedApplicants = async () => {
+      setIsMutating(true);
+      setMutationError(null);
+      try {
+        const ids = rejectedApplicants.map((a) => a.id);
+        await Promise.all(ids.map((id) => deleteApplication(id)));
+        setApplicants((current) =>
+          current.filter((a) => a.status !== "Rejected")
+        );
+      } catch (err) {
+        setMutationError(
+          err instanceof Error
+            ? err.message
+            : "Failed to clear rejected applicants"
+        );
+        // Refetch to reconcile partial failures
+        await fetchApplicants();
+      } finally {
+        setIsMutating(false);
+      }
+    };
+
+    const clearVerifiedAccount = useCallback(() => setVerifiedAccount(null), []);
+
+    return {
+      activeTab,
+      setActiveTab,
+      applicants,
+      filteredApplicants,
+      pagedApplicants,
+      selectedIds,
+      search,
+      setSearch,
+      filters,
+      setFilters,
+      sort,
+      setSort,
+      page,
+      setPage,
+      totalPages,
+      currentPage,
+      positionsPage,
+      setPositionsPage,
+      positionsTotalPages,
+      positionsTotal,
+      openPositionsCount,
+      isLoading,
+      isMutating,
+      error,
+      mutationError,
+      clearMutationError,
+      roleOptions,
+      toggleSort,
+      toggleApplicantSelection,
+      clearSelection,
+      approveApplicant,
+      rejectApplicant,
+      moveToInterviewScheduled,
+      moveToInterviewing,
+      scheduleInterview,
+      rescheduleInterview,
+      refetch: fetchApplicants,
+      selectedApplicant,
+      isDetailsLoading,
+      detailsError,
+      viewApplicantDetails,
+      closeApplicantDetails,
+      viewResume,
+      downloadResume,
+      isResumeLoading,
+      resumeError,
+      positions,
+      isPositionsLoading,
+      positionsError,
+      openRoleApplication,
+      updatePosition,
+      closePosition,
+      reopenPosition,
+      deletePosition,
+      verificationApplicants,
+      verifyApplicant,
+      verifiedAccount,
+      clearVerifiedAccount,
+      rejectedApplicants,
+      deleteRejectedApplicant,
+      clearAllRejectedApplicants,
+    };
   };
-
-  const clearAllRejectedApplicants = async () => {
-    setIsMutating(true);
-    setMutationError(null);
-    try {
-      const ids = rejectedApplicants.map((a) => a.id);
-      await Promise.all(ids.map((id) => deleteApplication(id)));
-      setApplicants((current) =>
-        current.filter((a) => a.status !== "Rejected")
-      );
-    } catch (err) {
-      setMutationError(
-        err instanceof Error
-          ? err.message
-          : "Failed to clear rejected applicants"
-      );
-      // Refetch to reconcile partial failures
-      await fetchApplicants();
-    } finally {
-      setIsMutating(false);
-    }
-  };
-
-  const clearVerifiedAccount = useCallback(() => setVerifiedAccount(null), []);
-
-  return {
-    activeTab,
-    setActiveTab,
-    applicants,
-    filteredApplicants,
-    pagedApplicants,
-    selectedIds,
-    search,
-    setSearch,
-    filters,
-    setFilters,
-    sort,
-    setSort,
-    page,
-    setPage,
-    totalPages,
-    currentPage,
-    positionsPage,
-    setPositionsPage,
-    positionsTotalPages,
-    positionsTotal,
-    openPositionsCount,
-    isLoading,
-    isMutating,
-    error,
-    mutationError,
-    clearMutationError,
-    roleOptions,
-    toggleSort,
-    toggleApplicantSelection,
-    clearSelection,
-    approveApplicant,
-    rejectApplicant,
-    moveToInterviewScheduled,
-    moveToInterviewing,
-    scheduleInterview,
-    rescheduleInterview,
-    refetch: fetchApplicants,
-    selectedApplicant,
-    isDetailsLoading,
-    detailsError,
-    viewApplicantDetails,
-    closeApplicantDetails,
-    viewResume,
-    downloadResume,
-    isResumeLoading,
-    resumeError,
-    positions,
-    isPositionsLoading,
-    positionsError,
-    openRoleApplication,
-    updatePosition,
-    closePosition,
-    reopenPosition,
-    deletePosition,
-    verificationApplicants,
-    verifyApplicant,
-    verifiedAccount,
-    clearVerifiedAccount,
-    rejectedApplicants,
-    deleteRejectedApplicant,
-    clearAllRejectedApplicants,
-  };
-};

--- a/client-side-ts/src/features/admin/recruitment-management/types/Recruitment.types.ts
+++ b/client-side-ts/src/features/admin/recruitment-management/types/Recruitment.types.ts
@@ -48,6 +48,7 @@ export interface RecruitmentApplicant {
   interviewType?: string;
   resumeFilename?: string;
   volunteerAccount?: VolunteerAccountCredentials;
+  rejectedAt?: string;
 }
 
 export interface VolunteerAccountCredentials {
@@ -91,8 +92,7 @@ export interface OpenRecruitmentRole {
 }
 
 export type RecruitmentOpeningConflictStrategy =
-  | "update_existing"
-  | "close_old_create_new";
+  "update_existing" | "close_old_create_new";
 
 export interface RecruitmentOpeningConflict {
   _id: string;

--- a/client-side-ts/src/types/recruitment.ts
+++ b/client-side-ts/src/types/recruitment.ts
@@ -81,7 +81,13 @@ export interface PaginatedResponse<T> {
 export interface ApplicantFilters {
   page?: number;
   limit?: number;
-  status?: Application["status"];
+  status?: Application["status"] | string;
   positionId?: string;
   search?: string;
+  role?: string;
+  course?: string;
+  year?: string;
+  sortField?: "name" | "id_number" | "courseYear" | "roleApplied" | "status";
+  sortDirection?: "asc" | "desc";
+  verificationOnly?: boolean;
 }

--- a/server-side/src/controllers/recruitment.v2.controller.ts
+++ b/server-side/src/controllers/recruitment.v2.controller.ts
@@ -197,6 +197,15 @@ class RecruitmentController {
     return res.status(200).json(result);
   });
 
+  /** Admin: Delete all rejected applications */
+  clearRejectedApplications = catchAsync(
+    async (req: Request, res: Response) => {
+      const result = await recruitmentService.clearRejectedApplications(req);
+      await logAdminAction(req, logs_action.CLEAR_REJECTED, "Rejected applicants");
+      return res.status(200).json(result);
+    }
+  );
+
   /** Admin: Create the volunteer account for an Approved applicant */
   verifyApplicantAccount = catchAsync(async (req: Request, res: Response) => {
     const id = req.params.id as string;

--- a/server-side/src/mail_template/mail.template.ts
+++ b/server-side/src/mail_template/mail.template.ts
@@ -545,7 +545,6 @@ export const recruitmentInterviewScheduledMail = async (data: {
   }
 };
 
-
 export const recruitmentInterviewRescheduledMail = async (data: {
   applicantName: string;
   applicantEmail: string;
@@ -571,7 +570,7 @@ export const recruitmentInterviewRescheduledMail = async (data: {
       bodyHtml: `
         <p>Dear ${data.applicantName},</p>
         <p style="margin-bottom:16px;">
-          We would like to inform you that your interview schedule has been <strong>rescheduled</strong>. Please take note of your new schedule below.
+          We would like to inform you that your interview schedule has been <strong>RESCHEDULED</strong>. Please take note of your new schedule below.
         </p>
         <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f5f5f5; border-radius:8px; margin-bottom:20px;">
           <tr><td style="padding:16px 18px;">

--- a/server-side/src/mail_template/mail.template.ts
+++ b/server-side/src/mail_template/mail.template.ts
@@ -545,6 +545,72 @@ export const recruitmentInterviewScheduledMail = async (data: {
   }
 };
 
+
+export const recruitmentInterviewRescheduledMail = async (data: {
+  applicantName: string;
+  applicantEmail: string;
+  interviewDate: string;
+  interviewTime: string;
+  mode: string;
+  officer: string;
+}): Promise<void> => {
+  let queueEntry: any;
+
+  try {
+    queueEntry = await emailService.createByEmail(
+      "recruitment",
+      data.applicantEmail,
+      "interview_rescheduled"
+    );
+
+    await sendPsitsTemplatedEmail({
+      to: data.applicantEmail,
+      subject: "PSITS Interview Reschedule Notification",
+      category: "Philipine Technology of Information Technology Students",
+      title: "Interview Rescheduled",
+      bodyHtml: `
+        <p>Dear ${data.applicantName},</p>
+        <p style="margin-bottom:16px;">
+          We would like to inform you that your interview schedule has been <strong>rescheduled</strong>. Please take note of your new schedule below.
+        </p>
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f5f5f5; border-radius:8px; margin-bottom:20px;">
+          <tr><td style="padding:16px 18px;">
+            <p style="margin:5px 0; font-weight:bold; font-size:15px;">New Interview Schedule</p>
+            <p style="margin:5px 0;"><strong>Date:</strong> ${data.interviewDate}</p>
+            <p style="margin:5px 0;"><strong>Time:</strong> ${data.interviewTime}</p>
+            <p style="margin:5px 0;"><strong>Mode:</strong> ${data.mode}</p>
+            <p style="margin:5px 0;"><strong>Officer's In-charge:</strong> ${data.officer}</p>
+          </td></tr>
+        </table>
+        <p style="margin-bottom:12px;"><strong>For FACE-TO-FACE interview:</strong></p>
+        <p style="margin-bottom:16px;">
+          Please proceed to <strong>PSITS Office</strong> beside <strong>Room 540</strong> at least <strong>5 minutes before</strong> your scheduled interview time. Kindly bring the documents requested during your application.
+        </p>
+        <p style="margin-bottom:12px;"><strong>For ONLINE interview:</strong></p>
+        <p style="margin-bottom:16px;">
+          A recruitment officer will contact you before your scheduled interview to provide the meeting link and any additional instructions. Please ensure that you are available at the scheduled time and have a stable internet connection.
+        </p>
+        <p style="margin-bottom:16px;">
+          If you have any questions or are unable to attend your rescheduled interview, please inform us as soon as possible.
+        </p>
+        <p style="margin-bottom:16px;">We look forward to meeting you and wish you the best of luck.</p>
+        <p style="margin-bottom:0;">Best regards,<br/><strong>Recruitment Team</strong></p>
+      `,
+    });
+
+    await emailService.updateStatusById(String(queueEntry._id), "sent");
+  } catch (err: unknown) {
+    console.error(
+      "Failed to send recruitment interview rescheduled email:",
+      err instanceof Error ? err.message : err
+    );
+    if (queueEntry) {
+      await emailService.updateStatusById(String(queueEntry._id), "failed");
+    }
+    throw err;
+  }
+};
+
 /**
  * Sends an account-creation email to a verified recruitment applicant whose
  * volunteer account has just been created. Includes the auto-generated login

--- a/server-side/src/routes/recruitment.route.ts
+++ b/server-side/src/routes/recruitment.route.ts
@@ -199,6 +199,14 @@ router.get(
   recruitmentController.getApplicationDetails
 );
 
+router.delete(
+  "/applicants/rejected",
+  requireAccessTokenWithDBCheck,
+  roleAuthenticateV2(["admin"]),
+  adminAccessAuthenticateV2(recruitmentMutationRoles),
+  recruitmentController.clearRejectedApplications
+);
+
 router.patch(
   "/applications/:id/status",
   requireAccessTokenWithDBCheck,

--- a/server-side/src/services/recruitment.service.ts
+++ b/server-side/src/services/recruitment.service.ts
@@ -1148,10 +1148,12 @@ export class RecruitmentService {
         year: "numeric",
         month: "long",
         day: "numeric",
+        timeZone: "Asia/Manila",
       });
       const timeStr = scheduledAt.toLocaleTimeString("en-US", {
         hour: "numeric",
         minute: "2-digit",
+        timeZone: "Asia/Manila",
       });
 
       const modeMatch = (notes || "").match(/Interview type:\s*(.+?)(?:;|$)/i);
@@ -1227,10 +1229,12 @@ export class RecruitmentService {
         year: "numeric",
         month: "long",
         day: "numeric",
+        timeZone: "Asia/Manila",
       });
       const timeStr = rescheduledAt.toLocaleTimeString("en-US", {
         hour: "numeric",
         minute: "2-digit",
+        timeZone: "Asia/Manila",
       });
 
       const modeMatch = (app.interview.notes || "").match(

--- a/server-side/src/services/recruitment.service.ts
+++ b/server-side/src/services/recruitment.service.ts
@@ -21,6 +21,7 @@ import {
   recruitmentApprovedMail,
   recruitmentAccountCreatedMail,
   recruitmentInterviewScheduledMail,
+  recruitmentInterviewRescheduledMail,
   recruitmentRejectedMail,
 } from "../mail_template/mail.template";
 import { adminService } from "./admin.service";
@@ -1097,7 +1098,10 @@ export class RecruitmentService {
       req.userV2.sub || (req.admin ? req.admin._id.toString() : null);
     if (!adminId) throw new AppError("Authentication required.", 401);
 
-    const app = await Application.findById(applicationId);
+    const app = await Application.findById(applicationId).populate(
+      "position",
+      "title"
+    );
     if (!app) throw new AppError("Application not found.", 404);
 
     const { scheduledAt, location, notes } = req.body;
@@ -1182,7 +1186,10 @@ export class RecruitmentService {
       req.userV2.sub || (req.admin ? req.admin._id.toString() : null);
     if (!adminId) throw new AppError("Authentication required.", 401);
 
-    const app = await Application.findById(applicationId);
+    const app = await Application.findById(applicationId).populate(
+      "position",
+      "title"
+    );
     if (!app) throw new AppError("Application not found.", 404);
 
     if (!app.interview)
@@ -1209,6 +1216,48 @@ export class RecruitmentService {
     app.interview.scheduledBy = adminId;
 
     await app.save();
+
+    // Send interview reschedule notification email — best-effort, don't
+    // block on failure. Parses the interview mode from the notes field
+    // (stored as "Interview type: [type]; ...") and formats the new date/time
+    // from the updated scheduledAt timestamp.
+    try {
+      const rescheduledAt = app.interview.scheduledAt;
+      const dateStr = rescheduledAt.toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      });
+      const timeStr = rescheduledAt.toLocaleTimeString("en-US", {
+        hour: "numeric",
+        minute: "2-digit",
+      });
+
+      const modeMatch = (app.interview.notes || "").match(
+        /Interview type:\s*(.+?)(?:;|$)/i
+      );
+      const mode = modeMatch?.[1]?.trim() || "Face-to-Face";
+
+      const officerMatch = (app.interview.notes || "").match(
+        /officer in charge:\s*(.+?)(?:;|$)/i
+      );
+      const officer = officerMatch?.[1]?.trim() || "";
+
+      await recruitmentInterviewRescheduledMail({
+        applicantName: app.applicantSnapshot.name || "",
+        applicantEmail: app.applicantSnapshot.email || "",
+        interviewDate: dateStr,
+        interviewTime: timeStr,
+        mode,
+        officer,
+      });
+    } catch (err) {
+      console.error(
+        "Failed to send interview reschedule email:",
+        err instanceof Error ? err.message : err
+      );
+    }
+
     return app;
   }
 

--- a/server-side/src/services/recruitment.service.ts
+++ b/server-side/src/services/recruitment.service.ts
@@ -1046,20 +1046,20 @@ export class RecruitmentService {
       }
     }
 
-    // Send rejection email automatically when the decision is REJECTED
+    // Send rejection email automatically when the decision is REJECTED.
+    // Fire-and-forget so the status update responds immediately instead of
+    // blocking on the email provider's network latency.
     if (status === applicationStatus.REJECTED) {
-      try {
-        await recruitmentRejectedMail({
-          applicantName: app.applicantSnapshot.name || "",
-          applicantEmail: app.applicantSnapshot.email || "",
-          reason: note || undefined,
-        });
-      } catch (err) {
+      recruitmentRejectedMail({
+        applicantName: app.applicantSnapshot.name || "",
+        applicantEmail: app.applicantSnapshot.email || "",
+        reason: note || undefined,
+      }).catch((err) => {
         console.error(
           "Failed to send recruitment rejection email:",
           err instanceof Error ? err.message : err
         );
-      }
+      });
     }
 
     // Send approval email automatically when the decision is APPROVED.

--- a/server-side/src/services/recruitment.service.ts
+++ b/server-side/src/services/recruitment.service.ts
@@ -49,6 +49,15 @@ const toPositiveInteger = (value: any, fallback: number) => {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 };
 
+const toStringList = (value: unknown) =>
+  (Array.isArray(value) ? value : [value])
+    .flatMap((item) => String(item ?? "").split(","))
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+const escapeRegex = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
 const toRequirementList = (value: any) =>
   String(value ?? "")
     .split("\n")
@@ -722,31 +731,230 @@ export class RecruitmentService {
     return obj;
   }
 
-  /** Admin: Get paginated applicant list with filters */
+  /** Admin: Get one filtered and sorted page of applicants. */
   async getApplicants(req: any) {
-    const { positionId, status, search, page = 1, limit = 10 } = req.query;
-    const query: any = {};
+    const page = toPositiveInteger(req.query.page, 1);
+    const limit = Math.min(toPositiveInteger(req.query.limit, 10), 50);
+    const positionId = String(req.query.positionId ?? "").trim();
+    const search = String(req.query.search ?? "").trim();
+    const statuses = toStringList(req.query.status);
+    const roles = toStringList(req.query.roles ?? req.query.role);
+    const courses = toStringList(req.query.courses ?? req.query.course);
+    const years = toStringList(req.query.years ?? req.query.year)
+      .map((year) => year.match(/\d/)?.[0])
+      .filter((year): year is string => Boolean(year));
+    const verificationOnly = toBooleanQuery(req.query.verificationOnly);
 
-    if (positionId) query.position = positionId;
-    if (status) query.status = status;
-    if (search)
-      query.$or = [
-        { "applicantSnapshot.name": { $regex: search, $options: "i" } },
-        { "applicantSnapshot.idNumber": { $regex: search, $options: "i" } },
-      ];
+    const statusMap: Record<string, string> = {
+      Pending: applicationStatus.SUBMITTED,
+      Scheduled: applicationStatus.INTERVIEW_SCHEDULED,
+      "Interview Completed": applicationStatus.INTERVIEWING,
+      Approved: applicationStatus.APPROVED,
+      Rejected: applicationStatus.REJECTED,
+      "For Verification": applicationStatus.APPROVED,
+    };
 
-    const applicants = await Application.find(query)
-      .populate("position", "title")
-      .populate("applicant", "name id_number email course year")
-      .sort({ createdAt: -1 })
-      .skip((parseInt(page) - 1) * parseInt(limit))
-      .limit(parseInt(limit));
+    const conditions: Record<string, any>[] = [];
+    const mappedStatuses = statuses
+      .map((status) => statusMap[status] ?? status)
+      .filter(Boolean);
 
-    const total = await Application.countDocuments(query);
+    if (positionId) conditions.push({ position: positionId });
+    if (mappedStatuses.length) conditions.push({ status: { $in: mappedStatuses } });
+    if (courses.length)
+      conditions.push({ "applicantSnapshot.course": { $in: courses } });
+    if (years.length) {
+      conditions.push({
+        $expr: {
+          $regexMatch: {
+            input: { $toString: { $ifNull: ["$applicantSnapshot.year", ""] } },
+            regex: `^[${years.join("")}]`,
+          },
+        },
+      });
+    }
+    if (search) {
+      const pattern = escapeRegex(search);
+      conditions.push({
+        $or: [
+          { "applicantSnapshot.name": { $regex: pattern, $options: "i" } },
+          {
+            "applicantSnapshot.idNumber": {
+              $regex: pattern,
+              $options: "i",
+            },
+          },
+          { "applicantSnapshot.email": { $regex: pattern, $options: "i" } },
+        ],
+      });
+    }
+    if (verificationOnly || statuses.includes("For Verification")) {
+      conditions.push({ status: applicationStatus.APPROVED });
+      conditions.push({ "volunteerAccount.username": { $exists: false } });
+    }
+
+    const applicationMatch =
+      conditions.length === 0
+        ? {}
+        : conditions.length === 1
+          ? conditions[0]
+          : { $and: conditions };
+
+    const sortField = String(req.query.sortField ?? "createdAt");
+    const sortDirection = req.query.sortDirection === "asc" ? 1 : -1;
+    const sort: Record<string, 1 | -1> = {};
+
+    switch (sortField) {
+      case "name":
+        sort["applicantSnapshot.name"] = sortDirection;
+        break;
+      case "id_number":
+        sort["applicantSnapshot.idNumber"] = sortDirection;
+        break;
+      case "courseYear":
+        sort["applicantSnapshot.course"] = sortDirection;
+        sort["applicantSnapshot.year"] = sortDirection;
+        break;
+      case "roleApplied":
+        sort["position.title"] = sortDirection;
+        break;
+      case "status":
+        sort.status = sortDirection;
+        break;
+      default:
+        sort.createdAt = -1;
+    }
+    sort._id = -1;
+
+    // Position is stored as a string in some older records and as an ObjectId
+    // in newer records. Comparing their string forms keeps both formats visible.
+    const positionLookup = [
+      {
+        $lookup: {
+          from: RecruitmentPosition.collection.name,
+          let: { applicationPositionId: { $toString: "$position" } },
+          pipeline: [
+            {
+              $match: {
+                $expr: {
+                  $eq: [
+                    { $toString: "$_id" },
+                    "$$applicationPositionId",
+                  ],
+                },
+              },
+            },
+            { $project: { title: 1 } },
+          ],
+          as: "positionDetails",
+        },
+      },
+      {
+        $set: {
+          position: { $arrayElemAt: ["$positionDetails", 0] },
+        },
+      },
+      { $unset: "positionDetails" },
+    ];
+
+    const roleMatch = roles.length
+      ? [{ $match: { "position.title": { $in: roles } } }]
+      : [];
+
+    const [pageResult, summaryRows, positionIds] = await Promise.all([
+      Application.aggregate([
+        { $match: applicationMatch },
+        ...positionLookup,
+        ...roleMatch,
+        {
+          $facet: {
+            applicants: [
+              { $sort: sort },
+              { $skip: (page - 1) * limit },
+              { $limit: limit },
+            ],
+            total: [{ $count: "count" }],
+          },
+        },
+      ]),
+      Application.aggregate([
+        {
+          $group: {
+            _id: null,
+            pending: {
+              $sum: {
+                $cond: [
+                  { $eq: ["$status", applicationStatus.SUBMITTED] },
+                  1,
+                  0,
+                ],
+              },
+            },
+            approved: {
+              $sum: {
+                $cond: [
+                  { $eq: ["$status", applicationStatus.APPROVED] },
+                  1,
+                  0,
+                ],
+              },
+            },
+            rejected: {
+              $sum: {
+                $cond: [
+                  { $eq: ["$status", applicationStatus.REJECTED] },
+                  1,
+                  0,
+                ],
+              },
+            },
+            verifications: {
+              $sum: {
+                $cond: [
+                  {
+                    $and: [
+                      { $eq: ["$status", applicationStatus.APPROVED] },
+                      {
+                        $eq: [
+                          { $ifNull: ["$volunteerAccount.username", null] },
+                          null,
+                        ],
+                      },
+                    ],
+                  },
+                  1,
+                  0,
+                ],
+              },
+            },
+          },
+        },
+      ]),
+      Application.distinct("position"),
+    ]);
+
+    const roleOptions = await RecruitmentPosition.distinct("title", {
+      _id: { $in: positionIds },
+    });
+    const result = pageResult[0] ?? { applicants: [], total: [] };
+    const total = Number(result.total?.[0]?.count ?? 0);
+    const summary = summaryRows[0] ?? {};
 
     return {
-      applicants,
-      pagination: { page, limit, total, totalPages: Math.ceil(total / limit) },
+      applicants: result.applicants,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.max(1, Math.ceil(total / limit)),
+      },
+      summary: {
+        pending: Number(summary.pending ?? 0),
+        approved: Number(summary.approved ?? 0),
+        rejected: Number(summary.rejected ?? 0),
+        verifications: Number(summary.verifications ?? 0),
+      },
+      filterOptions: { roles: roleOptions.sort() },
     };
   }
 
@@ -949,6 +1157,22 @@ export class RecruitmentService {
 
     await app.deleteOne();
     return { message: "Application deleted successfully" };
+  }
+
+  /** Admin: Delete every rejected application without loading them in the UI. */
+  async clearRejectedApplications(req: any) {
+    const adminId =
+      req.userV2?.sub || (req.admin ? req.admin._id.toString() : null);
+    if (!adminId) throw new AppError("Authentication required.", 401);
+
+    const result = await Application.deleteMany({
+      status: applicationStatus.REJECTED,
+    });
+
+    return {
+      message: "Rejected applications cleared successfully",
+      deletedCount: result.deletedCount ?? 0,
+    };
   }
 
   /** Update application status (admin only) */


### PR DESCRIPTION
## Summary

- Fix admin recruitment applicants showing only the first 10 records
- Fetch applicants page by page from the backend instead of loading all records
- Add server-side search, filters, sorting, and accurate total counts
- Paginate Applicants, Rejected, and Verification tabs
- Add compact page controls for large applicant lists
- Add a bulk endpoint to clear rejected applications without loading every record in the browser
