### PR TITLE
feat(reports): add batch-filtered merchandise reports and full CSV export

### DIFF
--- a/client-side-ts/src/features/admin/api/admin.ts
+++ b/client-side-ts/src/features/admin/api/admin.ts
@@ -160,7 +160,17 @@ export interface MerchandiseReportsResult {
   totalPages: number;
   message?: string;
   summary: { unitsSold: number; totalRevenue: number };
-  productNames: string[];
+}
+
+export interface MerchandiseReportProductOption {
+  productId: string;
+  productName: string;
+  batches: string[];
+}
+
+export interface MerchandiseReportFilterOptionsResult {
+  message?: string;
+  products: MerchandiseReportProductOption[];
 }
 
 export interface MerchandiseReportsParams {
@@ -170,9 +180,12 @@ export interface MerchandiseReportsParams {
   referenceCode?: string;
   studentId?: string;
   name?: string;
+  rfid?: string;
   course?: string;
   year?: string;
+  productId?: string;
   productName?: string;
+  batch?: string;
   size?: string;
   color?: string;
   dateFrom?: string;
@@ -606,9 +619,12 @@ export const merchandiseReports = async ({
   referenceCode,
   studentId,
   name,
+  rfid,
   course,
   year,
+  productId,
   productName,
+  batch,
   size,
   color,
   dateFrom,
@@ -626,14 +642,48 @@ export const merchandiseReports = async ({
           referenceCode,
           studentId,
           name,
+          rfid,
           course,
           year,
+          productId,
           productName,
+          batch,
           size,
           color,
           dateFrom,
           dateTo,
         },
+      }
+    );
+    return response.data;
+  } catch (error) {
+    handleApiError(error, false);
+  }
+};
+
+export const merchandiseReportFilterOptions =
+  async (): Promise<MerchandiseReportFilterOptionsResult | void> => {
+    try {
+      const response: AxiosResponse<MerchandiseReportFilterOptionsResult> =
+        await axios.get(`${backendConnection()}/api/reports/filter-options`, {
+          headers: createHeaders(),
+        });
+      return response.data;
+    } catch (error) {
+      handleApiError(error, false);
+    }
+  };
+
+export const exportMerchandiseReports = async (
+  params: Omit<MerchandiseReportsParams, "page" | "limit"> = {}
+): Promise<Blob | void> => {
+  try {
+    const response: AxiosResponse<Blob> = await axios.get(
+      `${backendConnection()}/api/reports/export`,
+      {
+        headers: createHeaders(),
+        params,
+        responseType: "blob",
       }
     );
     return response.data;

--- a/client-side-ts/src/features/admin/reports/components/ReportsView.tsx
+++ b/client-side-ts/src/features/admin/reports/components/ReportsView.tsx
@@ -6,18 +6,10 @@ import {
   Package,
   Search,
   ShoppingBag,
-  Trash2,
   Wallet,
   X,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -42,6 +34,7 @@ import {
 import { downloadCsv } from "../utils/exportCsv";
 import type {
   MerchandiseOrderDetail,
+  MerchandiseReportProductOption,
   ReportsFilters,
 } from "../types/reports.types";
 
@@ -65,24 +58,24 @@ const formatDate = (value: string | Date) => {
 interface ReportsFilterPopoverProps {
   activeTab: "membership" | "merchandise";
   filters: ReportsFilters;
-  uniqueProductNames: string[];
-  getBatchesForProduct: (productName: string) => string[];
+  productOptions: MerchandiseReportProductOption[];
   onApply: (filters: ReportsFilters) => void;
 }
 
 const ReportsFilterPopover = ({
   activeTab,
   filters,
-  uniqueProductNames,
-  getBatchesForProduct,
+  productOptions,
   onApply,
 }: ReportsFilterPopoverProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [draft, setDraft] = useState(filters);
 
   const batchOptions = useMemo(
-    () => getBatchesForProduct(draft.productName),
-    [draft.productName, getBatchesForProduct]
+    () =>
+      productOptions.find((option) => option.productId === draft.productId)
+        ?.batches ?? [],
+    [draft.productId, productOptions]
   );
 
   const hasActiveFilters = Object.values(filters).some(Boolean);
@@ -195,10 +188,13 @@ const ReportsFilterPopover = ({
                     Product
                   </Label>
                   <Select
-                    value={draft.productName}
+                    value={draft.productId || "all"}
                     onValueChange={(v) => {
-                      update("productName", v);
-                      setDraft((current) => ({ ...current, batch: "" }));
+                      setDraft((current) => ({
+                        ...current,
+                        productId: v === "all" ? "" : v,
+                        batch: "",
+                      }));
                     }}
                   >
                     <SelectTrigger className="h-9 w-full rounded-lg border-[#ececec]">
@@ -206,9 +202,12 @@ const ReportsFilterPopover = ({
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="all">All products</SelectItem>
-                      {uniqueProductNames.map((name) => (
-                        <SelectItem key={name} value={name}>
-                          {name}
+                      {productOptions.map((option) => (
+                        <SelectItem
+                          key={option.productId}
+                          value={option.productId}
+                        >
+                          {option.productName}
                         </SelectItem>
                       ))}
                     </SelectContent>
@@ -234,19 +233,22 @@ const ReportsFilterPopover = ({
                     </SelectContent>
                   </Select>
                 </div>
-                {draft.productName && (
+                {draft.productId && (
                   <div>
                     <Label className="mb-1.5 block text-xs font-medium">
                       Batch
                     </Label>
                     <Select
-                      value={draft.batch}
-                      onValueChange={(v) => update("batch", v)}
+                      value={draft.batch || "all"}
+                      onValueChange={(v) =>
+                        update("batch", v === "all" ? "" : v)
+                      }
                     >
                       <SelectTrigger className="h-9 w-full rounded-lg border-[#ececec]">
                         <SelectValue placeholder="All batches" />
                       </SelectTrigger>
                       <SelectContent>
+                        <SelectItem value="all">All batches</SelectItem>
                         {batchOptions.map((batch) => (
                           <SelectItem key={batch} value={batch}>
                             {batch}
@@ -467,31 +469,22 @@ export const ReportsView = () => {
     totalMerchandiseRows,
     membershipSummary,
     merchandiseSummary,
-    uniqueProductNames,
-    getBatchesForProduct,
-    canDeleteReports,
-    isMutating,
-    deleteMerchandiseReportItem,
+    merchandiseProductOptions,
+    isExporting,
     buildMembershipExportRows,
-    buildMerchandiseExportRows,
+    exportMerchandiseReport,
     refetchMembership,
     refetchMerchandise,
   } = useReportsData();
 
-  const [deleteTarget, setDeleteTarget] =
-    useState<MerchandiseOrderDetail | null>(null);
-
   const isMembership = activeTab === "membership";
   const status = isMembership ? membershipStatus : merchandiseStatus;
 
-  const handleExport = () => {
+  const handleExport = async () => {
     if (isMembership) {
       downloadCsv(buildMembershipExportRows(), "membership-report.csv");
     } else {
-      downloadCsv(
-        buildMerchandiseExportRows(),
-        `merchandise-report-${new Date().toISOString().slice(0, 10)}.csv`
-      );
+      await exportMerchandiseReport();
     }
   };
 
@@ -616,8 +609,7 @@ export const ReportsView = () => {
               <ReportsFilterPopover
                 activeTab={activeTab}
                 filters={filters}
-                uniqueProductNames={uniqueProductNames}
-                getBatchesForProduct={getBatchesForProduct}
+                productOptions={merchandiseProductOptions}
                 onApply={setFilters}
               />
               <Button
@@ -625,11 +617,13 @@ export const ReportsView = () => {
                 variant="outline"
                 className="h-9 shrink-0 rounded-full border-[#e8e8e8] px-3 sm:px-4"
                 onClick={handleExport}
-                disabled={status !== "success"}
+                disabled={status !== "success" || isExporting}
                 aria-label="Export CSV"
               >
                 <Download className="h-4 w-4" />
-                <span className="hidden sm:inline">Export CSV</span>
+                <span className="hidden sm:inline">
+                  {isExporting ? "Exporting..." : "Export CSV"}
+                </span>
               </Button>
             </div>
           </div>
@@ -645,8 +639,6 @@ export const ReportsView = () => {
               rows={pagedMerchandise}
               isLoading={status === "loading"}
               hasError={status === "error"}
-              canDelete={canDeleteReports}
-              onRequestDelete={setDeleteTarget}
             />
           )}
 
@@ -658,46 +650,6 @@ export const ReportsView = () => {
           />
         </section>
       </div>
-
-      <Dialog
-        open={Boolean(deleteTarget)}
-        onOpenChange={(open) => !open && setDeleteTarget(null)}
-      >
-        <DialogContent className="max-w-sm rounded-[20px]">
-          <DialogHeader>
-            <DialogTitle>Delete this report entry?</DialogTitle>
-          </DialogHeader>
-          <p className="text-sm text-[#777]">
-            This removes{" "}
-            <span className="font-medium">{deleteTarget?.product_name}</span>{" "}
-            from{" "}
-            <span className="font-medium">{deleteTarget?.student_name}</span>'s
-            order record. This cannot be undone.
-          </p>
-          <DialogFooter className="mt-3">
-            <Button
-              type="button"
-              variant="outline"
-              className="rounded-full"
-              onClick={() => setDeleteTarget(null)}
-            >
-              Cancel
-            </Button>
-            <Button
-              type="button"
-              disabled={isMutating}
-              className="rounded-full bg-red-500 hover:bg-red-600"
-              onClick={async () => {
-                if (!deleteTarget) return;
-                const success = await deleteMerchandiseReportItem(deleteTarget);
-                if (success) setDeleteTarget(null);
-              }}
-            >
-              Delete
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </div>
   );
 };
@@ -784,45 +736,41 @@ const MembershipTable = ({
 const MerchandiseTable = ({
   rows,
   isLoading,
-  canDelete,
-  onRequestDelete,
   hasError,
 }: {
   rows: MerchandiseOrderDetail[];
   isLoading: boolean;
-  canDelete: boolean;
   hasError: boolean;
-  onRequestDelete: (detail: MerchandiseOrderDetail) => void;
 }) => (
   <div className="overflow-x-auto">
-    <table className="w-full min-w-[980px] table-fixed border-collapse text-sm">
+    <table className="w-full min-w-[1080px] table-fixed border-collapse text-sm">
       <thead>
         <tr className="rounded-md bg-[#efefef] text-[#2f2f2f]">
-          <th className="w-[13%] rounded-l-md px-2 py-2 text-left font-medium">
+          <th className="w-[12%] rounded-l-md px-2 py-2 text-left font-medium">
             Reference Code
           </th>
-          <th className="w-[16%] px-2 py-2 text-left font-medium">Product</th>
-          <th className="w-[12%] px-2 py-2 text-left font-medium">
+          <th className="w-[15%] px-2 py-2 text-left font-medium">Product</th>
+          <th className="w-[7%] px-2 py-2 text-left font-medium">Batch</th>
+          <th className="w-[11%] px-2 py-2 text-left font-medium">
             Student ID
           </th>
-          <th className="w-[15%] px-2 py-2 text-left font-medium">Name</th>
+          <th className="w-[14%] px-2 py-2 text-left font-medium">Name</th>
           <th className="w-[10%] px-2 py-2 text-left font-medium">
             Course &amp; Year
           </th>
-          <th className="w-[8%] px-2 py-2 text-left font-medium">Size</th>
+          <th className="w-[7%] px-2 py-2 text-left font-medium">Size</th>
           <th className="w-[8%] px-2 py-2 text-left font-medium">Color</th>
           <th className="w-[6%] px-2 py-2 text-right font-medium">Qty</th>
-          <th className="w-[8%] px-2 py-2 text-right font-medium">Total</th>
-          <th
-            className={cn("px-2 py-2 text-right", canDelete ? "w-[8%]" : "w-4")}
-          />
+          <th className="w-[10%] rounded-r-md px-2 py-2 text-right font-medium">
+            Total
+          </th>
         </tr>
       </thead>
       <tbody>
         {isLoading ? (
           Array.from({ length: 8 }, (_, index) => (
             <tr key={index} className="border-b border-[#ededed]">
-              {Array.from({ length: canDelete ? 10 : 9 }, (_, cell) => (
+              {Array.from({ length: 10 }, (_, cell) => (
                 <td key={cell} className="px-2 py-3">
                   <Skeleton className="h-4 w-full rounded-full" />
                 </td>
@@ -837,6 +785,7 @@ const MerchandiseTable = ({
             >
               <td className="truncate px-2 py-3">{detail.reference_code}</td>
               <td className="truncate px-2 py-3">{detail.product_name}</td>
+              <td className="px-2 py-3">{detail.batch || "-"}</td>
               <td className="px-2 py-3">{detail.id_number}</td>
               <td className="truncate px-2 py-3">{detail.student_name}</td>
               <td className="px-2 py-3">
@@ -854,26 +803,12 @@ const MerchandiseTable = ({
               <td className="px-2 py-3 text-right font-medium">
                 {formatCurrency(detail.total || 0)}
               </td>
-              {canDelete && (
-                <td className="px-2 py-3 text-right">
-                  <Button
-                    type="button"
-                    size="icon-sm"
-                    variant="ghost"
-                    className="h-7 w-7 rounded-full text-red-500 hover:bg-red-50"
-                    title="Delete this report entry"
-                    onClick={() => onRequestDelete(detail)}
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
-                </td>
-              )}
             </tr>
           ))
         ) : (
           <tr>
             <td
-              colSpan={canDelete ? 10 : 9}
+              colSpan={10}
               className="px-3 py-16 text-center text-sm text-[#777]"
             >
               No merchandise records found.

--- a/client-side-ts/src/features/admin/reports/hooks/useReportsData.ts
+++ b/client-side-ts/src/features/admin/reports/hooks/useReportsData.ts
@@ -1,16 +1,15 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
-  deleteReports,
+  exportMerchandiseReports,
   membershipHistory,
+  merchandiseReportFilterOptions,
   merchandiseReports,
 } from "@/features/admin/api/admin";
-import { useAuth } from "@/features/auth";
-import { normalizeCampus } from "@/features/auth/utils/campus";
 import { showToast } from "@/utils/alertHelper";
-import { PSITS_ROLES } from "../../constants/adminAccess";
 import type {
   MembershipReportRow,
   MerchandiseOrderDetail,
+  MerchandiseReportProductOption,
   ReportsFilters,
   ReportsStatus,
   ReportsTab,
@@ -27,7 +26,7 @@ export const DEFAULT_FILTERS: ReportsFilters = {
   course: "",
   year: "",
   type: "",
-  productName: "",
+  productId: "",
   batch: "",
   size: "",
   color: "",
@@ -56,8 +55,8 @@ const flattenVariantField = (value: unknown): string[] => {
 };
 
 export const useReportsData = () => {
-  const { user } = useAuth();
-  const [activeTab, setActiveTab] = useState<ReportsTab>("membership");
+  const [activeTab, setActiveTabState] = useState<ReportsTab>("membership");
+  const [page, setPage] = useState(1);
 
   const [membershipData, setMembershipData] = useState<MembershipReportRow[]>(
     []
@@ -70,8 +69,8 @@ export const useReportsData = () => {
   >([]);
   const [merchandiseTotal, setMerchandiseTotal] = useState(0);
   const [merchandiseTotalPages, setMerchandiseTotalPages] = useState(1);
-  const [merchandiseProductNames, setMerchandiseProductNames] = useState<
-    string[]
+  const [merchandiseProductOptions, setMerchandiseProductOptions] = useState<
+    MerchandiseReportProductOption[]
   >([]);
   const [merchandiseSummary, setMerchandiseSummary] = useState({
     unitsSold: 0,
@@ -80,8 +79,8 @@ export const useReportsData = () => {
   const [merchandiseStatus, setMerchandiseStatus] =
     useState<ReportsStatus>("idle");
 
-  const [filters, setFilters] = useState<ReportsFilters>(DEFAULT_FILTERS);
-  const [search, setSearch] = useState("");
+  const [filters, setFiltersState] = useState<ReportsFilters>(DEFAULT_FILTERS);
+  const [search, setSearchState] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
 
   useEffect(() => {
@@ -92,18 +91,27 @@ export const useReportsData = () => {
     return () => clearTimeout(timer);
   }, [search]);
 
-  const [page, setPage] = useState(1);
-  const [isMutating, setIsMutating] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
   const membershipRequestRef = useRef(0);
   const merchandiseRequestRef = useRef(0);
+  const merchandiseOverviewRequestRef = useRef(0);
+  const merchandiseOptionsRequestedRef = useRef(false);
+  const merchandiseViewRequestedRef = useRef(false);
 
-  const isUcMainAdmin =
-    user?.role === "admin" && normalizeCampus(user.campus) === "UC_MAIN";
+  const setActiveTab = useCallback((value: ReportsTab) => {
+    setActiveTabState(value);
+    setPage(1);
+  }, []);
 
-  const canDeleteReports =
-    isUcMainAdmin &&
-    (user?.access === PSITS_ROLES.ADMIN ||
-      user?.access === PSITS_ROLES.FINANCE);
+  const setFilters = useCallback((value: ReportsFilters) => {
+    setFiltersState(value);
+    setPage(1);
+  }, []);
+
+  const setSearch = useCallback((value: string) => {
+    setSearchState(value);
+    setPage(1);
+  }, []);
 
   const fetchMembership = useCallback(async () => {
     const requestId = ++membershipRequestRef.current;
@@ -121,27 +129,43 @@ export const useReportsData = () => {
     }
   }, []);
 
+  const merchandiseQuery = useMemo(
+    () => ({
+      search: debouncedSearch,
+      studentId: filters.id,
+      rfid: filters.rfid,
+      name: filters.name,
+      course: filters.course,
+      year: filters.year,
+      productId: filters.productId,
+      batch: filters.batch,
+      size: filters.size,
+      color: filters.color,
+      dateFrom: filters.dateFrom,
+      dateTo: filters.dateTo,
+    }),
+    [debouncedSearch, filters]
+  );
+
   const fetchMerchandise = useCallback(
     async (requestedPage: number) => {
+      merchandiseViewRequestedRef.current = true;
       const requestId = ++merchandiseRequestRef.current;
       setMerchandiseStatus("loading");
+
+      if (!merchandiseOptionsRequestedRef.current) {
+        merchandiseOptionsRequestedRef.current = true;
+        void merchandiseReportFilterOptions().then((result) => {
+          setMerchandiseProductOptions(result?.products ?? []);
+        });
+      }
+
       try {
         const result = await merchandiseReports({
           page: requestedPage,
           limit: ROWS_PER_PAGE,
-          search: debouncedSearch,
-          studentId: filters.id,
-          name: filters.name,
-          course: filters.course,
-          year: filters.year,
-          productName: filters.productName,
-          size: filters.size,
-          color: filters.color,
-          dateFrom: filters.dateFrom,
-          dateTo: filters.dateTo,
+          ...merchandiseQuery,
         });
-
-        
 
         if (requestId !== merchandiseRequestRef.current) return;
         if (!result) throw new Error("No merchandise reports returned");
@@ -155,7 +179,6 @@ export const useReportsData = () => {
         setMerchandiseDetails(details.filter(Boolean));
         setMerchandiseTotal(result.total);
         setMerchandiseTotalPages(result.totalPages);
-        setMerchandiseProductNames(result.productNames ?? []);
         setMerchandiseSummary(
           result.summary ?? { unitsSold: 0, totalRevenue: 0 }
         );
@@ -165,21 +188,46 @@ export const useReportsData = () => {
         setMerchandiseDetails([]);
         setMerchandiseTotal(0);
         setMerchandiseTotalPages(1);
-        setMerchandiseProductNames([]);
         setMerchandiseSummary({ unitsSold: 0, totalRevenue: 0 });
         setMerchandiseStatus("error");
       }
     },
-    [debouncedSearch, filters]
+    [merchandiseQuery]
   );
 
+  const preloadMerchandiseOverview = useCallback(async () => {
+    const requestId = ++merchandiseOverviewRequestRef.current;
+
+    try {
+      const result = await merchandiseReports({ page: 1, limit: 1 });
+      if (
+        requestId !== merchandiseOverviewRequestRef.current ||
+        merchandiseViewRequestedRef.current ||
+        !result
+      ) {
+        return;
+      }
+
+      setMerchandiseTotal(result.total);
+      setMerchandiseSummary(
+        result.summary ?? { unitsSold: 0, totalRevenue: 0 }
+      );
+    } catch {
+      // The merchandise tab retains its normal retry behavior if this preload fails.
+    }
+  }, []);
+
   useEffect(() => {
-    if (activeTab === "membership" && membershipStatus === "idle") {
-      fetchMembership();
-    }
-    if (activeTab === "merchandise") {
-      fetchMerchandise(page);
-    }
+    const timer = window.setTimeout(() => {
+      if (activeTab === "membership" && membershipStatus === "idle") {
+        void fetchMembership();
+      }
+      if (activeTab === "merchandise") {
+        void fetchMerchandise(page);
+      }
+    }, 0);
+
+    return () => window.clearTimeout(timer);
   }, [
     activeTab,
     page,
@@ -191,25 +239,12 @@ export const useReportsData = () => {
   ]);
 
   useEffect(() => {
-    setPage(1);
-  }, [activeTab, filters, search]);
+    const timer = window.setTimeout(() => {
+      void preloadMerchandiseOverview();
+    }, 0);
 
-  const uniqueProductNames = merchandiseProductNames;
-
-  const getBatchesForProduct = useCallback(
-    (productName: string): string[] => {
-      if (!productName) return [];
-      return Array.from(
-        new Set(
-          merchandiseDetails
-            .filter((detail) => detail.product_name === productName)
-            .map((detail) => detail.batch)
-            .filter((batch): batch is string => Boolean(batch))
-        )
-      );
-    },
-    [merchandiseDetails]
-  );
+    return () => window.clearTimeout(timer);
+  }, [preloadMerchandiseOverview]);
 
   const filteredMembership = useMemo(() => {
     if (activeTab !== "membership") return EMPTY_MEMBERSHIP_ROWS;
@@ -280,28 +315,6 @@ export const useReportsData = () => {
     [membershipData.length, merchandiseTotal]
   );
 
-  const deleteMerchandiseReportItem = async (
-    detail: MerchandiseOrderDetail
-  ): Promise<boolean> => {
-    if (!canDeleteReports) {
-      showToast("error", "Unauthorized.");
-      return false;
-    }
-
-    setIsMutating(true);
-    try {
-      const success = await deleteReports(
-        detail.product_id,
-        detail._id,
-        detail.product_name
-      );
-      if (success) await fetchMerchandise(page);
-      return success;
-    } finally {
-      setIsMutating(false);
-    }
-  };
-
   const buildMembershipExportRows = () =>
     filteredMembership.map((row) => ({
       "Reference Code": row.reference_code,
@@ -314,21 +327,26 @@ export const useReportsData = () => {
       "Approved By": row.admin || "",
     }));
 
-  const buildMerchandiseExportRows = () =>
-    merchandiseDetails.map((detail) => ({
-      "Reference Code": detail.reference_code,
-      Merchandise: detail.product_name,
-      "Student ID": detail.id_number,
-      Name: detail.student_name,
-      Course: detail.course,
-      "Year Level": detail.year,
-      Batch: detail.batch || "",
-      Size: detail.size.join(", "),
-      Variation: detail.variation.join(", "),
-      Qty: detail.quantity,
-      Total: detail.total,
-      "Transaction Date": toDateKey(detail.transaction_date),
-    }));
+  const exportMerchandiseReport = async () => {
+    setIsExporting(true);
+    try {
+      const blob = await exportMerchandiseReports(merchandiseQuery);
+      if (!blob) throw new Error("No merchandise report export returned");
+
+      const url = window.URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = `merchandise-report-${new Date().toISOString().slice(0, 10)}.csv`;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      window.URL.revokeObjectURL(url);
+    } catch {
+      showToast("error", "Unable to export the merchandise report.");
+    } finally {
+      setIsExporting(false);
+    }
+  };
 
   return {
     activeTab,
@@ -349,13 +367,10 @@ export const useReportsData = () => {
     totalMerchandiseRows: merchandiseTotal,
     membershipSummary,
     merchandiseSummary,
-    uniqueProductNames,
-    getBatchesForProduct,
-    canDeleteReports,
-    isMutating,
-    deleteMerchandiseReportItem,
+    merchandiseProductOptions,
+    isExporting,
     buildMembershipExportRows,
-    buildMerchandiseExportRows,
+    exportMerchandiseReport,
     refetchMembership: fetchMembership,
     refetchMerchandise: () => fetchMerchandise(page),
   };

--- a/client-side-ts/src/features/admin/reports/types/reports.types.ts
+++ b/client-side-ts/src/features/admin/reports/types/reports.types.ts
@@ -43,6 +43,12 @@ export interface MerchandiseSalesSummary {
   totalRevenue: number;
 }
 
+export interface MerchandiseReportProductOption {
+  productId: string;
+  productName: string;
+  batches: string[];
+}
+
 export interface ReportsFilters {
   id: string;
   name: string;
@@ -50,7 +56,7 @@ export interface ReportsFilters {
   course: string;
   year: string;
   type: string;
-  productName: string;
+  productId: string;
   batch: string;
   size: string;
   color: string;

--- a/server-side/src/controllers/report.v2.controller.ts
+++ b/server-side/src/controllers/report.v2.controller.ts
@@ -1,6 +1,65 @@
-import { reportService } from "../services/report.service";
+import {
+  reportService,
+  type MerchandiseReportFilters,
+  type MerchandiseReportRow,
+} from "../services/report.service";
 import { catchAsync } from "../util/catch.async.util";
 import { Request, Response } from "express";
+
+const getFiltersFromQuery = (req: Request): MerchandiseReportFilters => ({
+  search: req.query.search as string,
+  referenceCode: req.query.referenceCode as string,
+  studentId: req.query.studentId as string,
+  rfid: req.query.rfid as string,
+  name: req.query.name as string,
+  course: req.query.course as string,
+  year: req.query.year as string,
+  productId: req.query.productId as string,
+  productName: req.query.productName as string,
+  batch: req.query.batch as string,
+  size: req.query.size as string,
+  color: req.query.color as string,
+  dateFrom: req.query.dateFrom as string,
+  dateTo: req.query.dateTo as string,
+});
+
+const escapeCsvCell = (value: unknown) => {
+  const stringValue = Array.isArray(value)
+    ? value.join(", ")
+    : value instanceof Date
+      ? value.toISOString()
+      : String(value ?? "");
+  const safeValue =
+    typeof value === "string" && /^[=+\-@]/.test(stringValue)
+      ? `'${stringValue}`
+      : stringValue;
+  return `"${safeValue.replace(/"/g, '""')}"`;
+};
+
+const toCsv = (rows: MerchandiseReportRow[]) => {
+  const columns: Array<[string, (row: MerchandiseReportRow) => unknown]> = [
+    ["Reference Code", (row) => row.reference_code],
+    ["Product", (row) => row.product_name],
+    ["Batch", (row) => row.batch],
+    ["Student ID", (row) => row.id_number],
+    ["RFID", (row) => row.rfid],
+    ["Name", (row) => row.student_name],
+    ["Course", (row) => row.course],
+    ["Year Level", (row) => row.year],
+    ["Size", (row) => row.size],
+    ["Color", (row) => row.variation],
+    ["Quantity", (row) => row.quantity],
+    ["Total", (row) => row.total],
+    ["Transaction Date", (row) => row.transaction_date],
+  ];
+
+  return [
+    columns.map(([heading]) => escapeCsvCell(heading)).join(","),
+    ...rows.map((row) =>
+      columns.map(([, getValue]) => escapeCsvCell(getValue(row))).join(",")
+    ),
+  ].join("\n");
+};
 
 class ReportController {
   fetchReport = catchAsync(async (req: Request, res: Response) => {
@@ -9,17 +68,7 @@ class ReportController {
     const result = await reportService.getMerchandiseReport({
       page,
       limit,
-      search: req.query.search as string,
-      referenceCode: req.query.referenceCode as string,
-      studentId: req.query.studentId as string,
-      name: req.query.name as string,
-      course: req.query.course as string,
-      year: req.query.year as string,
-      productName: req.query.productName as string,
-      size: req.query.size as string,
-      color: req.query.color as string,
-      dateFrom: req.query.dateFrom as string,
-      dateTo: req.query.dateTo as string,
+      ...getFiltersFromQuery(req),
     });
     return res.status(200).json({
       message: "Successfully retrieved merchandise reports",
@@ -29,8 +78,29 @@ class ReportController {
       limit: result.limit,
       totalPages: result.totalPages,
       summary: result.summary,
-      productNames: result.productNames,
     });
+  });
+
+  fetchFilterOptions = catchAsync(async (_req: Request, res: Response) => {
+    const products = await reportService.getMerchandiseReportFilterOptions();
+    return res.status(200).json({
+      message: "Successfully retrieved merchandise report filter options",
+      products,
+    });
+  });
+
+  exportReport = catchAsync(async (req: Request, res: Response) => {
+    const rows = await reportService.getMerchandiseReportExportRows(
+      getFiltersFromQuery(req)
+    );
+    const date = new Date().toISOString().slice(0, 10);
+
+    res.setHeader("Content-Type", "text/csv; charset=utf-8");
+    res.setHeader(
+      "Content-Disposition",
+      `attachment; filename="merchandise-report-${date}.csv"`
+    );
+    return res.status(200).send(`\uFEFF${toCsv(rows)}`);
   });
 }
 

--- a/server-side/src/models/orders.model.ts
+++ b/server-side/src/models/orders.model.ts
@@ -68,4 +68,7 @@ const orderSchema = new Schema<IOrdersDocument>({
   },
 });
 
+orderSchema.index({ order_status: 1, transaction_date: -1 });
+orderSchema.index({ order_status: 1, "items.product_id": 1 });
+
 export const Orders = mongoose.model<IOrdersDocument>("Orders", orderSchema);

--- a/server-side/src/routes/report.v2.route.ts
+++ b/server-side/src/routes/report.v2.route.ts
@@ -9,7 +9,20 @@ dotenv.config();
 
 const router = Router();
 
-//Fetch reports
+router.get(
+  "/filter-options",
+  requireAccessTokenWithDBCheck,
+  roleAuthenticateV2(["admin"]),
+  reportController.fetchFilterOptions
+);
+
+router.get(
+  "/export",
+  requireAccessTokenWithDBCheck,
+  roleAuthenticateV2(["admin"]),
+  reportController.exportReport
+);
+
 router.get(
   "/",
   requireAccessTokenWithDBCheck,

--- a/server-side/src/services/report.service.ts
+++ b/server-side/src/services/report.service.ts
@@ -1,12 +1,22 @@
-import { isValidObjectId, type ClientSession } from "mongoose";
+import {
+  isValidObjectId,
+  Types,
+  type ClientSession,
+  type PipelineStage,
+} from "mongoose";
+import { Orders } from "../models/orders.model";
 import { Report } from "../models/report.model";
 import { IOrdersItems } from "../models/orders.interface";
 
 export interface MerchandiseReportRow {
   _id: string;
+  order_id: string;
+  product_id: string;
   reference_code: string;
   product_name: string;
+  batch: string;
   id_number: string;
+  rfid: string;
   student_name: string;
   course: string;
   year: string;
@@ -14,6 +24,7 @@ export interface MerchandiseReportRow {
   variation: unknown;
   quantity: number;
   total: number;
+  transaction_date: Date;
   date: Date;
 }
 
@@ -21,10 +32,13 @@ export interface MerchandiseReportFilters {
   search?: string;
   referenceCode?: string;
   studentId?: string;
+  rfid?: string;
   name?: string;
   course?: string;
   year?: string;
+  productId?: string;
   productName?: string;
+  batch?: string;
   size?: string;
   color?: string;
   dateFrom?: string;
@@ -39,6 +53,12 @@ export interface MerchandiseReportQuery extends MerchandiseReportFilters {
 export interface MerchandiseReportSummary {
   unitsSold: number;
   totalRevenue: number;
+}
+
+export interface MerchandiseReportProductOption {
+  productId: string;
+  productName: string;
+  batches: string[];
 }
 
 export interface CreateReportInput {
@@ -70,7 +90,6 @@ export interface MerchandiseReportResult {
   limit: number;
   totalPages: number;
   summary: MerchandiseReportSummary;
-  productNames: string[];
 }
 
 const normalizePage = (value?: number) => {
@@ -80,7 +99,7 @@ const normalizePage = (value?: number) => {
 
 const normalizeLimit = (value?: number) => {
   if (!value || Number.isNaN(value)) return 10;
-  return Math.max(1, Math.floor(value));
+  return Math.min(100, Math.max(1, Math.floor(value)));
 };
 
 const toLowerTrim = (value: unknown): string => {
@@ -88,238 +107,323 @@ const toLowerTrim = (value: unknown): string => {
   return String(value).trim().toLowerCase();
 };
 
-const buildBasePipeline = (filters: MerchandiseReportFilters) => {
-  const matchConditions: Record<string, any>[] = [];
+const escapeRegex = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
-  if (filters.search) {
-    const q = filters.search.trim();
+const containsMatch = (value: string) => ({
+  $regex: escapeRegex(value.trim()),
+  $options: "i",
+});
+
+const exactMatch = (value: string) => ({
+  $regex: `^${escapeRegex(value.trim())}$`,
+  $options: "i",
+});
+
+const parseDateBoundary = (
+  value: string | undefined,
+  endExclusive: boolean
+) => {
+  if (!value) return null;
+  const date = new Date(`${value}T00:00:00.000Z`);
+  if (Number.isNaN(date.getTime())) return null;
+  if (endExclusive) date.setUTCDate(date.getUTCDate() + 1);
+  return date;
+};
+
+const buildPaidOrderItemPipeline = (
+  filters: MerchandiseReportFilters = {}
+): PipelineStage[] => {
+  const matchConditions: Record<string, unknown>[] = [];
+  const orderMatch: Record<string, unknown> = { order_status: "Paid" };
+
+  if (filters.productId?.trim() && isValidObjectId(filters.productId)) {
+    orderMatch["items.product_id"] = new Types.ObjectId(filters.productId);
+  }
+
+  if (filters.search?.trim()) {
+    const query = containsMatch(filters.search);
     matchConditions.push({
       $or: [
-        { effective_id_number: { $regex: q, $options: "i" } },
-        { effective_reference_code: { $regex: q, $options: "i" } },
-        { effective_student_name: { $regex: q, $options: "i" } },
-        { "merch.name": { $regex: q, $options: "i" } },
+        { id_number: query },
+        { rfid: query },
+        { reference_code: query },
+        { student_name: query },
+        { "items.product_name": query },
       ],
     });
   }
 
-  if (filters.referenceCode) {
+  if (filters.referenceCode?.trim()) {
     matchConditions.push({
-      effective_reference_code: {
-        $regex: filters.referenceCode.trim(),
-        $options: "i",
-      },
+      reference_code: containsMatch(filters.referenceCode),
     });
   }
-
-  if (filters.studentId) {
+  if (filters.studentId?.trim()) {
+    matchConditions.push({ id_number: containsMatch(filters.studentId) });
+  }
+  if (filters.rfid?.trim()) {
+    matchConditions.push({ rfid: containsMatch(filters.rfid) });
+  }
+  if (filters.name?.trim()) {
+    matchConditions.push({ student_name: containsMatch(filters.name) });
+  }
+  if (filters.course?.trim()) {
+    matchConditions.push({ course: exactMatch(filters.course) });
+  }
+  if (filters.year?.trim()) {
+    const year = Number(filters.year);
+    if (Number.isFinite(year)) matchConditions.push({ year });
+  }
+  if (filters.productId?.trim()) {
+    matchConditions.push({ report_product_id: filters.productId.trim() });
+  }
+  if (filters.productName?.trim()) {
     matchConditions.push({
-      effective_id_number: { $regex: filters.studentId.trim(), $options: "i" },
+      "items.product_name": exactMatch(filters.productName),
     });
   }
-
-  if (filters.course) {
-    matchConditions.push({
-      effective_course: { $regex: filters.course.trim(), $options: "i" },
-    });
+  if (filters.batch?.trim()) {
+    matchConditions.push({ report_batch: filters.batch.trim() });
+  }
+  if (filters.size?.trim()) {
+    matchConditions.push({ "items.sizes": exactMatch(filters.size) });
+  }
+  if (filters.color?.trim()) {
+    matchConditions.push({ "items.variation": exactMatch(filters.color) });
   }
 
-  if (filters.year) {
-    matchConditions.push({ effective_year: Number(filters.year) });
+  const dateFrom = parseDateBoundary(filters.dateFrom, false);
+  const dateTo = parseDateBoundary(filters.dateTo, true);
+  if (dateFrom || dateTo) {
+    const dateMatch: Record<string, Date> = {};
+    if (dateFrom) dateMatch.$gte = dateFrom;
+    if (dateTo) dateMatch.$lt = dateTo;
+    matchConditions.push({ report_transaction_date: dateMatch });
   }
 
-  if (filters.dateFrom || filters.dateTo) {
-    const dateFilter: Record<string, any> = {};
-    if (filters.dateFrom) dateFilter.$gte = new Date(filters.dateFrom);
-    if (filters.dateTo) dateFilter.$lte = new Date(filters.dateTo);
-    matchConditions.push({ date: dateFilter });
-  }
-
-  const pipeline: any[] = [
-    {
-      $lookup: {
-        from: "orders",
-        localField: "order_id",
-        foreignField: "_id",
-        as: "order",
-      },
-    },
-    { $unwind: { path: "$order", preserveNullAndEmptyArrays: true } },
-    {
-      $lookup: {
-        from: "merches",
-        localField: "merch_id",
-        foreignField: "_id",
-        as: "merch",
-      },
-    },
-    { $unwind: { path: "$merch", preserveNullAndEmptyArrays: true } },
+  return [
+    { $match: orderMatch },
+    { $unwind: "$items" },
     {
       $addFields: {
-        effective_id_number: {
-          $cond: {
-            if: { $gt: [{ $ifNull: ["$order.id_number", ""] }, ""] },
-            then: "$order.id_number",
-            else: "$id_number",
+        report_product_id: {
+          $convert: {
+            input: "$items.product_id",
+            to: "string",
+            onError: "",
+            onNull: "",
           },
         },
-        orderItem: {
-          $first: {
-            $filter: {
-              input: "$order.items",
-              as: "item",
-              cond: { $eq: ["$$item.product_id", "$merch._id"] },
+        report_item_id: {
+          $convert: {
+            input: "$items._id",
+            to: "string",
+            onError: "",
+            onNull: "",
+          },
+        },
+        report_batch: {
+          $trim: {
+            input: {
+              $convert: {
+                input: "$items.batch",
+                to: "string",
+                onError: "",
+                onNull: "",
+              },
             },
           },
         },
-        effective_reference_code: { $ifNull: ["$order.reference_code", ""] },
-        effective_student_name: { $ifNull: ["$order.student_name", ""] },
-        effective_course: { $ifNull: ["$order.course", ""] },
-        effective_year: { $ifNull: ["$order.year", null] },
+        report_transaction_date: {
+          $ifNull: ["$transaction_date", "$order_date"],
+        },
       },
     },
     ...(matchConditions.length > 0
       ? [{ $match: { $and: matchConditions } }]
       : []),
-    {
-      $project: {
-        _id: 1,
-        reference_code: "$effective_reference_code",
-        product_name: "$merch.name",
-        id_number: "$effective_id_number",
-        student_name: "$effective_student_name",
-        course: "$effective_course",
-        year: { $toString: "$effective_year" },
-        size: "$orderItem.sizes",
-        variation: "$orderItem.variation",
-        quantity: "$item_count",
-        total: "$total",
-        date: "$date",
-      },
-    },
-    { $sort: { date: -1 } },
   ];
-
-  return pipeline;
 };
 
-const applyPostMatchFilters = (
-  docs: any[],
-  filters: MerchandiseReportFilters
-) => {
-  return docs.filter((doc) => {
-    if (filters.name) {
-      const merchName = toLowerTrim(doc.product_name);
-      if (!merchName.includes(toLowerTrim(filters.name))) return false;
-    }
-    if (filters.productName) {
-      const productName = toLowerTrim(doc.product_name);
-      if (!productName.includes(toLowerTrim(filters.productName))) return false;
-    }
-    if (filters.size) {
-      const sizeVal = doc.size;
-      const sizeStr = Array.isArray(sizeVal)
-        ? sizeVal.join(" ")
-        : typeof sizeVal === "object" && sizeVal !== null
-          ? JSON.stringify(sizeVal)
-          : String(sizeVal ?? "");
-      if (!toLowerTrim(sizeStr).includes(toLowerTrim(filters.size)))
-        return false;
-    }
-    if (filters.color) {
-      const variationVal = doc.variation;
-      const variationStr = Array.isArray(variationVal)
-        ? variationVal.join(" ")
-        : typeof variationVal === "object" && variationVal !== null
-          ? JSON.stringify(variationVal)
-          : String(variationVal ?? "");
-      if (!toLowerTrim(variationStr).includes(toLowerTrim(filters.color)))
-        return false;
-    }
-    if (filters.referenceCode) {
-      const ref = toLowerTrim(doc.reference_code);
-      if (!ref.includes(toLowerTrim(filters.referenceCode))) return false;
-    }
-    return true;
-  });
+const rowProjection: PipelineStage.Project = {
+  $project: {
+    _id: {
+      $concat: [
+        { $toString: "$_id" },
+        ":",
+        {
+          $cond: [
+            { $ne: ["$report_item_id", ""] },
+            "$report_item_id",
+            "$report_product_id",
+          ],
+        },
+      ],
+    },
+    order_id: { $toString: "$_id" },
+    product_id: "$report_product_id",
+    reference_code: { $ifNull: ["$reference_code", "-"] },
+    product_name: { $ifNull: ["$items.product_name", "-"] },
+    batch: "$report_batch",
+    id_number: { $ifNull: ["$id_number", "-"] },
+    rfid: { $ifNull: ["$rfid", ""] },
+    student_name: { $ifNull: ["$student_name", "-"] },
+    course: { $ifNull: ["$course", "-"] },
+    year: {
+      $convert: { input: "$year", to: "string", onError: "-", onNull: "-" },
+    },
+    size: { $ifNull: ["$items.sizes", []] },
+    variation: { $ifNull: ["$items.variation", []] },
+    quantity: { $ifNull: ["$items.quantity", 0] },
+    total: { $ifNull: ["$items.sub_total", 0] },
+    transaction_date: "$report_transaction_date",
+    date: "$report_transaction_date",
+  },
 };
 
-const mapToRow = (doc: Record<string, unknown>): MerchandiseReportRow => ({
-  _id: String(doc._id),
-  reference_code: toLowerTrim(doc.reference_code)
-    ? String(doc.reference_code)
-    : "-",
-  product_name: toLowerTrim(doc.product_name) ? String(doc.product_name) : "-",
-  id_number: toLowerTrim(doc.id_number) ? String(doc.id_number) : "-",
-  student_name: toLowerTrim(doc.student_name) ? String(doc.student_name) : "-",
-  course: toLowerTrim(doc.course) ? String(doc.course) : "-",
-  year: doc.year != null ? String(doc.year) : "-",
-  size: doc.size ?? "-",
-  variation: doc.variation ?? "-",
-  quantity: Number(doc.quantity ?? 0),
-  total: Number(doc.total ?? 0),
-  date:
-    doc.date instanceof Date
-      ? doc.date
-      : new Date(doc.date as string | number | Date),
-});
+const rowSort: PipelineStage.Sort = {
+  $sort: {
+    report_transaction_date: -1,
+    _id: -1,
+    "items._id": 1,
+  },
+};
+
+const mapToRow = (doc: Record<string, unknown>): MerchandiseReportRow => {
+  const transactionDate =
+    doc.transaction_date instanceof Date
+      ? doc.transaction_date
+      : new Date(doc.transaction_date as string | number | Date);
+
+  return {
+    _id: String(doc._id),
+    order_id: String(doc.order_id ?? ""),
+    product_id: String(doc.product_id ?? ""),
+    reference_code: toLowerTrim(doc.reference_code)
+      ? String(doc.reference_code)
+      : "-",
+    product_name: toLowerTrim(doc.product_name)
+      ? String(doc.product_name)
+      : "-",
+    batch: String(doc.batch ?? ""),
+    id_number: toLowerTrim(doc.id_number) ? String(doc.id_number) : "-",
+    rfid: String(doc.rfid ?? ""),
+    student_name: toLowerTrim(doc.student_name)
+      ? String(doc.student_name)
+      : "-",
+    course: toLowerTrim(doc.course) ? String(doc.course) : "-",
+    year: doc.year != null ? String(doc.year) : "-",
+    size: doc.size ?? [],
+    variation: doc.variation ?? [],
+    quantity: Number(doc.quantity ?? 0),
+    total: Number(doc.total ?? 0),
+    transaction_date: transactionDate,
+    date: transactionDate,
+  };
+};
 
 export const getMerchandiseReport = async (
   params: MerchandiseReportQuery = {}
 ): Promise<MerchandiseReportResult> => {
   const page = normalizePage(params.page);
   const limit = normalizeLimit(params.limit);
-
-  const pipeline = buildBasePipeline(params);
-  const dbMatched = await Report.aggregate(pipeline);
-
-  const filteredResults = applyPostMatchFilters(dbMatched, params);
-  const rows = filteredResults.map(mapToRow);
-
-  const totalCount = rows.length;
-  const totalPages = Math.max(1, Math.ceil(totalCount / limit));
   const skip = (page - 1) * limit;
-  const pagedRows = rows.slice(skip, skip + limit);
 
-  const summary = rows.reduce(
-    (acc, row) => {
-      acc.unitsSold += row.quantity;
-      acc.totalRevenue += row.total;
-      return acc;
+  const [result] = await Orders.aggregate([
+    ...buildPaidOrderItemPipeline(params),
+    {
+      $facet: {
+        data: [rowSort, { $skip: skip }, { $limit: limit }, rowProjection],
+        metadata: [{ $count: "total" }],
+        summary: [
+          {
+            $group: {
+              _id: null,
+              unitsSold: { $sum: { $ifNull: ["$items.quantity", 0] } },
+              totalRevenue: { $sum: { $ifNull: ["$items.sub_total", 0] } },
+            },
+          },
+        ],
+      },
     },
-    { unitsSold: 0, totalRevenue: 0 }
-  );
+  ]);
 
-  const productNames = await getMerchandiseProductNames();
+  const rows = ((result?.data ?? []) as Record<string, unknown>[]).map(
+    mapToRow
+  );
+  const total = Number(result?.metadata?.[0]?.total ?? 0);
+  const summary = result?.summary?.[0] ?? {
+    unitsSold: 0,
+    totalRevenue: 0,
+  };
 
   return {
-    rows: pagedRows,
-    data: pagedRows,
-    total: totalCount,
+    rows,
+    data: rows,
+    total,
     page,
     limit,
-    totalPages,
-    summary,
-    productNames,
+    totalPages: Math.max(1, Math.ceil(total / limit)),
+    summary: {
+      unitsSold: Number(summary.unitsSold ?? 0),
+      totalRevenue: Number(summary.totalRevenue ?? 0),
+    },
   };
 };
 
-export const getMerchandiseProductNames = async (): Promise<string[]> => {
-  const names = await Report.aggregate([
+export const getMerchandiseReportFilterOptions = async (): Promise<
+  MerchandiseReportProductOption[]
+> => {
+  const options = await Orders.aggregate([
+    ...buildPaidOrderItemPipeline(),
     {
-      $lookup: {
-        from: "merches",
-        localField: "merch_id",
-        foreignField: "_id",
-        as: "merch",
+      $match: {
+        report_product_id: { $ne: "" },
+        "items.product_name": { $nin: [null, ""] },
       },
     },
-    { $unwind: { path: "$merch", preserveNullAndEmptyArrays: true } },
-    { $match: { "merch.name": { $ne: null } } },
-    { $group: { _id: "$merch.name" } },
-    { $sort: { _id: 1 } },
+    {
+      $group: {
+        _id: "$report_product_id",
+        productName: { $max: "$items.product_name" },
+        batches: { $addToSet: "$report_batch" },
+      },
+    },
+    {
+      $project: {
+        _id: 0,
+        productId: "$_id",
+        productName: 1,
+        batches: { $setDifference: ["$batches", [""]] },
+      },
+    },
+    { $sort: { productName: 1, productId: 1 } },
   ]);
-  return names.map((n) => n._id).filter(Boolean);
+
+  return options.map((option) => ({
+    productId: String(option.productId),
+    productName: String(option.productName),
+    batches: (option.batches as unknown[])
+      .map(String)
+      .sort((a, b) => a.localeCompare(b, undefined, { numeric: true })),
+  }));
+};
+
+export const getMerchandiseReportExportRows = async (
+  filters: MerchandiseReportFilters = {}
+): Promise<MerchandiseReportRow[]> => {
+  const rows = await Orders.aggregate([
+    ...buildPaidOrderItemPipeline(filters),
+    rowSort,
+    rowProjection,
+  ]);
+  return (rows as Record<string, unknown>[]).map(mapToRow);
+};
+
+export const getMerchandiseProductNames = async (): Promise<string[]> => {
+  const options = await getMerchandiseReportFilterOptions();
+  return Array.from(new Set(options.map((option) => option.productName)));
 };
 
 export const getMerchandiseReportById = async (reportId: string) => {
@@ -330,45 +434,63 @@ export const getMerchandiseReportById = async (reportId: string) => {
   const report = await Report.findById(reportId)
     .populate({
       path: "order_id",
-      select: "reference_code id_number student_name course year",
+      select:
+        "reference_code id_number rfid student_name course year transaction_date",
     })
     .populate({
       path: "merch_id",
-      select: "name selectedVariations",
+      select: "name batch selectedVariations",
     })
     .lean();
 
   if (!report) return null;
 
   const order = report.order_id as {
+    _id?: unknown;
     reference_code?: string;
     items?: IOrdersItems[];
     id_number?: string;
+    rfid?: string;
     student_name?: string;
     course?: string;
     year?: number;
+    transaction_date?: Date;
   } | null;
 
   const merch = report.merch_id as {
+    _id?: unknown;
     name?: string;
+    batch?: string;
     selectedSizes?: unknown;
     selectedVariations?: unknown;
   } | null;
+  const transactionDate = order?.transaction_date ?? report.date;
 
   return {
     _id: String(report._id),
+    order_id: String(order?._id ?? ""),
+    product_id: String(merch?._id ?? ""),
     reference_code: order?.reference_code || "-",
     product_name: merch?.name || "-",
+    batch: String(merch?.batch ?? ""),
     id_number: order?.id_number || report.id_number || "-",
+    rfid: order?.rfid || "",
     student_name: order?.student_name || "-",
     course: order?.course || "-",
     year: order?.year != null ? String(order.year) : "-",
-    size: order?.items ?? "-",
-    variation: merch?.selectedVariations ?? "-",
+    size: order?.items ?? [],
+    variation: merch?.selectedVariations ?? [],
     quantity: Number(report.item_count ?? 0),
     total: Number(report.total ?? 0),
-    date: report.date instanceof Date ? report.date : new Date(report.date),
-  } as MerchandiseReportRow;
+    transaction_date:
+      transactionDate instanceof Date
+        ? transactionDate
+        : new Date(transactionDate),
+    date:
+      transactionDate instanceof Date
+        ? transactionDate
+        : new Date(transactionDate),
+  } satisfies MerchandiseReportRow;
 };
 
 export const deleteMerchandiseReportById = async (reportId: string) => {
@@ -427,12 +549,8 @@ export const reportService = {
   getMerchandiseReportById,
   deleteMerchandiseReportById,
   getMerchandiseProductNames,
+  getMerchandiseReportFilterOptions,
+  getMerchandiseReportExportRows,
 };
 
-export default {
-  createReports,
-  getMerchandiseReport,
-  getMerchandiseReportById,
-  deleteMerchandiseReportById,
-  getMerchandiseProductNames,
-};
+export default reportService;


### PR DESCRIPTION
## Summary

Improves the Admin Merchandise Reports workflow with accurate paid-order reporting, batch filtering, and complete CSV exports.

## Changes

- Uses paid order-item snapshots as the merchandise report source.
- Adds product and batch filters based on all paid sales records.
- Shows the purchased batch directly in the merchandise report table.
- Preloads the merchandise total so the tab count is visible before opening it.
- Keeps table results server-paginated to avoid loading all report rows at once.
- Adds order indexes to support merchandise report queries.
- Makes merchandise reports read-only to keep report data aligned with paid orders.

## CSV Export

The CSV export now downloads all records matching the active filters, not only the 10 rows currently visible on screen.

Example: selecting a Batch 8 uniform exports every paid Batch 8 purchaser, across all report pages.

## Validation

- Client production build passed.
- Focused lint checks passed.
- Server report TypeScript changes compile; local startup dependency issue for `marked` was restored.