### PR TITLE
feat(orders): add printable receipts and remove force buy for 1st year students

### DIFF
--- a/client-side-ts/src/features/admin/devtools/components/EmailQueuePanel.tsx
+++ b/client-side-ts/src/features/admin/devtools/components/EmailQueuePanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { getEmailQueue, resendEmail, exportEmailQueueCsv, triggerCron, getFailedEmailDetails, bulkUpdateEmailStatus } from "../api/devtools.api";
+import { getEmailQueue, resendEmail, exportEmailQueueCsv, triggerCron, getFailedEmailDetails } from "../api/devtools.api";
 import type { EmailQueueEntry } from "../types/devtools.types";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
@@ -11,7 +11,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { AlertTriangle } from "lucide-react";
 
 interface FailedEmail {
   _id: string;
@@ -35,8 +34,6 @@ export const EmailQueuePanel = () => {
   const [pageSize] = useState(50);
   const [resendAllConfirm, setResendAllConfirm] = useState(false);
   const [failedEmails, setFailedEmails] = useState<FailedEmail[]>([]);
-  const [loadingFailed, setLoadingFailed] = useState(false);
-  const [selectedFailed, setSelectedFailed] = useState<Set<string>>(new Set());
 
   const fetchEntries = async () => {
     setLoading(true);
@@ -62,14 +59,11 @@ export const EmailQueuePanel = () => {
   }, [page, filter]);
 
   const loadFailedEmails = async () => {
-    setLoadingFailed(true);
     try {
       const data = await getFailedEmailDetails(100);
       setFailedEmails(data);
     } catch {
       // silently fail
-    } finally {
-      setLoadingFailed(false);
     }
   };
 

--- a/client-side-ts/src/features/admin/devtools/components/OrderManagerPanel.tsx
+++ b/client-side-ts/src/features/admin/devtools/components/OrderManagerPanel.tsx
@@ -29,7 +29,6 @@ const STATUS_OPTIONS = [
 export const OrderManagerPanel = () => {
   const [orders, setOrders] = useState<OrderDetail[]>([]);
   const [total, setTotal] = useState(0);
-  const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
   const [statusFilter, setStatusFilter] = useState("");
@@ -39,7 +38,6 @@ export const OrderManagerPanel = () => {
   const [selectedOrder, setSelectedOrder] = useState<OrderDetail | null>(null);
 
   const fetchOrders = async () => {
-    setLoading(true);
     try {
       const params: Record<string, string | number> = {
         limit: pageSize,
@@ -54,7 +52,6 @@ export const OrderManagerPanel = () => {
     } catch {
       showToast("error", "Failed to load orders");
     } finally {
-      setLoading(false);
       setInitialLoading(false);
     }
   };

--- a/client-side-ts/src/features/admin/recruitment-management/types/Recruitment.types.ts
+++ b/client-side-ts/src/features/admin/recruitment-management/types/Recruitment.types.ts
@@ -25,6 +25,7 @@ export type RecruitmentStatus =
   | "Pending"
   | "For Verification"
   | "Scheduled"
+  | "Interview Completed"
   | "Interviewed"
   | "Approved"
   | "Rejected";

--- a/client-side-ts/src/features/orders/api/orders.ts
+++ b/client-side-ts/src/features/orders/api/orders.ts
@@ -2,10 +2,12 @@ import backendConnection from "../../../api/backendApi";
 import axios from "axios";
 import type { AxiosError, AxiosResponse } from "axios";
 import { showToast } from "../../../utils/alertHelper";
+import type { PrintableOrderReceipt } from "../types/orders.types";
 
 interface CartItem {
   product_id?: string;
   imageUrl1?: string;
+  image?: string;
   product_name: string;
   limited?: boolean;
   start_date?: string | Date;
@@ -63,10 +65,13 @@ interface OrderFormData {
   items: CartItem[];
   total: number;
   reference_code?: string;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 interface OrderResponse {
+  _id?: string;
+  id?: string;
+  orderId?: string;
   id_number: string;
   rfid?: string;
   membership_discount?: boolean;
@@ -76,13 +81,14 @@ interface OrderResponse {
   year?: number;
   items?: CartItem[];
   total?: number;
+  cash?: number;
   order_date?: string | Date;
   transaction_date?: string | Date;
   order_status?: string;
   admin?: string;
   reference_code?: string;
   role?: string;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 interface ErrorResponse {
@@ -436,6 +442,22 @@ export const refundOrderV2 = async (order_id: string): Promise<boolean> => {
   }
 };
 
+export const getOrderReceiptV2 = async (
+  orderId: string
+): Promise<PrintableOrderReceipt | null> => {
+  try {
+    const response: AxiosResponse<{ data: PrintableOrderReceipt }> =
+      await axios.get(`${backendConnection()}/api/orders/v2/${orderId}/receipt`, {
+        headers: createHeaders(),
+      });
+
+    return response.status === 200 ? response.data.data : null;
+  } catch (error) {
+    handleApiError(error, false);
+    return null;
+  }
+};
+
 // ─── Student Order APIs (V2) ─────────────────────────────────────────
 
 export const getStudentOrders = async ({
@@ -447,7 +469,7 @@ export const getStudentOrders = async ({
   page?: number;
   limit?: number;
 } = {}): Promise<{
-  data: any[];
+  data: OrderResponse[];
   total: number;
   page: number;
   limit: number;

--- a/client-side-ts/src/features/orders/components/CartArea.tsx
+++ b/client-side-ts/src/features/orders/components/CartArea.tsx
@@ -39,7 +39,9 @@ export const Cart: React.FC = () => {
         sessionStorage.removeItem("buyNowItemId");
         return new Set([preSelected]);
       }
-    } catch (e) {}
+    } catch {
+      return new Set();
+    }
     return new Set();
   });
   const [isSubmitting, setIsSubmitting] = React.useState(false);
@@ -70,7 +72,10 @@ export const Cart: React.FC = () => {
   }, [items, selectedIds]);
 
   useEffect(() => {
-    fetchEligiblePromos();
+    const timer = window.setTimeout(() => {
+      void fetchEligiblePromos();
+    }, 0);
+    return () => window.clearTimeout(timer);
   }, [fetchEligiblePromos]);
 
   const handlePlaceOrder = async () => {
@@ -93,6 +98,7 @@ export const Cart: React.FC = () => {
       // Transform cart items to API format
       const orderItems = selected.map((s) => ({
         product_id: String(s.id),
+        imageUrl1: s.image,
         product_name: s.name,
         price: s.price,
         quantity: s.qty,

--- a/client-side-ts/src/features/orders/components/OrdersView.tsx
+++ b/client-side-ts/src/features/orders/components/OrdersView.tsx
@@ -1,9 +1,10 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Check,
   ChevronLeft,
   ChevronRight,
   Clock3,
+  Printer,
   Search,
   X,
 } from "lucide-react";
@@ -21,7 +22,10 @@ import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import { showToast } from "@/utils/alertHelper";
+import { getOrderReceiptV2 } from "../api/orders";
 import { useOrdersData, ROWS_PER_PAGE } from "../hooks/useOrdersData";
+import { PrintableOrderReceipt } from "./PrintableOrderReceipt";
+import type { PrintableOrderReceipt as PrintableOrderReceiptData } from "../types/orders.types";
 
 const formatDate = (value: string | Date) => {
   if (!value) return "-";
@@ -293,6 +297,11 @@ export const OrdersView = () => {
   const [cancelTarget, setCancelTarget] = useState<OrderRowData | null>(null);
   const [refundTarget, setRefundTarget] = useState<OrderRowData | null>(null);
   const [detailOrder, setDetailOrder] = useState<OrderRowData | null>(null);
+  const [receipt, setReceipt] = useState<PrintableOrderReceiptData | null>(
+    null
+  );
+  const [printTicket, setPrintTicket] = useState(0);
+  const [printingOrderId, setPrintingOrderId] = useState<string | null>(null);
 
   const data = activeTab === "pending" ? pendingData : paidData;
   const totalPages =
@@ -329,6 +338,42 @@ export const OrdersView = () => {
 
   const totalPagesNum = Math.max(1, totalPages);
   const currentPage = Math.min(page, totalPagesNum);
+
+  useEffect(() => {
+    if (!receipt || printTicket === 0) return;
+
+    const timer = window.setTimeout(() => {
+      window.print();
+    }, 150);
+
+    return () => window.clearTimeout(timer);
+  }, [receipt, printTicket]);
+
+  useEffect(() => {
+    const handleAfterPrint = () => setReceipt(null);
+    window.addEventListener("afterprint", handleAfterPrint);
+    return () => window.removeEventListener("afterprint", handleAfterPrint);
+  }, []);
+
+  const handlePrintReceipt = async (order: OrderRowData) => {
+    if (!canManageOrders) {
+      showToast("error", "Unauthorized.");
+      return;
+    }
+
+    setPrintingOrderId(order._id);
+    try {
+      const result = await getOrderReceiptV2(order._id);
+      if (!result) {
+        showToast("error", "Unable to load receipt.");
+        return;
+      }
+      setReceipt(result);
+      setPrintTicket((ticket) => ticket + 1);
+    } finally {
+      setPrintingOrderId(null);
+    }
+  };
 
   return (
     <div className="bg-background flex min-h-full flex-1 flex-col text-[#333] [&_[data-disabled]]:pointer-events-auto [&_[data-disabled]]:cursor-not-allowed [&_[role=menuitem]]:cursor-pointer [&_a]:cursor-pointer [&_button:disabled]:cursor-not-allowed [&_button:not(:disabled)]:cursor-pointer">
@@ -397,7 +442,7 @@ export const OrdersView = () => {
 
           {/* Table */}
           <div className="overflow-x-auto">
-            <table className="w-full min-w-[920px] table-fixed border-collapse text-sm">
+            <table className="w-full min-w-[1020px] table-fixed border-collapse text-sm">
               <colgroup>
                 <col className="w-12" />
                 <col className="w-[22%]" />
@@ -406,7 +451,7 @@ export const OrdersView = () => {
                 <col className="w-[14%]" />
                 <col className="w-[18%]" />
                 <col className="w-[12%]" />
-                <col className="w-[190px]" />
+                <col style={{ width: activeTab === "paid" ? 280 : 190 }} />
               </colgroup>
               <thead>
                 <tr className="rounded-md bg-[#efefef] text-[#2f2f2f]">
@@ -561,6 +606,21 @@ export const OrdersView = () => {
                               onClick={() => setDetailOrder(order)}
                             >
                               Details
+                            </Button>
+                          )}
+                          {activeTab === "paid" && canManageOrders && (
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant="outline"
+                              className="h-8 rounded-full border-[#d7eef9] text-[#1c9dde] hover:bg-[#f0fafd]"
+                              disabled={printingOrderId === order._id}
+                              onClick={() => void handlePrintReceipt(order)}
+                            >
+                              <Printer className="mr-1 h-3.5 w-3.5" />
+                              {printingOrderId === order._id
+                                ? "Preparing..."
+                                : "Print"}
                             </Button>
                           )}
                           {activeTab === "paid" && canManageOrders && (
@@ -828,6 +888,20 @@ export const OrdersView = () => {
             </table>
 
             <div className="mt-6 flex justify-end">
+              {detailOrder?.order_status === "Paid" && canManageOrders ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="mr-3 h-10 min-w-24 rounded-full border-[#d7eef9] text-[#1c9dde] hover:bg-[#f0fafd]"
+                  disabled={printingOrderId === detailOrder._id}
+                  onClick={() => void handlePrintReceipt(detailOrder)}
+                >
+                  <Printer className="mr-1 h-4 w-4" />
+                  {printingOrderId === detailOrder._id
+                    ? "Preparing..."
+                    : "Print"}
+                </Button>
+              ) : null}
               <Button
                 type="button"
                 className="h-10 min-w-24 rounded-full bg-[#1c9dde] hover:bg-[#168bc7]"
@@ -839,6 +913,7 @@ export const OrdersView = () => {
           </div>
         </DialogContent>
       </Dialog>
+      <PrintableOrderReceipt receipt={receipt} />
     </div>
   );
 };

--- a/client-side-ts/src/features/orders/components/PrintableOrderReceipt.tsx
+++ b/client-side-ts/src/features/orders/components/PrintableOrderReceipt.tsx
@@ -1,0 +1,197 @@
+import logo from "@/assets/logo.png";
+import type { PrintableOrderReceipt as PrintableOrderReceiptData } from "../types/orders.types";
+
+interface PrintableOrderReceiptProps {
+  receipt: PrintableOrderReceiptData | null;
+}
+
+const formatCurrency = (value?: number) =>
+  `\u20B1${Number(value || 0).toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+
+const formatDateTime = (value?: string | Date) => {
+  if (!value) return "-";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return String(value);
+  return date.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+};
+
+const formatList = (value?: string[]) => {
+  if (!value || value.length === 0) return "-";
+  return value.join(", ");
+};
+
+export const PrintableOrderReceipt = ({
+  receipt,
+}: PrintableOrderReceiptProps) => {
+  if (!receipt) return null;
+
+  return (
+    <div className="order-receipt-print-shell" aria-hidden="true">
+      <style>
+        {`
+          .order-receipt-print-shell {
+            position: fixed;
+            left: -10000px;
+            top: 0;
+            width: 80mm;
+            background: #fff;
+            color: #111;
+            font-family: Inter, Arial, sans-serif;
+            pointer-events: none;
+          }
+
+          @media print {
+            @page {
+              size: 80mm 297mm;
+              margin: 4mm;
+            }
+
+            body * {
+              visibility: hidden !important;
+            }
+
+            .order-receipt-print-shell,
+            .order-receipt-print-shell * {
+              visibility: visible !important;
+            }
+
+            .order-receipt-print-shell {
+              position: absolute !important;
+              left: 0 !important;
+              top: 0 !important;
+              width: 72mm !important;
+              padding: 0 !important;
+              margin: 0 !important;
+              pointer-events: auto !important;
+            }
+          }
+        `}
+      </style>
+
+      <div className="px-2 py-3 text-[11px] leading-tight">
+        <div className="mb-3 flex items-center gap-3">
+          <img
+            src={logo}
+            alt="PSITS"
+            className="h-14 w-14 rounded-full object-cover"
+          />
+          <div>
+            <p className="text-lg font-semibold leading-none">Official</p>
+            <p className="text-lg font-semibold leading-none">Receipt</p>
+            <p className="mt-1 text-[10px] text-neutral-500">Order Copy</p>
+          </div>
+        </div>
+
+        <div className="mb-3 border-b border-dashed border-neutral-300 pb-3">
+          <p className="text-xs font-semibold">University of Cebu Main Campus</p>
+          <p className="text-[10px] text-neutral-600">
+            Sanciangko Street Cebu City, 6000
+          </p>
+        </div>
+
+        <div className="space-y-1 border-b border-dashed border-neutral-300 pb-3">
+          <p>
+            <span className="font-semibold">Name:</span>{" "}
+            {receipt.student_name || "-"}
+          </p>
+          <p>
+            <span className="font-semibold">Student ID:</span>{" "}
+            {receipt.id_number || "-"}
+          </p>
+          <p>
+            <span className="font-semibold">Course & Year:</span>{" "}
+            {receipt.course || "-"} {receipt.year ? `- ${receipt.year}` : ""}
+          </p>
+          <p>
+            <span className="font-semibold">Reference:</span>{" "}
+            {receipt.reference_code || "-"}
+          </p>
+          <p>
+            <span className="font-semibold">Date:</span>{" "}
+            {formatDateTime(receipt.transaction_date || receipt.order_date)}
+          </p>
+          <p>
+            <span className="font-semibold">Managed by:</span>{" "}
+            {receipt.admin || "-"}
+          </p>
+        </div>
+
+        {receipt.membership_discount || receipt.promo_name ? (
+          <div className="space-y-1 border-b border-dashed border-neutral-300 py-3">
+            {receipt.membership_discount ? (
+              <p>
+                <span className="font-semibold">Membership:</span> Discounted
+              </p>
+            ) : null}
+            {receipt.promo_name ? (
+              <p>
+                <span className="font-semibold">Promo:</span>{" "}
+                {receipt.promo_name}
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+
+        <div className="border-b border-dashed border-neutral-300 py-3">
+          <p className="mb-2 font-semibold">Items</p>
+          <div className="space-y-3">
+            {receipt.items.map((item, index) => (
+              <div key={`${item.product_name}-${index}`}>
+                <div className="flex justify-between gap-2">
+                  <p className="font-semibold">{item.product_name}</p>
+                  <p className="shrink-0 font-semibold">
+                    {formatCurrency(item.sub_total)}
+                  </p>
+                </div>
+                <p className="text-[10px] text-neutral-600">
+                  Qty {item.quantity}
+                  {item.price !== undefined
+                    ? ` x ${formatCurrency(item.price)}`
+                    : ""}
+                </p>
+                <p className="text-[10px] text-neutral-600">
+                  Batch: {item.batch ?? "-"} | Size: {formatList(item.sizes)} |
+                  Variation: {formatList(item.variation)}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="space-y-1 border-b border-dashed border-neutral-300 py-3">
+          <div className="flex justify-between">
+            <span>Cash</span>
+            <span>{formatCurrency(receipt.cash)}</span>
+          </div>
+          <div className="flex justify-between">
+            <span>Change</span>
+            <span>{formatCurrency(receipt.change)}</span>
+          </div>
+          <div className="flex justify-between pt-1 text-sm font-bold">
+            <span>Total</span>
+            <span>{formatCurrency(receipt.total)}</span>
+          </div>
+        </div>
+
+        <div className="pt-3 text-center">
+          <p className="text-xs font-semibold">{receipt.reference_code}</p>
+          <p className="mt-1 text-[10px] text-neutral-500">
+            Thank you for your purchase!
+          </p>
+          <p className="mt-1 text-[9px] text-neutral-400">
+            PSITS - University of Cebu Main Campus
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/client-side-ts/src/features/orders/types/orders.types.ts
+++ b/client-side-ts/src/features/orders/types/orders.types.ts
@@ -16,11 +16,13 @@ export interface OrderRow {
     variation?: string[];
     sizes?: string[];
     imageUrl1?: string;
+    image?: string;
     category?: string;
     batch?: string;
     limited?: boolean;
   }>;
   total: number;
+  cash?: number;
   order_date: string | Date;
   transaction_date?: string | Date;
   order_status: string;
@@ -53,4 +55,31 @@ export interface RefundDetail {
   refund_price: number;
   refund_admin: string;
   refund_date: string | Date;
+}
+
+export interface PrintableOrderReceiptItem {
+  product_name: string;
+  batch?: string | number;
+  sizes?: string[];
+  variation?: string[];
+  quantity: number;
+  price?: number;
+  sub_total: number;
+}
+
+export interface PrintableOrderReceipt {
+  reference_code?: string;
+  order_date?: string | Date;
+  transaction_date?: string | Date;
+  student_name?: string;
+  id_number?: string;
+  course?: string;
+  year?: number;
+  admin?: string;
+  items: PrintableOrderReceiptItem[];
+  cash: number;
+  change: number;
+  total: number;
+  membership_discount?: boolean;
+  promo_name?: string;
 }

--- a/client-side-ts/src/pages/student/MyOrders.tsx
+++ b/client-side-ts/src/pages/student/MyOrders.tsx
@@ -18,6 +18,17 @@ import type { OrdersTab, RefundDetail } from "@/features/orders/types/orders.typ
 import OrderDetailModal from "@/features/orders/components/OrderDetailModal";
 
 const ROWS_PER_PAGE = 8;
+const ORDER_STATUS_BY_TAB: Record<OrdersTab, "Pending" | "Paid" | "Refunded"> = {
+  pending: "Pending",
+  paid: "Paid",
+  refunded: "Refunded",
+};
+
+const EMPTY_COUNTS: Record<OrdersTab, number> = {
+  pending: 0,
+  paid: 0,
+  refunded: 0,
+};
 
 interface OrderItem {
   id: string;
@@ -38,14 +49,52 @@ interface Order {
   course?: string;
   year?: number;
   reference_code?: string;
-  transaction_date?: string;
+  transaction_date?: string | Date;
   admin?: string;
   total: number;
 }
 
-const mapApiToUi = (apiOrder: any): Order => {
+interface ApiOrderItem {
+  product_id?: string;
+  _id?: string;
+  id?: string;
+  product_name?: string;
+  name?: string;
+  title?: string;
+  variation?: string[];
+  variant?: string;
+  color?: string;
+  price?: number;
+  unit_price?: number;
+  sub_total?: number;
+  quantity?: number;
+  qty?: number;
+  units?: number;
+  imageUrl1?: string;
+  image?: string;
+  img?: string;
+}
+
+interface ApiOrder {
+  _id?: string;
+  id?: string;
+  orderId?: string;
+  reference_code?: string;
+  items?: ApiOrderItem[];
+  order_date?: string | Date;
+  order_status?: string;
+  status?: string;
+  student_name?: string;
+  course?: string;
+  year?: number;
+  transaction_date?: string | Date;
+  admin?: string;
+  total?: number;
+}
+
+const mapApiToUi = (apiOrder: ApiOrder): Order => {
   const items = Array.isArray(apiOrder.items)
-    ? apiOrder.items.map((it: any) => ({
+    ? apiOrder.items.map((it) => ({
         id: String(it.product_id ?? it._id ?? it.id ?? Math.random()),
         title: it.product_name ?? it.name ?? it.title ?? "",
         variant: Array.isArray(it.variation)
@@ -80,6 +129,32 @@ const mapApiToUi = (apiOrder: any): Order => {
     admin: apiOrder.admin,
     total: Number(apiOrder.total ?? 0),
   };
+};
+
+const ProductThumb: React.FC<{ src?: string; title: string }> = ({
+  src,
+  title,
+}) => {
+  const [failed, setFailed] = useState(false);
+  const fallback = title.trim().charAt(0).toUpperCase() || "?";
+
+  if (!src || failed) {
+    return (
+      <div className="grid h-16 w-16 shrink-0 place-items-center rounded-xl bg-sky-50 text-sm font-semibold text-[#1C9DDE] ring-1 ring-sky-100">
+        {fallback}
+      </div>
+    );
+  }
+
+  return (
+    <img
+      src={src}
+      alt={title}
+      className="h-16 w-16 shrink-0 rounded-xl object-cover ring-1 ring-gray-100"
+      loading="lazy"
+      onError={() => setFailed(true)}
+    />
+  );
 };
 
 const OrderCard: React.FC<{
@@ -141,15 +216,18 @@ const OrderCard: React.FC<{
         {order.items.map((item) => (
           <div
             key={item.id}
-            className="flex flex-col items-start gap-4 rounded-xl border border-gray-100 bg-white p-4 sm:flex-row sm:items-center"
+            className="flex items-start gap-4 rounded-xl border border-gray-100 bg-white p-4"
           >
-            <div className="w-full flex-1">
-              <div className="flex w-full flex-col items-start justify-between sm:flex-row sm:items-center">
+            <ProductThumb src={item.image} title={item.title} />
+            <div className="min-w-0 flex-1">
+              <div className="flex w-full flex-col items-start justify-between gap-2 sm:flex-row sm:items-center">
                 <div>
                   <div className="font-medium">{item.title}</div>
-                  <div className="text-sm text-gray-600">{item.variant}</div>
+                  {item.variant ? (
+                    <div className="text-sm text-gray-600">{item.variant}</div>
+                  ) : null}
                 </div>
-                <div className="mt-2 text-left sm:mt-0 sm:text-right">
+                <div className="text-left sm:text-right">
                   <div className="font-medium text-[#1C9DDE]">
                     ₱{item.price.toFixed(2)}
                   </div>
@@ -285,17 +363,34 @@ const MyOrders: React.FC = () => {
   const [page, setPage] = useState(1);
   const [totalOrders, setTotalOrders] = useState(0);
   const [_totalPages, setTotalPages] = useState(0);
+  const [statusCounts, setStatusCounts] =
+    useState<Record<OrdersTab, number>>(EMPTY_COUNTS);
 
   // Detail modal state
   const [detailOrder, setDetailOrder] = useState<Order | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
   const [refundData, setRefundData] = useState<RefundDetail[]>([]);
 
+  const fetchStatusCounts = useCallback(async () => {
+    const entries = await Promise.all(
+      (Object.keys(ORDER_STATUS_BY_TAB) as OrdersTab[]).map(async (tab) => {
+        const result = await getStudentOrders({
+          status: ORDER_STATUS_BY_TAB[tab],
+          page: 1,
+          limit: 1,
+        });
+        return [tab, result?.total ?? 0] as const;
+      })
+    );
+
+    setStatusCounts(Object.fromEntries(entries) as Record<OrdersTab, number>);
+  }, []);
+
   const fetchOrders = useCallback(async () => {
     setLoading(true);
     try {
       const result = await getStudentOrders({
-        status: activeTab === "pending" ? "Pending" : activeTab === "paid" ? "Paid" : "Refunded",
+        status: ORDER_STATUS_BY_TAB[activeTab],
         page,
         limit: ROWS_PER_PAGE,
       });
@@ -305,22 +400,37 @@ const MyOrders: React.FC = () => {
         setOrders(mapped);
         setTotalOrders(result.total);
         setTotalPages(result.totalPages);
+        setStatusCounts((prev) => ({ ...prev, [activeTab]: result.total }));
       } else {
         setOrders([]);
         setTotalOrders(0);
         setTotalPages(0);
+        setStatusCounts((prev) => ({ ...prev, [activeTab]: 0 }));
       }
     } catch (error) {
       console.error("Failed to fetch orders", error);
       setOrders([]);
+      setTotalOrders(0);
+      setTotalPages(0);
+      setStatusCounts((prev) => ({ ...prev, [activeTab]: 0 }));
     } finally {
       setLoading(false);
     }
   }, [activeTab, page]);
 
   useEffect(() => {
-    fetchOrders();
+    const timer = window.setTimeout(() => {
+      void fetchOrders();
+    }, 0);
+    return () => window.clearTimeout(timer);
   }, [fetchOrders]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      void fetchStatusCounts();
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [fetchStatusCounts]);
 
   const handleTabChange = (value: string) => {
     setActiveTab(value as OrdersTab);
@@ -331,7 +441,7 @@ const MyOrders: React.FC = () => {
     try {
       const ok = await cancelOrder(orderId);
       if (ok) {
-        fetchOrders();
+        await Promise.all([fetchOrders(), fetchStatusCounts()]);
       }
     } catch (err) {
       console.error("Cancel failed", err);
@@ -355,9 +465,9 @@ const MyOrders: React.FC = () => {
     }
   };
 
-  const pendingCount = orders.filter((o) => o.status === "Pending").length;
-  const paidCount = orders.filter((o) => o.status === "Paid").length;
-  const refundedCount = orders.filter((o) => o.status === "Refunded").length;
+  const pendingCount = statusCounts.pending;
+  const paidCount = statusCounts.paid;
+  const refundedCount = statusCounts.refunded;
 
   return (
     <div className="min-h-screen">

--- a/server-side/package-lock.json
+++ b/server-side/package-lock.json
@@ -25,6 +25,7 @@
         "dotenv": "^16.4.5",
         "ejs": "^3.1.10",
         "express": "^4.19.2",
+        "express-async-errors": "^3.1.1",
         "express-rate-limit": "^7.4.0",
         "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.2",
@@ -2097,6 +2098,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-async-errors": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/express-async-errors/-/express-async-errors-3.1.1.tgz",
+      "integrity": "sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==",
+      "license": "ISC",
+      "peerDependencies": {
+        "express": "^4.16.2"
       }
     },
     "node_modules/express-rate-limit": {

--- a/server-side/package.json
+++ b/server-side/package.json
@@ -31,6 +31,7 @@
     "dotenv": "^16.4.5",
     "ejs": "^3.1.10",
     "express": "^4.19.2",
+    "express-async-errors": "^3.1.1",
     "express-rate-limit": "^7.4.0",
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.2",

--- a/server-side/src/controllers/order.v2.controller.ts
+++ b/server-side/src/controllers/order.v2.controller.ts
@@ -83,6 +83,16 @@ class OrderController {
       totalPages: result.totalPages,
     });
   });
+
+  getOrderReceipt = catchAsync(async (req: Request, res: Response) => {
+    const orderId = String(req.params.orderId || "");
+    const receipt = await orderService.getPrintableOrderReceipt(orderId);
+
+    return res.status(200).json({
+      message: "Successfully retrieved order receipt",
+      data: receipt,
+    });
+  });
   //Create Order Controller
   //Create Order
   /*
@@ -292,6 +302,7 @@ class OrderController {
       const result: any = await orderService.approveOrderService(
         order_id,
         admin.name,
+        cash,
         session
       );
       //Create a Stocks array for bulk update

--- a/server-side/src/controllers/studentV2.controller.ts
+++ b/server-side/src/controllers/studentV2.controller.ts
@@ -2,7 +2,8 @@ import { Request, Response } from "express";
 import { IStudent } from "../models/student.interface";
 import { Student } from "../models/student.model";
 import { user_model } from "../model_template/model_data";
-import { orderService } from "../services/order.service";
+import { Orders } from "../models/orders.model";
+import { Merch } from "../models/merch.model";
 import { Refund } from "../models/refund.model";
 import { Settings } from "../models/settings.model";
 import { membership_status } from "../enums/status.enums";
@@ -215,22 +216,60 @@ export const requestStudentMembershipV2 = async (
 export const getStudentOrders = async (req: Request, res: Response) => {
   try {
     const { idNumber } = req.userV2;
-    const result = await orderService.getAllOrdersDynamicStatus({
-      query: req.query,
-      status: (req.query.status as string) || "Pending",
-    });
+    const page = Math.max(Number(req.query.page) || 1, 1);
+    const limit = Math.max(Number(req.query.limit) || 8, 1);
+    const status = String(req.query.status || "Pending");
+    const query = {
+      id_number: idNumber,
+      order_status: status,
+    };
 
-    const studentOrders = (result.data as any[]).filter(
-      (o) => o.id_number === idNumber
+    const [rawOrders, total] = await Promise.all([
+      Orders.find(query)
+        .sort(status === "Paid" ? { transaction_date: -1 } : { order_date: -1 })
+        .skip((page - 1) * limit)
+        .limit(limit)
+        .lean(),
+      Orders.countDocuments(query),
+    ]);
+    const productIds = Array.from(
+      new Set(
+        rawOrders.flatMap((order: any) =>
+          Array.isArray(order.items)
+            ? order.items.map((item: any) => String(item.product_id || ""))
+            : []
+        )
+      )
+    ).filter(Boolean);
+    const products = productIds.length
+      ? await Merch.find({ _id: { $in: productIds } })
+          .select("_id imageUrl")
+          .lean()
+      : [];
+    const imageByProductId = new Map(
+      products.map((product: any) => [
+        String(product._id),
+        Array.isArray(product.imageUrl) ? product.imageUrl[0] : undefined,
+      ])
     );
+    const studentOrders = rawOrders.map((order: any) => ({
+      ...order,
+      items: Array.isArray(order.items)
+        ? order.items.map((item: any) => ({
+            ...item,
+            imageUrl1:
+              item.imageUrl1 || imageByProductId.get(String(item.product_id)),
+          }))
+        : [],
+    }));
 
     return res.status(200).json({
       message: "Successfully retrieved student orders",
       data: studentOrders,
-      total: result.total,
-      page: result.page,
-      limit: result.limit,
-      totalPages: result.totalPages,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
     });
   } catch (error) {
     console.error("Error fetching student orders:", error);

--- a/server-side/src/models/orders.interface.ts
+++ b/server-side/src/models/orders.interface.ts
@@ -31,6 +31,7 @@ export interface IOrders {
   year: number;
   items: IOrdersItems[];
   total: number;
+  cash?: number;
   order_date: Date;
   transaction_date: Date;
   order_status: string;

--- a/server-side/src/models/orders.model.ts
+++ b/server-side/src/models/orders.model.ts
@@ -46,6 +46,9 @@ const orderSchema = new Schema<IOrdersDocument>({
     type: Number,
     required: true,
   },
+  cash: {
+    type: Number,
+  },
   order_date: {
     type: Date,
     required: true,

--- a/server-side/src/routes/orders.route.ts
+++ b/server-side/src/routes/orders.route.ts
@@ -110,6 +110,19 @@ router.get(
   orderV2Controller.getAllPendingPaidOrders
 );
 
+// Printable receipt for paid orders (V2)
+router.get(
+  "/v2/:orderId/receipt",
+  requireAccessTokenWithDBCheck,
+  roleAuthenticateV2(["admin"]),
+  adminAccessAuthenticateV2([
+    psits_roles.ADMIN,
+    psits_roles.FINANCE,
+    psits_roles.HEAD_FINANCE,
+  ]),
+  orderV2Controller.getOrderReceipt
+);
+
 // Cancel order (body: { _id }) — restores stock (V2)
 router.put(
   "/v2/cancel",

--- a/server-side/src/services/order.service.inteface.ts
+++ b/server-side/src/services/order.service.inteface.ts
@@ -1,6 +1,7 @@
 import mongoose from "mongoose";
 export interface IUserItems {
   product_id: mongoose.Types.ObjectId;
+  imageUrl1?: string;
   product_name: string;
   limited: boolean;
   price: number;

--- a/server-side/src/services/order.service.ts
+++ b/server-side/src/services/order.service.ts
@@ -234,8 +234,10 @@ class OrderService {
       orderTotal += itemSubTotal;
 
       //This will be the process
+      const firstImage = findMerch.data?.imageUrl?.[0];
       const processedItem: IUserItems = {
         product_id: item.product_id,
+        imageUrl1: firstImage ? String(firstImage) : item.imageUrl1,
         product_name: findMerch.data?.name,
         limited: findMerch.data?.control === "limited-purchase",
         price: actualPrice,
@@ -351,21 +353,29 @@ class OrderService {
   approveOrderService = async (
     _id: Types.ObjectId,
     admin: string,
+    cash: number | undefined,
     session: ClientSession
   ) => {
-    const result = await Orders.findByIdAndUpdate(
-      _id,
-      {
-        order_status: "Paid",
-        reference_code: this.generateReferenceCode(),
-        transaction_date: new Date(),
-        admin,
-      },
-      { new: true, session }
-    );
+    const result = await Orders.findById(_id).session(session);
     if (!result) {
       throw new AppError("Order not found!", 404);
     }
+
+    const cashAmount = Number(cash);
+    const resolvedCash =
+      Number.isFinite(cashAmount) && cashAmount >= 0 ? cashAmount : result.total;
+
+    if (resolvedCash < result.total) {
+      throw new AppError("Cash cannot be lower than order total", 400);
+    }
+
+    result.order_status = "Paid";
+    result.reference_code = this.generateReferenceCode();
+    result.transaction_date = new Date();
+    result.admin = admin;
+    result.cash = resolvedCash;
+    await result.save({ session });
+
     return {
       status: true,
       items: result.items,
@@ -388,6 +398,9 @@ class OrderService {
     admin: string,
     cash: number
   ) => {
+    const cashAmount = Number(cash);
+    const resolvedCash =
+      Number.isFinite(cashAmount) && cashAmount >= 0 ? cashAmount : order.total;
     const receipt = {
       reference_code: order.reference_code,
       order_date: order.order_date,
@@ -403,12 +416,36 @@ class OrderService {
         sizes: item.sizes,
         variation: item.variation,
         quantity: item.quantity,
+        price: item.price,
         sub_total: item.sub_total,
       })),
-      cash,
+      cash: resolvedCash,
+      change: resolvedCash - order.total,
       total: order.total,
+      membership_discount: order.membership_discount,
+      promo_name: order.promo?.promo_name,
     };
     return receipt;
+  };
+
+  getPrintableOrderReceipt = async (orderId: string) => {
+    if (!Types.ObjectId.isValid(orderId)) {
+      throw new AppError("Invalid order ID", 400);
+    }
+
+    const order = await Orders.findById(orderId).lean();
+    if (!order) {
+      throw new AppError("Order not found!", 404);
+    }
+    if (order.order_status !== "Paid") {
+      throw new AppError("Only paid orders can be printed", 400);
+    }
+
+    return this.generateOrderReceipt(
+      order as IOrders,
+      order.admin || "N/A",
+      order.cash ?? order.total
+    );
   };
   //Check if order is approved or not
   checkOrderApproveStatus = async (_id: Types.ObjectId) => {


### PR DESCRIPTION
## Summary
- Add printable order receipts for paid admin orders
- Add receipt API endpoint and frontend print action
- Save cash amount on paid orders for accurate receipt reprints
- Show product images in student Pending, Paid, and Refunded order cards
- Fix student order tab counts so totals load before tabs are clicked
- Scope student order pagination/counts by logged-in student
- Add product image snapshots to new orders and enrich older orders from merchandise data
- Remove force buy of memebership for 1st year students
- Fix build blockers in devtools/recruitment TypeScript files

## Verification
- npm run build passed in client-side-ts
- npm run build passed in server-side