### PR TITLE
fix(events): sync event times with sessions

### DIFF
--- a/client-side-ts/src/features/admin/event-management/components/modals/AddEventModal.tsx
+++ b/client-side-ts/src/features/admin/event-management/components/modals/AddEventModal.tsx
@@ -88,6 +88,23 @@ const validateSessions = (config: CanonicalSessionConfig): string | null => {
   return null;
 };
 
+const getSessionBounds = (
+  config: CanonicalSessionConfig
+): { startTime: string; endTime: string } | null => {
+  const enabled = ["morning", "afternoon", "evening"] as const;
+  const ranges = enabled
+    .map((name) => config[name])
+    .filter((entry) => entry.enabled && entry.timeRange)
+    .map((entry) => entry.timeRange);
+
+  if (ranges.length === 0) return null;
+
+  const [startTime = ""] = ranges[0].split(" - ");
+  const [, endTime = ""] = ranges[ranges.length - 1].split(" - ");
+
+  return { startTime, endTime };
+};
+
 export const AddEventModal: React.FC<AddEventModalProps> = ({
   open,
   onOpenChange,
@@ -114,6 +131,12 @@ export const AddEventModal: React.FC<AddEventModalProps> = ({
       return;
     }
 
+    const sessionBounds = getSessionBounds(formData.sessionConfig);
+    if (!sessionBounds) {
+      showToast("error", "Enable at least one session");
+      return;
+    }
+
     setIsSubmitting(true);
 
     try {
@@ -131,8 +154,8 @@ export const AddEventModal: React.FC<AddEventModalProps> = ({
         eventVenue: formData.eventVenue,
         eventTheme: formData.eventTheme,
         eventVenueSpecific: formData.eventVenueSpecific,
-        eventStartTime: formData.eventStartTime,
-        eventEndTime: formData.eventEndTime,
+        eventStartTime: sessionBounds.startTime,
+        eventEndTime: sessionBounds.endTime,
       });
 
       if (result) {

--- a/client-side-ts/src/features/admin/event-management/components/modals/EditEventModal.tsx
+++ b/client-side-ts/src/features/admin/event-management/components/modals/EditEventModal.tsx
@@ -94,6 +94,23 @@ const isSessionComplete = (timeRange: string): boolean => {
   return Boolean(start?.trim() && end?.trim());
 };
 
+const getSessionBounds = (
+  sessionConfig: EventFormData["sessionConfig"]
+): { startTime: string; endTime: string } | null => {
+  const enabledRanges = SESSION_KEYS.map((key) => sessionConfig[key])
+    .filter((session) => session.enabled && isSessionComplete(session.timeRange))
+    .map((session) => session.timeRange);
+
+  if (enabledRanges.length === 0) {
+    return null;
+  }
+
+  const [startTime = ""] = enabledRanges[0].split(" - ");
+  const [, endTime = ""] = enabledRanges[enabledRanges.length - 1].split(" - ");
+
+  return { startTime, endTime };
+};
+
 export const EditEventModal: React.FC<EditEventModalProps> = ({
   open,
   onOpenChange,
@@ -167,6 +184,13 @@ export const EditEventModal: React.FC<EditEventModalProps> = ({
       return;
     }
 
+    const sessionBounds = getSessionBounds(formData.sessionConfig);
+    if (!sessionBounds) {
+      setActiveTab("session-setup");
+      showToast("error", "Please enable at least one attendance session.");
+      return;
+    }
+
     try {
       setIsSaving(true);
 
@@ -182,8 +206,8 @@ export const EditEventModal: React.FC<EditEventModalProps> = ({
         eventVenue: formData.eventVenue,
         eventTheme: formData.eventTheme,
         eventVenueSpecific: formData.eventVenueSpecific,
-        eventStartTime: formData.eventStartTime,
-        eventEndTime: formData.eventEndTime,
+        eventStartTime: sessionBounds.startTime,
+        eventEndTime: sessionBounds.endTime,
         attendanceType: formData.attendanceType,
         sessionConfig: formData.sessionConfig,
       };

--- a/client-side-ts/src/pages/admin/EventManagement.tsx
+++ b/client-side-ts/src/pages/admin/EventManagement.tsx
@@ -178,7 +178,7 @@ const normalizeStatus = (
 
 const getSessionBounds = (
   sessionConfig: EventSessionConfig | undefined
-): { startTime: string; endTime: string } => {
+): { startTime?: string; endTime?: string } => {
   const order: Array<keyof EventSessionConfig> = [
     "morning",
     "afternoon",
@@ -193,12 +193,12 @@ const getSessionBounds = (
     .map((session) => String(session.timeRange));
 
   if (enabledRanges.length === 0) {
-    return { startTime: "TBA", endTime: "TBA" };
+    return {};
   }
 
-  const [firstStart = "TBA"] = enabledRanges[0].split(" - ");
+  const [firstStart] = enabledRanges[0].split(" - ");
   const lastRange = enabledRanges[enabledRanges.length - 1];
-  const [, lastEnd = "TBA"] = lastRange.split(" - ");
+  const [, lastEnd] = lastRange.split(" - ");
 
   return { startTime: firstStart, endTime: lastEnd };
 };
@@ -292,8 +292,13 @@ const mapApiEventToEventDetails = (
   const sessionConfig = event.sessionConfig as EventSessionConfig | undefined;
   const { startTime, endTime } = getSessionBounds(sessionConfig);
   const effectiveStartTime =
-    normalizeTimeValue(event.eventStartTime) ?? startTime;
-  const effectiveEndTime = normalizeTimeValue(event.eventEndTime) ?? endTime;
+    normalizeTimeValue(startTime) ??
+    normalizeTimeValue(event.eventStartTime) ??
+    undefined;
+  const effectiveEndTime =
+    normalizeTimeValue(endTime) ??
+    normalizeTimeValue(event.eventEndTime) ??
+    undefined;
   const mappedCampusCodes = Array.isArray(event.limit)
     ? event.limit
         .map((item) => {
@@ -354,14 +359,14 @@ const mapApiEventToEventDetails = (
     ),
     startDate: formatEventDateLabel(event.eventDate),
     rawStartDate: event.eventDate ? String(event.eventDate) : undefined,
-    startTime,
+    startTime: effectiveStartTime ?? "TBA",
     endDate: formatEventDateLabel(event.eventEndDate ?? event.eventDate),
     rawEndDate: event.eventEndDate
       ? String(event.eventEndDate)
       : event.eventDate
         ? String(event.eventDate)
         : undefined,
-    endTime,
+    endTime: effectiveEndTime ?? "TBA",
     location:
       (typeof event.eventVenue === "string" && event.eventVenue) ||
       "Location not specified",
@@ -379,8 +384,8 @@ const mapApiEventToEventDetails = (
         : "ticketed",
     eventTheme: event.eventTheme as string | undefined,
     eventVenueSpecific: event.eventVenueSpecific as string | undefined,
-    eventStartTime: event.eventStartTime as string | undefined,
-    eventEndTime: event.eventEndTime as string | undefined,
+    eventStartTime: effectiveStartTime,
+    eventEndTime: effectiveEndTime,
     sessionConfig: normalizeSessionConfig(sessionConfig),
   };
 };
@@ -702,10 +707,7 @@ const EventManagement: React.FC = () => {
                             {formatFullMonthDate(eventDetails.rawStartDate)}
                           </p>
                           <p className="text-muted-foreground text-xs">
-                            {formatTimeToAMPM(
-                              eventDetails.eventStartTime ||
-                                eventDetails.startTime
-                            )}
+                            {formatTimeToAMPM(eventDetails.startTime)}
                           </p>
                         </div>
                       </div>
@@ -717,9 +719,7 @@ const EventManagement: React.FC = () => {
                             {formatFullMonthDate(eventDetails.rawEndDate)}
                           </p>
                           <p className="text-muted-foreground text-xs">
-                            {formatTimeToAMPM(
-                              eventDetails.eventEndTime || eventDetails.endTime
-                            )}
+                            {formatTimeToAMPM(eventDetails.endTime)}
                           </p>
                         </div>
                       </div>

--- a/client-side-ts/src/pages/student/EventAttendance.tsx
+++ b/client-side-ts/src/pages/student/EventAttendance.tsx
@@ -25,6 +25,35 @@ import { EventCard, getMyEvents } from "@/features/events";
 import React, { useEffect, useState, useCallback } from "react";
 import { InfinitySpin } from "react-loader-spinner";
 
+const SESSION_ORDER = ["morning", "afternoon", "evening"] as const;
+const TIME_ONLY_PATTERN = /^([01]\d|2[0-3]):([0-5]\d)$/;
+
+const normalizeTimeValue = (value: unknown): string | undefined => {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return TIME_ONLY_PATTERN.test(trimmed) ? trimmed : undefined;
+};
+
+const getSessionBounds = (
+  sessionConfig: SessionConfig | undefined
+): { startTime?: string; endTime?: string } => {
+  const enabledRanges = SESSION_ORDER.map((key) => sessionConfig?.[key])
+    .filter((session) => Boolean(session?.enabled && session?.timeRange))
+    .map((session) => String(session?.timeRange));
+
+  if (enabledRanges.length === 0) {
+    return {};
+  }
+
+  const [startTime] = enabledRanges[0].split(" - ");
+  const [, endTime] = enabledRanges[enabledRanges.length - 1].split(" - ");
+
+  return {
+    startTime: normalizeTimeValue(startTime),
+    endTime: normalizeTimeValue(endTime),
+  };
+};
+
 // ─── Mapper: Raw Event → Frontend EventData ───────────────────────────────────
 // The event already has `attendees` pre-filtered to the requesting student
 // (0 or 1 records) — handled server-side
@@ -52,6 +81,9 @@ const mapEventToEventData = (event: Event): EventData | null => {
       : event.eventDate;
   if (!dateValue || Number.isNaN(dateValue.getTime())) return null;
 
+  const sessionConfig = event.sessionConfig as SessionConfig | undefined;
+  const sessionBounds = getSessionBounds(sessionConfig);
+
   return {
     id: (event.eventId || event._id) as string,
     title: event.eventName,
@@ -60,11 +92,11 @@ const mapEventToEventData = (event: Event): EventData | null => {
     location: "University of Cebu Main Campus",
     date: getManilaStartOfDay(dateValue),
     status: event.status,
-    startTime: event.eventStartTime,
-    endTime: event.eventEndTime,
+    startTime: sessionBounds.startTime ?? event.eventStartTime,
+    endTime: sessionBounds.endTime ?? event.eventEndTime,
     attendanceType: event.attendanceType || "open",
     attendees: parsedAttendees,
-    sessionConfig: event.sessionConfig as SessionConfig | undefined,
+    sessionConfig,
   };
 };
 

--- a/server-side/src/controllers/eventV2.controller.ts
+++ b/server-side/src/controllers/eventV2.controller.ts
@@ -3021,6 +3021,25 @@ const getFirstSessionStartTime = (sessionConfig: unknown): string | null => {
   return null;
 };
 
+const getLastSessionEndTime = (sessionConfig: unknown): string | null => {
+  if (!sessionConfig || typeof sessionConfig !== "object") return null;
+
+  const sessions = sessionConfig as Record<string, unknown>;
+  for (const sessionKey of [...SESSION_ORDER].reverse()) {
+    const session = sessions[sessionKey];
+    if (!session || typeof session !== "object") continue;
+
+    const data = session as { enabled?: unknown; timeRange?: unknown };
+    if (data.enabled !== true || typeof data.timeRange !== "string") continue;
+
+    const [, end] = data.timeRange.split(" - ");
+    const normalizedEnd = normalizeTimeValue(end);
+    if (normalizedEnd) return normalizedEnd;
+  }
+
+  return null;
+};
+
 const buildManilaDateTime = (
   dateValue: Date | null | undefined,
   timeValue: string | null,
@@ -3045,8 +3064,8 @@ const hasEventStartedBySchedule = (
   sessionConfig: unknown
 ) => {
   const startTime =
-    normalizeTimeValue(eventStartTime) ??
-    getFirstSessionStartTime(sessionConfig);
+    getFirstSessionStartTime(sessionConfig) ??
+    normalizeTimeValue(eventStartTime);
   const startsAt = buildManilaDateTime(eventDate, startTime, "00:00");
 
   return !startsAt || new Date() >= startsAt;
@@ -3158,6 +3177,14 @@ export const createEventV2Controller = async (req: Request, res: Response) => {
     const parsedEndDate = body.eventEndDate
       ? parseManilaMidnightDate(body.eventEndDate)
       : null;
+    const derivedEventStartTime =
+      getFirstSessionStartTime(parsedSessionConfigResult) ??
+      normalizeTimeValue(body.eventStartTime) ??
+      "";
+    const derivedEventEndTime =
+      getLastSessionEndTime(parsedSessionConfigResult) ??
+      normalizeTimeValue(body.eventEndTime) ??
+      "";
 
     const eventFields: Record<string, unknown> = {
       eventId: new mongoose.Types.ObjectId(),
@@ -3179,10 +3206,8 @@ export const createEventV2Controller = async (req: Request, res: Response) => {
         typeof body.eventVenueSpecific === "string"
           ? body.eventVenueSpecific.trim()
           : "",
-      eventStartTime:
-        typeof body.eventStartTime === "string" ? body.eventStartTime : "",
-      eventEndTime:
-        typeof body.eventEndTime === "string" ? body.eventEndTime : "",
+      eventStartTime: derivedEventStartTime,
+      eventEndTime: derivedEventEndTime,
     };
 
     if (parsedEndDate) {
@@ -3349,6 +3374,14 @@ export const updateEventV2Controller = async (
         });
       }
       updateFields.sessionConfig = parsedSessionConfigResult;
+      updateFields.eventStartTime =
+        getFirstSessionStartTime(parsedSessionConfigResult) ??
+        normalizeTimeValue(eventStartTime) ??
+        "";
+      updateFields.eventEndTime =
+        getLastSessionEndTime(parsedSessionConfigResult) ??
+        normalizeTimeValue(eventEndTime) ??
+        "";
     }
 
     if (limit !== undefined) {


### PR DESCRIPTION
## Summary
- Use enabled session windows as source for event start/end display
- Sync create/edit payload times from first enabled session to last enabled session
- Make student registration timing use session-derived start time
- Make backend registration gate prefer session schedule over stale event time fields

## Testing
- Ran `npm run build` in `client-side-ts`
- Ran `npm run build` in `server-side`
- Ran `git diff --check`