### PR TITLE
fix(events): enforce registration and attendance rules

### DIFF
--- a/client-side-ts/src/features/admin/event-management/components/AttendeesTable.tsx
+++ b/client-side-ts/src/features/admin/event-management/components/AttendeesTable.tsx
@@ -558,27 +558,58 @@ export const AttendeesTable: React.FC<AttendeesTableProps> = ({
   const WALK_IN_ONLY_CAMPUSES = ["UC_MAIN", "UC_CS"];
   const isWalkInOnlyCampus = WALK_IN_ONLY_CAMPUSES.includes(adminCampus ?? "");
 
-  const getAttendanceSummary = (attendance: Attendee["attendance"]) => {
-    if (!isAttendanceAvailable) {
-      return "Not Available Yet";
-    }
-
+  const getAttendedSessionCount = (attendance: Attendee["attendance"]) => {
     const sessions = [
       attendance?.morning?.attended,
       attendance?.afternoon?.attended,
       attendance?.evening?.attended,
     ];
-    const attendedCount = sessions.filter(Boolean).length;
-
-    return `${attendedCount}/3 Sessions`;
+    return sessions.filter(Boolean).length;
   };
 
   const computeIsPresent = (attendance: Attendee["attendance"]): boolean => {
-    return Boolean(
-      attendance?.morning?.attended ||
-      attendance?.afternoon?.attended ||
-      attendance?.evening?.attended
-    );
+    return getAttendedSessionCount(attendance) > 0;
+  };
+
+  const getAttendanceSummary = (attendance: Attendee["attendance"]) => {
+    if (!isAttendanceAvailable) {
+      return "Not Available Yet";
+    }
+
+    const attendedCount = getAttendedSessionCount(attendance);
+    if (attendedCount > 0) {
+      return `${attendedCount}/3 Sessions`;
+    }
+
+    return isEventEnded ? "0/3 Sessions" : "--";
+  };
+
+  const getAttendanceBadge = (attendance: Attendee["attendance"]) => {
+    if (!isAttendanceAvailable) {
+      return {
+        label: "Attendee",
+        className: "border-gray-200 bg-gray-300 text-gray-700",
+      };
+    }
+
+    if (computeIsPresent(attendance)) {
+      return {
+        label: "Present",
+        className: "border-green-200 bg-green-50 text-green-700",
+      };
+    }
+
+    if (isEventEnded) {
+      return {
+        label: "Absent",
+        className: "border-red-200 bg-red-50 text-red-700",
+      };
+    }
+
+    return {
+      label: "--",
+      className: "border-gray-200 bg-gray-50 text-gray-500",
+    };
   };
 
   const openAttendanceStatus = (attendee: Attendee) => {
@@ -589,11 +620,10 @@ export const AttendeesTable: React.FC<AttendeesTableProps> = ({
   const handleViewDetails = (attendeeId: string) => {
     const student = attendees.find((a) => a.id === attendeeId);
     if (student) {
+      const isPresent = computeIsPresent(student.attendance);
       setSelectedStudent({
         ...student,
-        isPresent: isAttendanceAvailable
-          ? computeIsPresent(student.attendance)
-          : undefined,
+        isPresent: isPresent ? true : isEventEnded ? false : undefined,
       });
       setIsStudentDetailsOpen(true);
     }
@@ -860,10 +890,9 @@ export const AttendeesTable: React.FC<AttendeesTableProps> = ({
                 </TableRow>
               ) : (
                 paginatedAttendees.map((attendee) => {
-                  const isPresent =
-                    attendee.attendance?.morning?.attended ||
-                    attendee.attendance?.afternoon?.attended ||
-                    attendee.attendance?.evening?.attended;
+                  const attendanceBadge = getAttendanceBadge(
+                    attendee.attendance
+                  );
                   return (
                     <TableRow key={attendee.id}>
                       <TableCell>
@@ -892,19 +921,9 @@ export const AttendeesTable: React.FC<AttendeesTableProps> = ({
                         >
                           <Badge
                             variant="outline"
-                            className={
-                              !isAttendanceAvailable
-                                ? "border-gray-200 bg-gray-300 text-gray-700"
-                                : isPresent
-                                  ? "border-green-200 bg-green-50 text-green-700"
-                                  : "border-red-200 bg-red-50 text-red-700"
-                            }
+                            className={attendanceBadge.className}
                           >
-                            {isAttendanceAvailable
-                              ? isPresent
-                                ? "Present"
-                                : "Absent"
-                              : "Attendee"}
+                            {attendanceBadge.label}
                           </Badge>
                         </button>
                       </TableCell>
@@ -992,10 +1011,7 @@ export const AttendeesTable: React.FC<AttendeesTableProps> = ({
           </div>
         ) : (
           paginatedAttendees.map((attendee) => {
-            const isPresent =
-              attendee.attendance?.morning?.attended ||
-              attendee.attendance?.afternoon?.attended ||
-              attendee.attendance?.evening?.attended;
+            const attendanceBadge = getAttendanceBadge(attendee.attendance);
             return (
               <div
                 key={attendee.id}
@@ -1027,19 +1043,9 @@ export const AttendeesTable: React.FC<AttendeesTableProps> = ({
                   >
                     <Badge
                       variant="outline"
-                      className={
-                        !isAttendanceAvailable
-                          ? "border-gray-200 bg-gray-100 text-gray-600"
-                          : isPresent
-                            ? "border-green-200 bg-green-50 text-green-700"
-                            : "border-red-200 bg-red-50 text-red-700"
-                      }
+                      className={attendanceBadge.className}
                     >
-                      {isAttendanceAvailable
-                        ? isPresent
-                          ? "Present"
-                          : "Absent"
-                        : "Attendee"}
+                      {attendanceBadge.label}
                     </Badge>
                   </button>
                 </div>
@@ -1234,6 +1240,7 @@ export const AttendeesTable: React.FC<AttendeesTableProps> = ({
       <ScanQRModal
         open={isScanQROpen}
         onOpenChange={setIsScanQROpen}
+        eventId={eventId}
         onScanSuccess={async (payload: QRCodePayloadV2) => {
           const result = await markAttendanceV2(eventId, payload.studentId, {
             campus: payload.campus,

--- a/client-side-ts/src/features/admin/event-management/components/modals/AttendanceStatusModal.tsx
+++ b/client-side-ts/src/features/admin/event-management/components/modals/AttendanceStatusModal.tsx
@@ -115,7 +115,7 @@ export const AttendanceStatusModal: React.FC<AttendanceStatusModalProps> = ({
                           : "border-slate-200 bg-slate-100 text-slate-700"
                       }
                     >
-                      {attended ? "Attended" : "Not Attended"}
+                      {attended ? "Attended" : "Not recorded"}
                     </Badge>
                   </div>
                 );

--- a/client-side-ts/src/features/admin/event-management/components/modals/EditEventModal.tsx
+++ b/client-side-ts/src/features/admin/event-management/components/modals/EditEventModal.tsx
@@ -13,6 +13,7 @@ import type { EventFormData } from "./AddEventModal";
 import { showToast } from "@/utils/alertHelper";
 import { updateEventDetails } from "@/features/events/api/eventService";
 import axios from "axios";
+import { format } from "date-fns";
 
 type SessionKey = "morning" | "afternoon" | "evening";
 
@@ -46,6 +47,7 @@ interface EditEventModalProps {
 }
 
 const SESSION_KEYS: SessionKey[] = ["morning", "afternoon", "evening"];
+const formatDateKey = (date: Date): string => format(date, "yyyy-MM-dd");
 
 /**
  * Factory rather than a shared constant: each form instance gets its own
@@ -171,8 +173,12 @@ export const EditEventModal: React.FC<EditEventModalProps> = ({
       const payload: Parameters<typeof updateEventDetails>[1] = {
         eventName: formData.eventName,
         eventDescription: formData.eventDescription,
-        eventDate: formData.eventSchedule?.from?.toISOString(),
-        eventEndDate: formData.eventSchedule?.to?.toISOString(),
+        eventDate: formData.eventSchedule?.from
+          ? formatDateKey(formData.eventSchedule.from)
+          : undefined,
+        eventEndDate: formData.eventSchedule?.to
+          ? formatDateKey(formData.eventSchedule.to)
+          : undefined,
         eventVenue: formData.eventVenue,
         eventTheme: formData.eventTheme,
         eventVenueSpecific: formData.eventVenueSpecific,

--- a/client-side-ts/src/features/admin/event-management/components/modals/ScanQRModal.tsx
+++ b/client-side-ts/src/features/admin/event-management/components/modals/ScanQRModal.tsx
@@ -15,7 +15,12 @@ import type { QRCodePayloadV2 } from "@/features/events/types/event.types";
 interface ScanQRModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  eventId: string;
   onScanSuccess: (payload: QRCodePayloadV2) => Promise<boolean>;
+}
+
+function normalizeEventId(value: string): string {
+  return value.trim().toLowerCase();
 }
 
 function parseQRPayload(raw: string): QRCodePayloadV2 | null {
@@ -41,6 +46,7 @@ function parseQRPayload(raw: string): QRCodePayloadV2 | null {
 export const ScanQRModal: React.FC<ScanQRModalProps> = ({
   open,
   onOpenChange,
+  eventId,
   onScanSuccess,
 }) => {
   const [error, setError] = useState("");
@@ -59,6 +65,11 @@ export const ScanQRModal: React.FC<ScanQRModalProps> = ({
     const payload = parseQRPayload(scannedValue);
 
     if (payload) {
+      if (normalizeEventId(payload.eventId) !== normalizeEventId(eventId)) {
+        setError("This QR code is for another event.");
+        return;
+      }
+
       setError("");
       setIsProcessingScan(true);
 

--- a/client-side-ts/src/features/events/components/EventCard.tsx
+++ b/client-side-ts/src/features/events/components/EventCard.tsx
@@ -20,7 +20,7 @@ import { applyToEvent } from "@/features/events";
 import { useAuth } from "@/features/auth";
 import type { EventData } from "@/features/events/types/event.types";
 import { createQRPayload } from "@/features/events/utils/qrPayload.utils";
-import { getManilaStartOfDay } from "@/utils/date-manila";
+import { formatEventDateKey } from "@/utils/date-manila";
 import { CalendarDays, CheckCircle2, MapPin, XCircle } from "lucide-react";
 import React, { useMemo, useState } from "react";
 
@@ -59,6 +59,49 @@ const AttendancePill = React.memo<{ attended: boolean; label?: string }>(
   )
 );
 
+const MANILA_UTC_OFFSET = "+08:00";
+const TIME_ONLY_PATTERN = /^([01]\d|2[0-3]):([0-5]\d)$/;
+const SESSION_ORDER = ["morning", "afternoon", "evening"] as const;
+
+const normalizeTimeValue = (value: unknown): string | null => {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return TIME_ONLY_PATTERN.test(trimmed) ? trimmed : null;
+};
+
+const getFirstSessionStartTime = (
+  sessionConfig: EventData["sessionConfig"]
+): string | null => {
+  if (!sessionConfig) return null;
+
+  for (const sessionKey of SESSION_ORDER) {
+    const session = sessionConfig[sessionKey];
+    if (!session?.enabled) continue;
+
+    const [start] = String(session.timeRange ?? "").split(" - ");
+    const normalizedStart = normalizeTimeValue(start);
+    if (normalizedStart) return normalizedStart;
+  }
+
+  return null;
+};
+
+const buildManilaDateTime = (
+  dateValue: Date | undefined,
+  timeValue: string | null,
+  fallbackTime: string
+): Date | null => {
+  if (!dateValue || Number.isNaN(dateValue.getTime())) return null;
+
+  const dateKey = formatEventDateKey(dateValue);
+  const time = timeValue ?? fallbackTime;
+  const parsedDateTime = new Date(
+    `${dateKey}T${time}:00${MANILA_UTC_OFFSET}`
+  );
+
+  return Number.isNaN(parsedDateTime.getTime()) ? null : parsedDateTime;
+};
+
 export const EventCard: React.FC<EventCardProps> = ({
   event,
   studentId,
@@ -74,11 +117,18 @@ export const EventCard: React.FC<EventCardProps> = ({
     isPast,
   } = event;
   const normalizedStatus = String(event.status ?? "").toLowerCase();
-  const hasEventStartedByDate = event.date
-    ? event.date <= getManilaStartOfDay()
-    : true;
+  const eventStartsAt = buildManilaDateTime(
+    event.date,
+    normalizeTimeValue(event.startTime) ??
+      getFirstSessionStartTime(sessionConfig),
+    "00:00"
+  );
+  const hasEventStartedBySchedule =
+    !eventStartsAt || new Date() >= eventStartsAt;
+  const isRegistrationManuallyClosed =
+    normalizedStatus === "ended" || normalizedStatus === "cancelled";
   const isStudentRegistrationOpen =
-    normalizedStatus === "upcoming" && !hasEventStartedByDate;
+    !isRegistrationManuallyClosed && !hasEventStartedBySchedule;
   const { user } = useAuth();
 
   const [failedImageUrl, setFailedImageUrl] = useState<string | null>(null);

--- a/client-side-ts/src/features/events/components/EventCard.tsx
+++ b/client-side-ts/src/features/events/components/EventCard.tsx
@@ -72,8 +72,13 @@ export const EventCard: React.FC<EventCardProps> = ({
     attendees,
     sessionConfig,
     isPast,
-    attendanceType,
   } = event;
+  const normalizedStatus = String(event.status ?? "").toLowerCase();
+  const hasEventStartedByDate = event.date
+    ? event.date <= getManilaStartOfDay()
+    : true;
+  const isStudentRegistrationOpen =
+    normalizedStatus === "upcoming" && !hasEventStartedByDate;
   const { user } = useAuth();
 
   const [failedImageUrl, setFailedImageUrl] = useState<string | null>(null);
@@ -180,23 +185,11 @@ export const EventCard: React.FC<EventCardProps> = ({
   ]);
 
   // ── QR visibility gate ──────────────────────────────────────────────────
-  // Applied students always see their QR. Otherwise, only on the event day
-  // itself is the QR open as a walk-in allowance — but only for "open"
-  // events, since scanning the QR auto-registers the attendee server-side
-  // (see resolveAttendanceAttendee). Before the event day, unregistered
-  // students see the Register button. Ticketed events always keep the
-  // Register button until the student has applied.
+  // Students must register first; only attendees already attached to this
+  // event can show a QR that admin attendance can accept.
   const canShowQR = useMemo(() => {
-    if (studentAttendee) return true;
-    if (attendanceType !== "open") return false;
-    if (!event.date) return false;
-    const today = getManilaStartOfDay();
-    const eventDay = getManilaStartOfDay(event.date);
-    const daysUntil = Math.round(
-      (eventDay.getTime() - today.getTime()) / 86_400_000
-    );
-    return daysUntil <= 0;
-  }, [studentAttendee, event.date, attendanceType]);
+    return Boolean(studentAttendee);
+  }, [studentAttendee]);
 
   return (
     <Card className="h-full rounded-2xl transition-all hover:shadow-md">
@@ -333,7 +326,7 @@ export const EventCard: React.FC<EventCardProps> = ({
                           </div>
                         )}
                       </>
-                    ) : (
+                    ) : isStudentRegistrationOpen ? (
                       <div className="flex w-full flex-col items-center gap-3 px-4 py-6 text-center">
                         <h4 className="text-base font-semibold text-gray-800">
                           {title}
@@ -351,6 +344,17 @@ export const EventCard: React.FC<EventCardProps> = ({
                         >
                           {isRegister ? "Registering..." : "Register Event"}
                         </Button>
+                      </div>
+                    ) : (
+                      <div className="flex w-full flex-col items-center gap-3 px-4 py-6 text-center">
+                        <h4 className="text-base font-semibold text-gray-800">
+                          Registration closed
+                        </h4>
+                        <div className="max-h-32 w-full overflow-y-auto rounded-lg bg-gray-50 px-3 py-2">
+                          <p className="text-xs leading-relaxed text-gray-500">
+                            Please ask an admin to add you as a late attendee.
+                          </p>
+                        </div>
                       </div>
                     )}
                   </div>

--- a/client-side-ts/src/features/events/types/event.types.ts
+++ b/client-side-ts/src/features/events/types/event.types.ts
@@ -71,6 +71,7 @@ export interface EventData {
   imageUrl?: string;
   location?: string;
   date?: Date;
+  status?: string;
   attendanceType: string;
   attendees: AttendeeData[];
   sessionConfig?: SessionConfig;

--- a/client-side-ts/src/features/events/types/event.types.ts
+++ b/client-side-ts/src/features/events/types/event.types.ts
@@ -72,6 +72,8 @@ export interface EventData {
   location?: string;
   date?: Date;
   status?: string;
+  startTime?: string;
+  endTime?: string;
   attendanceType: string;
   attendees: AttendeeData[];
   sessionConfig?: SessionConfig;

--- a/client-side-ts/src/pages/admin/EventManagement.tsx
+++ b/client-side-ts/src/pages/admin/EventManagement.tsx
@@ -85,16 +85,66 @@ type EventStatus = EventDetails["status"];
 
 import { formatEventDateLabel, formatEventDateKey } from "@/utils/date-manila";
 
+const MANILA_UTC_OFFSET = "+08:00";
+const TIME_ONLY_PATTERN = /^([01]\d|2[0-3]):([0-5]\d)$/;
+
+const normalizeTimeValue = (value: unknown): string | null => {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return TIME_ONLY_PATTERN.test(trimmed) ? trimmed : null;
+};
+
+const buildManilaDateTime = (
+  dateValue: string | Date | null | undefined,
+  timeValue: string | null,
+  fallbackTime: string
+): Date | null => {
+  if (!dateValue) return null;
+
+  const parsedDate =
+    typeof dateValue === "string" ? new Date(dateValue) : dateValue;
+  if (!parsedDate || Number.isNaN(parsedDate.getTime())) return null;
+
+  const dateKey = formatEventDateKey(parsedDate);
+  const time = timeValue ?? fallbackTime;
+  const parsedDateTime = new Date(
+    `${dateKey}T${time}:00${MANILA_UTC_OFFSET}`
+  );
+
+  return Number.isNaN(parsedDateTime.getTime()) ? null : parsedDateTime;
+};
+
 const normalizeStatus = (
   value: unknown,
   eventDate?: string | Date | null,
-  eventEndDate?: string | Date | null
+  eventEndDate?: string | Date | null,
+  eventStartTime?: string,
+  eventEndTime?: string
 ): EventStatus => {
   const normalized = String(value ?? "")
     .trim()
     .toLowerCase();
 
   if (normalized === "ended" || normalized === "cancelled") return "ended";
+
+  const startsAt = buildManilaDateTime(
+    eventDate,
+    normalizeTimeValue(eventStartTime),
+    "00:00"
+  );
+  const endsAt = buildManilaDateTime(
+    eventEndDate ?? eventDate,
+    normalizeTimeValue(eventEndTime),
+    "23:59"
+  );
+
+  if (startsAt && endsAt) {
+    const now = new Date();
+    if (now < startsAt) return "upcoming";
+    if (now > endsAt) return "ended";
+    return "ongoing";
+  }
+
   if (normalized === "ongoing") return "ongoing";
   if (eventDate) {
     const parsedStartDate =
@@ -241,6 +291,9 @@ const mapApiEventToEventDetails = (
 ): EventDetails => {
   const sessionConfig = event.sessionConfig as EventSessionConfig | undefined;
   const { startTime, endTime } = getSessionBounds(sessionConfig);
+  const effectiveStartTime =
+    normalizeTimeValue(event.eventStartTime) ?? startTime;
+  const effectiveEndTime = normalizeTimeValue(event.eventEndTime) ?? endTime;
   const mappedCampusCodes = Array.isArray(event.limit)
     ? event.limit
         .map((item) => {
@@ -295,7 +348,9 @@ const mapApiEventToEventDetails = (
     status: normalizeStatus(
       event.status,
       event.eventDate,
-      event.eventEndDate ?? event.eventDate
+      event.eventEndDate ?? event.eventDate,
+      effectiveStartTime,
+      effectiveEndTime
     ),
     startDate: formatEventDateLabel(event.eventDate),
     rawStartDate: event.eventDate ? String(event.eventDate) : undefined,

--- a/client-side-ts/src/pages/student/EventAttendance.tsx
+++ b/client-side-ts/src/pages/student/EventAttendance.tsx
@@ -59,6 +59,7 @@ const mapEventToEventData = (event: Event): EventData | null => {
     imageUrl,
     location: "University of Cebu Main Campus",
     date: getManilaStartOfDay(dateValue),
+    status: event.status,
     attendanceType: event.attendanceType || "open",
     attendees: parsedAttendees,
     sessionConfig: event.sessionConfig as SessionConfig | undefined,

--- a/client-side-ts/src/pages/student/EventAttendance.tsx
+++ b/client-side-ts/src/pages/student/EventAttendance.tsx
@@ -60,6 +60,8 @@ const mapEventToEventData = (event: Event): EventData | null => {
     location: "University of Cebu Main Campus",
     date: getManilaStartOfDay(dateValue),
     status: event.status,
+    startTime: event.eventStartTime,
+    endTime: event.eventEndTime,
     attendanceType: event.attendanceType || "open",
     attendees: parsedAttendees,
     sessionConfig: event.sessionConfig as SessionConfig | undefined,

--- a/server-side/src/controllers/eventV2.controller.ts
+++ b/server-side/src/controllers/eventV2.controller.ts
@@ -1763,9 +1763,19 @@ export const applyToEventV2Controller = async (req: Request, res: Response) => {
 
     // ── Students can only pre-register before the event starts. Late
     // attendees must be registered manually by an admin.
+    const normalizedEventStatus = String(event.status ?? "")
+      .trim()
+      .toLowerCase();
+    const isRegistrationManuallyClosed =
+      normalizedEventStatus === "ended" || normalizedEventStatus === "cancelled";
+
     if (
-      event.status !== "Upcoming" ||
-      hasEventStartedByDate(event.eventDate)
+      isRegistrationManuallyClosed ||
+      hasEventStartedBySchedule(
+        event.eventDate,
+        event.eventStartTime,
+        event.sessionConfig
+      )
     ) {
       return res.status(409).json({
         error: "APPLICATIONS_CLOSED",
@@ -2953,6 +2963,9 @@ interface CreateEventV2Body {
 
 const MANILA_TIME_ZONE = "Asia/Manila";
 const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const MANILA_UTC_OFFSET = "+08:00";
+const TIME_ONLY_PATTERN = /^([01]\d|2[0-3]):([0-5]\d)$/;
+const SESSION_ORDER = ["morning", "afternoon", "evening"] as const;
 
 const formatManilaDateKey = (date: Date): string =>
   new Intl.DateTimeFormat("en-CA", {
@@ -2983,11 +2996,60 @@ const parseEventCalendarDate = (value: string): Date | null => {
   return parseManilaMidnightDate(formatManilaDateKey(parsed));
 };
 
-const hasEventStartedByDate = (eventDate: Date | null | undefined) => {
-  if (!eventDate) return true;
-  const eventDateKey = formatManilaDateKey(new Date(eventDate));
-  const todayKey = formatManilaDateKey(new Date());
-  return todayKey >= eventDateKey;
+const normalizeTimeValue = (value: unknown): string | null => {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return TIME_ONLY_PATTERN.test(trimmed) ? trimmed : null;
+};
+
+const getFirstSessionStartTime = (sessionConfig: unknown): string | null => {
+  if (!sessionConfig || typeof sessionConfig !== "object") return null;
+
+  const sessions = sessionConfig as Record<string, unknown>;
+  for (const sessionKey of SESSION_ORDER) {
+    const session = sessions[sessionKey];
+    if (!session || typeof session !== "object") continue;
+
+    const data = session as { enabled?: unknown; timeRange?: unknown };
+    if (data.enabled !== true || typeof data.timeRange !== "string") continue;
+
+    const [start] = data.timeRange.split(" - ");
+    const normalizedStart = normalizeTimeValue(start);
+    if (normalizedStart) return normalizedStart;
+  }
+
+  return null;
+};
+
+const buildManilaDateTime = (
+  dateValue: Date | null | undefined,
+  timeValue: string | null,
+  fallbackTime: string
+): Date | null => {
+  if (!dateValue) return null;
+  const date = new Date(dateValue);
+  if (Number.isNaN(date.getTime())) return null;
+
+  const dateKey = formatManilaDateKey(date);
+  const time = timeValue ?? fallbackTime;
+  const parsedDateTime = new Date(
+    `${dateKey}T${time}:00${MANILA_UTC_OFFSET}`
+  );
+
+  return Number.isNaN(parsedDateTime.getTime()) ? null : parsedDateTime;
+};
+
+const hasEventStartedBySchedule = (
+  eventDate: Date | null | undefined,
+  eventStartTime: unknown,
+  sessionConfig: unknown
+) => {
+  const startTime =
+    normalizeTimeValue(eventStartTime) ??
+    getFirstSessionStartTime(sessionConfig);
+  const startsAt = buildManilaDateTime(eventDate, startTime, "00:00");
+
+  return !startsAt || new Date() >= startsAt;
 };
 
 export const getEventImageController = async (req: Request, res: Response) => {

--- a/server-side/src/controllers/eventV2.controller.ts
+++ b/server-side/src/controllers/eventV2.controller.ts
@@ -1761,11 +1761,16 @@ export const applyToEventV2Controller = async (req: Request, res: Response) => {
         .json({ error: "EVENT_NOT_FOUND", message: "Event not found" });
     }
 
-    // ── Only allow applying while event is Upcoming or Ongoing ──────────
-    if (event.status !== "Upcoming" && event.status !== "Ongoing") {
+    // ── Students can only pre-register before the event starts. Late
+    // attendees must be registered manually by an admin.
+    if (
+      event.status !== "Upcoming" ||
+      hasEventStartedByDate(event.eventDate)
+    ) {
       return res.status(409).json({
         error: "APPLICATIONS_CLOSED",
-        message: "This event is no longer accepting applications",
+        message:
+          "Student registration is closed. Please ask an admin to add you.",
       });
     }
 
@@ -2946,11 +2951,43 @@ interface CreateEventV2Body {
   eventEndTime?: string;
 }
 
+const MANILA_TIME_ZONE = "Asia/Manila";
+const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+const formatManilaDateKey = (date: Date): string =>
+  new Intl.DateTimeFormat("en-CA", {
+    timeZone: MANILA_TIME_ZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(date);
+
 const parseManilaMidnightDate = (value: string): Date | null => {
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
-  const parsed = new Date(`${value}T16:00:00.000Z`);
+  if (!DATE_ONLY_PATTERN.test(value)) return null;
+  const parsed = new Date(`${value}T00:00:00+08:00`);
   if (Number.isNaN(parsed.getTime())) return null;
-  return parsed;
+  return formatManilaDateKey(parsed) === value ? parsed : null;
+};
+
+const parseEventCalendarDate = (value: string): Date | null => {
+  const normalized = value.trim();
+  if (!normalized) return null;
+
+  if (DATE_ONLY_PATTERN.test(normalized)) {
+    return parseManilaMidnightDate(normalized);
+  }
+
+  const parsed = new Date(normalized);
+  if (Number.isNaN(parsed.getTime())) return null;
+
+  return parseManilaMidnightDate(formatManilaDateKey(parsed));
+};
+
+const hasEventStartedByDate = (eventDate: Date | null | undefined) => {
+  if (!eventDate) return true;
+  const eventDateKey = formatManilaDateKey(new Date(eventDate));
+  const todayKey = formatManilaDateKey(new Date());
+  return todayKey >= eventDateKey;
 };
 
 export const getEventImageController = async (req: Request, res: Response) => {
@@ -3181,8 +3218,8 @@ export const updateEventV2Controller = async (
         });
       }
 
-      const parsed = new Date(rawDateValue);
-      if (Number.isNaN(parsed.getTime())) {
+      const parsed = parseEventCalendarDate(rawDateValue);
+      if (!parsed) {
         return res.status(400).json({
           error: "VALIDATION",
           message: "Invalid event date",
@@ -3207,8 +3244,8 @@ export const updateEventV2Controller = async (
         });
       }
 
-      const parsedEnd = new Date(rawEndDateValue);
-      if (Number.isNaN(parsedEnd.getTime())) {
+      const parsedEnd = parseEventCalendarDate(rawEndDateValue);
+      if (!parsedEnd) {
         return res.status(400).json({
           error: "VALIDATION",
           message: "Invalid event end date",

--- a/server-side/src/services/attendance.service.ts
+++ b/server-side/src/services/attendance.service.ts
@@ -370,26 +370,6 @@ function getActiveSession(event: {
   return matchedSessions[0] as keyof IAttendanceSession;
 }
 
-function buildOpenEventAttendee(input: MarkAttendanceInput): EventAttendee {
-  return {
-    _id: new Types.ObjectId(),
-    id_number: input.attendeeIdNumber,
-    name: input.attendeeName,
-    course: input.course || "Unknown",
-    year: input.year || 1,
-    campus: input.campus,
-    attendance: buildDefaultAttendance(),
-    confirmedBy: "",
-    shirtPrice: 0,
-    shirtSize: "",
-    raffleIsRemoved: false,
-    raffleIsWinner: false,
-    transactBy: "",
-    transactDate: null,
-    editedBy: [],
-  };
-}
-
 async function findProjectedAttendee(
   eventId: Types.ObjectId,
   attendeeMatch: Record<string, unknown>,
@@ -411,57 +391,13 @@ async function findProjectedAttendee(
 }
 
 async function resolveAttendanceAttendee(
-  event: Pick<AttendanceEventMetadata, "_id" | "attendanceType">,
+  event: Pick<AttendanceEventMetadata, "_id">,
   input: MarkAttendanceInput,
   session: ClientSession
 ): Promise<{ attendee: EventAttendee; isNewAttendee: boolean }> {
   const eventObjectId = toObjectId(event._id);
   if (!eventObjectId) {
     throw new AttendanceError("EVENT_NOT_FOUND", "Event not found");
-  }
-
-  if (event.attendanceType === "open") {
-    const existing = await findProjectedAttendee(
-      eventObjectId,
-      { id_number: input.attendeeIdNumber },
-      session
-    );
-
-    if (existing) {
-      return { attendee: existing, isNewAttendee: false };
-    }
-
-    const newAttendee = buildOpenEventAttendee(input);
-    const insertResult = await Event.updateOne(
-      {
-        _id: eventObjectId,
-        "attendees.id_number": { $ne: input.attendeeIdNumber },
-      },
-      {
-        $push: {
-          attendees: newAttendee,
-        },
-      },
-      { session }
-    );
-
-    const inserted = await findProjectedAttendee(
-      eventObjectId,
-      { id_number: input.attendeeIdNumber },
-      session
-    );
-
-    if (!inserted) {
-      throw new AttendanceError(
-        "ATTENDEE_NOT_FOUND",
-        "Attendee not found in this event"
-      );
-    }
-
-    return {
-      attendee: inserted,
-      isNewAttendee: insertResult.modifiedCount > 0,
-    };
   }
 
   const attendee = await findProjectedAttendee(
@@ -475,7 +411,7 @@ async function resolveAttendanceAttendee(
   if (!attendee) {
     throw new AttendanceError(
       "ATTENDEE_NOT_FOUND",
-      "Attendee not found in this event"
+      "Student is not registered for this event"
     );
   }
 


### PR DESCRIPTION
## Summary
- Require students to be registered before attendance can be marked
- Block student self-registration once the event date has started
- Allow late attendees to be added manually by admins only
- Reject QR scans from a different event
- Show unmarked ongoing attendance as neutral instead of Absent
- Fix event date handling to avoid one-day timezone shifts

## Verification
- npm run build passed in server-side
- npm run build passed in client-side-ts
- git diff --check passed