### PR TITLE
feat(merchandise): auto-select variations on category change

### DIFF
--- a/client-side-ts/src/features/admin/merchandise/components/MerchandiseView.tsx
+++ b/client-side-ts/src/features/admin/merchandise/components/MerchandiseView.tsx
@@ -62,6 +62,7 @@ import {
   formatCurrency,
   formatPurchaseControl,
   getProductStatus,
+  getAutoSelectedVariations,
   getVariationLabel,
   getVariationSwatch,
   getVariationsForCategory,
@@ -1522,9 +1523,10 @@ const ProductFormPage = ({ productId }: ProductFormPageProps) => {
                       onChange={(value) => {
                         setValue("category", value);
                         setValue("type", "");
-                        // Variations are category-scoped, so a stale pick from
-                        // the previous category would no longer be selectable.
-                        setValue("selectedVariations", []);
+                        setValue(
+                          "selectedVariations",
+                          getAutoSelectedVariations(value)
+                        );
                       }}
                     />
                   </FormField>
@@ -1586,7 +1588,7 @@ const ProductFormPage = ({ productId }: ProductFormPageProps) => {
                       {!formValues.category && (
                         <p className="mt-2 text-[11px] text-[#9a9a9a]">
                           Pick a product category first — Uniform products only
-                          offer Set A and Set B.
+                          offer White and Purple.
                         </p>
                       )}
                     </div>

--- a/client-side-ts/src/features/admin/merchandise/hooks/useMerchandiseData.ts
+++ b/client-side-ts/src/features/admin/merchandise/hooks/useMerchandiseData.ts
@@ -19,6 +19,7 @@ export {
   getVariationsForCategory,
   getVariationSwatch,
   getVariationLabel,
+  getAutoSelectedVariations,
 } from "@/features/merchandise/constants/variations";
 import type {
   MerchandiseSection,

--- a/client-side-ts/src/features/merchandise/constants/variations.ts
+++ b/client-side-ts/src/features/merchandise/constants/variations.ts
@@ -1,27 +1,26 @@
 export type ProductVariation = {
-  /** Persisted to the DB. Never change these - existing orders reference them. */
   value: string;
-  /** Shown to admins in the picker. */
   label: string;
-  /** Rendered as the colour dot on the student-facing detail view. */
   swatch: string;
-  /** When set, this variation is only offered for these product categories. */
   categories?: string[];
+  autoSelect?: boolean;
 };
 
 export const PRODUCT_VARIATION_OPTIONS: ProductVariation[] = [
   // uniform-only
   {
-    value: "Set A (BSIT)",
-    label: "Set A",
+    value: "White",
+    label: "White",
     swatch: "#ffffff",
     categories: ["uniform"],
+    autoSelect: true,
   },
   {
-    value: "Set B (BSCS)",
-    label: "Set B",
+    value: "Purple",
+    label: "Purple",
     swatch: "#a855f7",
     categories: ["uniform"],
+    autoSelect: true,
   },
   // general colours
   { value: "Black", label: "Black", swatch: "#000000" },
@@ -52,7 +51,7 @@ const VARIATION_BY_VALUE = new Map(
 );
 
 /**
- * Uniform products only offer Set A / Set B. Everything else falls back to the
+ * Uniform products only offer White / Purple. Everything else falls back to the
  * general colour list (any option without a `categories` restriction).
  */
 export const getVariationsForCategory = (category?: string) => {
@@ -69,3 +68,12 @@ export const getVariationSwatch = (value: string) =>
 
 export const getVariationLabel = (value: string) =>
   VARIATION_BY_VALUE.get(value)?.label ?? value;
+
+export const getAutoSelectedVariations = (category?: string) =>
+  getVariationsForCategory(category)
+    .filter((option) => option.autoSelect)
+    .map((option) => option.value);
+
+const BUNDLED_VARIATION_CATEGORIES = ["uniform"];
+export const isBundledVariationCategory = (category?: string) =>
+  BUNDLED_VARIATION_CATEGORIES.includes((category ?? "").toLowerCase());

--- a/client-side-ts/src/features/orders/components/ProductDetails.tsx
+++ b/client-side-ts/src/features/orders/components/ProductDetails.tsx
@@ -9,11 +9,9 @@ import { addToCartApi, useMembershipGate } from "@/features/student";
 import {
   getVariationLabel,
   getVariationSwatch,
+  isBundledVariationCategory,
 } from "@/features/merchandise/constants/variations";
 import { getMerchandiseById, type MerchandiseItem } from "../api/orders";
-
-// Fallback image for products without images
-import fallbackImage from "../../../assets/awarding/1.jpg";
 
 interface Product {
   id: string;
@@ -72,7 +70,7 @@ const transformMerchandise = (item: MerchandiseItem): Product => {
     id: item._id,
     name: item.name || item.product_name || "Unknown Product",
     price: item.price,
-    image: item.imageUrl?.[0] || item.imageUrl1 || fallbackImage,
+    image: item.imageUrl?.[0] || item.imageUrl1 || "",
     isSoldOut: (item.stocks ?? item.stock ?? 0) <= 0,
     category: item.category || "Merchandise",
     description: item.description,
@@ -123,7 +121,7 @@ const BuyNowButton: React.FC<AddToCartButtonProps> = ({
       name: product.name,
       price: product.price,
       image: product.image,
-      // Persist the raw variation value, never the display label.
+      // Persist the raw variation value(s), never the display label.
       color: selectedColor,
       size: selectedSize,
       course: selectedCourse,
@@ -202,7 +200,7 @@ const AddToCartButton: React.FC<AddToCartButtonProps> = ({
         const payload: any = {
           product_id: product.id,
           sizes: selectedSize,
-          // Raw value, so it matches what is stored on the merch document.
+          // Raw value(s), so they match what is stored on the merch document.
           variation: selectedColor,
           quantity,
           id_number: user.idNumber,
@@ -264,8 +262,11 @@ export const ProductDetails: React.FC<ProductDetailsProps> = ({
   const location = useLocation();
 
   const [quantity, setQuantity] = useState(1);
-  const [selectedSize, setSelectedSize] = useState("");
-  const [selectedColor, setSelectedColor] = useState("");
+  // Holds the student's *explicit* choice only. The value actually in effect
+  // is derived below, so no effect writes state on mount and a valid option is
+  // active from the very first render.
+  const [pickedSize, setPickedSize] = useState("");
+  const [pickedColor, setPickedColor] = useState("");
   const [selectedCourse, setSelectedCourse] = useState("BSIT");
   const [fetchedProduct, setFetchedProduct] = useState<Product | null>(null);
   const [loading, setLoading] = useState(false);
@@ -304,14 +305,6 @@ export const ProductDetails: React.FC<ProductDetailsProps> = ({
 
   // Determine which product to display
   const currentProduct = product ?? stateProduct ?? fetchedProduct;
-
-  // Initialize size and color from product data
-  useEffect(() => {
-    if (currentProduct) {
-      setSelectedSize(currentProduct.sizes?.[0] ?? "");
-      setSelectedColor(currentProduct.colors?.[0] ?? "");
-    }
-  }, [currentProduct]);
 
   // Loading state
   if (loading) {
@@ -376,12 +369,24 @@ export const ProductDetails: React.FC<ProductDetailsProps> = ({
     );
   }
 
-  // Only show what the admin actually configured on this product. No invented
-  // defaults - a hardcoded fallback is what made every item look like it had
-  // White and Purple options.
+  // Only show what the admin actually configured on this product.
   const availableSizes = currentProduct.sizes ?? [];
   const availableColors = currentProduct.colors ?? [];
   const stockCount = currentProduct.stock ?? 0;
+
+  // A uniform is a set: the student receives every configured piece, so all
+  // chips show as selected and none of them are clickable. Other categories
+  // treat their variations as alternatives and let the student pick one.
+  const isBundle = isBundledVariationCategory(currentProduct.category);
+
+  const selectedColor = isBundle
+    ? availableColors.join(", ")
+    : pickedColor || availableColors[0] || "";
+
+  const isColorSelected = (color: string) =>
+    isBundle ? true : selectedColor === color;
+
+  const selectedSize = pickedSize || availableSizes[0] || "";
 
   const getDisplayPrice = (): number => {
     if (currentProduct.selectedSizes && selectedSize) {
@@ -406,12 +411,7 @@ export const ProductDetails: React.FC<ProductDetailsProps> = ({
   const isNotStarted = startDate ? now < startDate : false;
   const isExpired = endDate ? now > endDate : false;
   const isOutOfActiveWindow = isNotStarted || isExpired;
-  // Don't let an order through with an unpicked variation or size.
-  const missingSelection =
-    (availableColors.length > 0 && !selectedColor) ||
-    (availableSizes.length > 0 && !selectedSize);
-  const purchaseDisabled =
-    currentProduct.isSoldOut || isOutOfActiveWindow || missingSelection;
+  const purchaseDisabled = currentProduct.isSoldOut || isOutOfActiveWindow;
 
   return (
     <div className="animate-in fade-in slide-in-from-right-4 mx-auto mt-16 min-h-screen max-w-6xl bg-transparent p-4 font-sans duration-500 sm:mt-20 sm:p-6 lg:p-12">
@@ -473,32 +473,51 @@ export const ProductDetails: React.FC<ProductDetailsProps> = ({
           </div>
 
           <div className="space-y-6 sm:space-y-10">
-            {/* Color Selection - hidden entirely when the product has none */}
+            {/* Color - hidden entirely when the product has no variations */}
             {availableColors.length > 0 && (
               <div>
-                <h3 className="mb-4 text-sm font-bold tracking-wider text-gray-900 uppercase">
-                  Color
-                </h3>
+                <div className="mb-4 flex flex-wrap items-baseline gap-x-3">
+                  <h3 className="text-sm font-bold tracking-wider text-gray-900 uppercase">
+                    Color
+                  </h3>
+                  {isBundle && (
+                    <span className="text-xs font-medium text-gray-500 normal-case">
+                      Both pieces are included in this set
+                    </span>
+                  )}
+                </div>
                 <div className="flex flex-wrap gap-3">
                   {availableColors.map((color) => {
-                    const isSelected = selectedColor === color;
+                    const isSelected = isColorSelected(color);
                     return (
                       <Button
                         key={color}
-                        onClick={() => setSelectedColor(color)}
+                        // A bundled set is informational, not a choice.
+                        disabled={isBundle}
+                        onClick={
+                          isBundle ? undefined : () => setPickedColor(color)
+                        }
                         className={cn(
-                          "inline-flex cursor-pointer items-center gap-2 rounded-full px-5 py-2 text-xs font-bold transition-all sm:px-6 sm:py-3 sm:text-sm",
+                          "inline-flex items-center gap-2 rounded-full px-5 py-2 text-xs font-bold transition-all sm:px-6 sm:py-3 sm:text-sm",
+                          isBundle ? "cursor-default" : "cursor-pointer",
                           isSelected
                             ? "bg-[#1c9dde] text-white shadow-lg shadow-blue-200"
-                            : "border border-gray-200 bg-white text-gray-600 hover:bg-[#1c9dde]/90 hover:text-white"
+                            : "border border-gray-200 bg-white text-gray-600 hover:bg-[#1c9dde]/90 hover:text-white",
+                          // Keep a locked chip at full strength - the shadcn
+                          // Button dims disabled elements by default.
+                          isBundle && "opacity-100 disabled:opacity-100"
                         )}
                         aria-pressed={isSelected}
-                        aria-label={`Select ${getVariationLabel(color)}`}
+                        aria-label={getVariationLabel(color)}
                       >
+                        {/* The swatch is dropped once selected - a small pale
+                            circle inside a filled pill reads as an unchecked
+                            radio button. Space is kept so the chip doesn't
+                            change width. */}
                         <span
                           className={cn(
-                            "h-3.5 w-3.5 shrink-0 rounded-full border",
-                            isSelected ? "border-white/70" : "border-gray-300"
+                            "h-3.5 w-3.5 shrink-0 rounded-full border-2",
+                            isSelected ? "border-white/60" : "border-gray-400"
                           )}
                           style={{ backgroundColor: getVariationSwatch(color) }}
                         />
@@ -534,7 +553,7 @@ export const ProductDetails: React.FC<ProductDetailsProps> = ({
                   {availableSizes.map((size) => (
                     <Button
                       key={size}
-                      onClick={() => setSelectedSize(size)}
+                      onClick={() => setPickedSize(size)}
                       className={cn(
                         "cursor-pointer rounded-full px-5 py-3 text-xs font-bold transition-all sm:px-8 sm:py-5 sm:text-sm",
                         selectedSize === size
@@ -615,20 +634,6 @@ export const ProductDetails: React.FC<ProductDetailsProps> = ({
             </div>
 
             {/* Final Action */}
-            {missingSelection && (
-              <p className="text-xs font-medium text-orange-600">
-                Choose a
-                {availableColors.length > 0 && !selectedColor ? " colour" : ""}
-                {availableColors.length > 0 &&
-                !selectedColor &&
-                availableSizes.length > 0 &&
-                !selectedSize
-                  ? " and"
-                  : ""}
-                {availableSizes.length > 0 && !selectedSize ? " size" : ""} to
-                continue.
-              </p>
-            )}
             <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:gap-4">
               <BuyNowButton
                 product={selectedPriceProduct}


### PR DESCRIPTION
-Replace uniform **Set A/Set B** variation values with color based **White/Purple** options and mark them as autoSelect. When an admin changes a product category, preselect any autoSelect variations for the new category instead of clearing all selections. This avoids stale, category-scoped variation picks and keeps bundled uniform options selectable.

-Also remove the default fallback product image so items without a real image render with an empty state.