### PR TITLE
feat: rework event dates and add forgot-password cooldown

### DIFF
--- a/client-side-ts/src/data/events.utils.ts
+++ b/client-side-ts/src/data/events.utils.ts
@@ -1,0 +1,46 @@
+import type { EventItem } from "@/data/sections-data";
+
+const MANILA_TIMEZONE = "Asia/Manila";
+
+export const isEventPast = (event: EventItem, now = new Date()): boolean =>
+  now.getTime() > new Date(event.endDateTime).getTime();
+
+export const formatEventDateRange = (event: EventItem): string => {
+  const start = new Date(event.startDateTime);
+  const end = new Date(event.endDateTime);
+
+  const dateLabel = new Intl.DateTimeFormat("en-US", {
+    timeZone: MANILA_TIMEZONE,
+    month: "long",
+    day: "numeric",
+  }).format(start);
+
+  const timeFormatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: MANILA_TIMEZONE,
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  });
+
+  return `${dateLabel} - ${timeFormatter.format(start)} - ${timeFormatter.format(end)}`;
+};
+
+export const getManilaDateParts = (
+  iso: string
+): { year: number; month: string; day: string } => {
+  const date = new Date(iso);
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: MANILA_TIMEZONE,
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).formatToParts(date);
+
+  const get = (type: string) => parts.find((p) => p.type === type)?.value ?? "";
+
+  return {
+    year: Number(get("year")),
+    month: get("month"),
+    day: get("day"),
+  };
+};

--- a/client-side-ts/src/data/sections-data.ts
+++ b/client-side-ts/src/data/sections-data.ts
@@ -253,184 +253,168 @@ export const deansMessageData = {
   },
 };
 
-// --- Upcoming Events Data ---
-
-export interface UpcomingEvent {
+// --- Events Data ---
+export interface EventItem {
   id: number;
   title: string;
-  date: string;
   location: string;
   image: string;
+  startDateTime: string; // ISO string with explicit +08:00 (Asia/Manila) offset
+  endDateTime: string; // ISO string with explicit +08:00 (Asia/Manila) offset
+  description: string;
 }
 
-export const upcomingEventsData: {
-  header: {
-    title: string;
-    year: string;
-  };
-  events: UpcomingEvent[];
-} = {
-  header: {
-    title: "Upcoming Events",
-    year: "2026",
-  },
+export const eventsData: { events: EventItem[] } = {
   events: [
     {
       id: 1,
       title: "CCS Freshmen Orientation 2026",
-      date: "August 24 - 8:00 AM - 5:00 PM",
       location: "University of Cebu Jones 15th Floor",
-    image: FreshmanOrientation26,
-  }
-  ],
-};
-
-// --- Past Events Data ---
-export const pastEventsData = {
-  header: {
-    title: "Past Events",
-    year: "2026",
-  },
-  events: [
+      image: FreshmanOrientation26,
+      startDateTime: "2026-08-24T08:00:00+08:00",
+      endDateTime: "2026-08-24T17:00:00+08:00",
+      description:
+        "The CCS Freshmen Orientation 2026 welcomed new College of Computer Studies students at the University of Cebu Jones 15th Floor, introducing them to the college's programs, faculty, and student organizations to help them start their academic journey with confidence.",
+    },
     {
       id: 14,
       title: "12th Cebu ICT Congress 2026",
       location: "New Cebu Coliseum Cebu City",
-      year: 2026,
-      date: { month: "April", day: "22" },
+      image: ICTCongress26,
+      startDateTime: "2026-04-22T00:00:00+08:00",
+      endDateTime: "2026-04-22T23:59:59+08:00",
       description:
         "The 12th ICT Congress gathered students from the University of Cebu campuses on April 22, 2026, at the Cebu Coliseum for a day of innovation, collaboration, and learning. Participants explored emerging technologies, shared ideas through exhibits and presentations, and demonstrated the CCS core values of initiative, innovation, and service while connecting with fellow future IT professionals.",
-      image: ICTCongress26,
     },
     {
       id: 13,
       title: "CCS Git Together 2026",
       location: "Mandani Bay",
-      year: 2026,
-      date: { month: "March", day: "28" },
+      image: CSSGitTogether,
+      startDateTime: "2026-03-28T00:00:00+08:00",
+      endDateTime: "2026-03-28T23:59:59+08:00",
       description:
         "CCS Git Together 2026 brought the College of Computer Studies community together for an evening of celebration, connection, and unforgettable memories on March 28, 2026, at Mandani Bay. With the theme Black and White, students, faculty, and staff enjoyed a night of music, entertainment, and camaraderie, strengthening friendships and fostering a greater sense of unity within the department.",
-      image: CSSGitTogether,
     },
     {
       id: 12,
       title: "UC Intramurals 2025-2026",
       location: "University of Cebu Main Campus",
-      year: 2026,
-      date: { month: "March", day: "4" },
+      image: Intrams25,
+      startDateTime: "2026-03-04T00:00:00+08:00",
+      endDateTime: "2026-03-04T23:59:59+08:00",
       description:
         "The UC Intramurals 2025–2026 brought together students from different departments for three days of sports, performances, and school spirit at the University of Cebu Main Campus from March 4–6, 2026. CCS students proudly represented their department, demonstrating teamwork, determination, and camaraderie in various competitions while fostering lasting memories throughout the event.",
-      image: Intrams25,
     },
     {
       id: 11,
       title: "CCS Days Competition 2026",
       location: "University of Cebu Main Campus",
-      year: 2026,
-      date: { month: "March", day: "2" },
+      image: CCSDays26,
+      startDateTime: "2026-03-02T00:00:00+08:00",
+      endDateTime: "2026-03-02T23:59:59+08:00",
       description:
         "CCS Days Competition 2026 gathered aspiring tech students for two days of exciting competitions held on March 2–3, 2026. Participants showcased their skills in programming, UI/UX design, networking, hackathon challenges, and the General IT Quiz, demonstrating creativity, problem-solving, teamwork, and technical excellence while competing for the opportunity to represent the college in future events.",
-      image: CCSDays26,
     },
-        {
+    {
       id: 10,
       title: "AI-Driven Embedded Systems Project Exhibit 2025",
       location: "University of Cebu Main Campus",
-      year: 2025,
-      date: { month: "December", day: "18" },
+      image: ProjectExhibit25,
+      startDateTime: "2025-12-18T00:00:00+08:00",
+      endDateTime: "2025-12-18T23:59:59+08:00",
       description:
         "The College of Computer Studies (CCS) at the University of Cebu Main Campus showcased innovative student projects during the AI-Driven Embedded Systems Project Exhibit 2025 held on December 18, 2025. The exhibit highlighted AI-powered embedded systems developed by students, demonstrating their technical skills, creativity, and innovative solutions to real-world problems.",
-      image: ProjectExhibit25,
     },
     {
       id: 9,
       title: "CCS Freshman Orientation 2025",
       location: "University of Cebu Main Campus",
-      year: 2025,
-      date: { month: "August", day: "13" },
+      image: Orientation,
+      startDateTime: "2025-08-13T00:00:00+08:00",
+      endDateTime: "2025-08-13T23:59:59+08:00",
       description:
         "The College of Computer Studies (CCS) at the University of Cebu Main Campus warmly welcomed its new batch of students during the CCS Orientation 2025 held on August 13, 2025. The event was designed to introduce freshmen to the college's programs, faculty, and student organizations.",
-      image: Orientation,
     },
     {
       id: 8,
       title: "11th ICT Congress 2025",
       location: "SM Seaside City Cebu",
-      year: 2025,
-      date: { month: "April", day: "12" },
+      image: ICT,
+      startDateTime: "2025-04-12T00:00:00+08:00",
+      endDateTime: "2025-04-12T23:59:59+08:00",
       description:
         "The 11th ICT Congress 2025 at SM Seaside City Cebu was a landmark event that brought together IT enthusiasts, professionals, and students from across the region. The congress featured a series of keynote speeches, panel discussions, and workshops focused on the latest trends and innovations in information and communication technology.",
-      image: ICT,
     },
     {
       id: 7,
       title: "CCS Days",
       location: "University of Cebu Main Campus",
-      year: 2025,
-      date: { month: "February", day: "12" },
+      image: CCSDays,
+      startDateTime: "2025-02-12T00:00:00+08:00",
+      endDateTime: "2025-02-12T23:59:59+08:00",
       description:
         "CCS Days at the University of Cebu Main Campus was a vibrant celebration of technology, creativity, and community spirit. The event spanned several days and featured a variety of activities including coding competitions, hackathons, tech talks, and exhibitions showcasing student projects.",
-      image: CCSDays,
     },
     {
       id: 6,
       title: "Cebu Blockchain Conference 2025",
       location: "IEC Convention Center Cebu",
-      year: 2025,
-      date: { month: "January", day: "17" },
+      image: Blockchain,
+      startDateTime: "2025-01-17T00:00:00+08:00",
+      endDateTime: "2025-01-17T23:59:59+08:00",
       description:
         "The Cebu Blockchain Conference 2025 held at the IEC Convention Center Cebu was a groundbreaking event that delved into the transformative potential of blockchain technology. The conference attracted industry leaders, developers, entrepreneurs, and enthusiasts eager to explore the applications and implications of blockchain across various sectors.",
-      image: Blockchain,
     },
     {
       id: 5,
       title: "Nihonggo Culminating Activity 2024",
       location: "University of Cebu Main Campus",
-      year: 2024,
-      date: { month: "December", day: "17" },
+      image: Nihonggo,
+      startDateTime: "2024-12-17T00:00:00+08:00",
+      endDateTime: "2024-12-17T23:59:59+08:00",
       description:
         "The Nihonggo Culminating Activity 2024 at the University of Cebu Main Campus was a festive event that marked the conclusion of the Nihonggo language program for the year. The activity showcased the progress and achievements of students who had been studying the Japanese language and culture throughout the semester.",
-      image: Nihonggo,
     },
     {
       id: 4,
       title: "Embedded Systems and IOT Project Exhibit 2024",
       location: "University of Cebu Main Campus",
-      year: 2024,
-      date: { month: "November", day: "17" },
+      image: EmbeddedSystems,
+      startDateTime: "2024-11-17T00:00:00+08:00",
+      endDateTime: "2024-11-17T23:59:59+08:00",
       description:
         "The Embedded Systems and IoT Project Exhibit 2024 at the University of Cebu Main Campus was an exciting event that highlighted the innovative projects developed by students in the fields of embedded systems and the Internet of Things (IoT). The exhibit provided a platform for students to showcase their creativity, technical skills, and problem-solving abilities.",
-      image: EmbeddedSystems,
     },
     {
       id: 3,
       title: "UC CCS Cares and Internship 2024",
       location: "University of Cebu Main Campus",
-      year: 2024,
-      date: { month: "November", day: "17" },
+      image: UCCCSCares,
+      startDateTime: "2024-11-17T00:00:00+08:00",
+      endDateTime: "2024-11-17T23:59:59+08:00",
       description:
         "The UC CCS Cares and Internship 2024 program at the University of Cebu Main Campus was a commendable initiative that combined community service with practical work experience for students. The program aimed to foster a sense of social responsibility among students while providing them with valuable insights into their future careers.",
-      image: UCCCSCares,
     },
     {
       id: 2,
       title: "UC Intramurals",
       location: "University of Cebu Main Campus",
-      year: 2024,
-      date: { month: "November", day: "20" },
+      image: UCIntramurals,
+      startDateTime: "2024-11-20T00:00:00+08:00",
+      endDateTime: "2024-11-20T23:59:59+08:00",
       description:
         "The UC Intramurals at the University of Cebu Main Campus was a lively event that brought together students from various departments to compete in a range of sports and recreational activities. The intramurals fostered camaraderie, sportsmanship, and school spirit among participants and spectators alike.",
-      image: UCIntramurals,
     },
     {
       id: 1,
       title: "CCS Acquaintance Party 2024",
       location: "SM Seaside City Cebu",
-      year: 2024,
-      date: { month: "November", day: "16" },
+      image: CCSAcquaintance,
+      startDateTime: "2024-11-16T00:00:00+08:00",
+      endDateTime: "2024-11-16T23:59:59+08:00",
       description:
         "On November 16, 2024, the CCS Acquaintance Party brought together students, faculty, and alumni at SM Seaside City Cebu for a night inspired by the timeless allure of the Old Money theme. The event was a celebration of camaraderie, elegance, and the rich heritage of the College of Computer Studies (CCS) community.",
-      image: CCSAcquaintance,
     },
   ],
 };

--- a/client-side-ts/src/features/admin/devtools/components/ActivityLogPanel.tsx
+++ b/client-side-ts/src/features/admin/devtools/components/ActivityLogPanel.tsx
@@ -11,7 +11,20 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Search, Trash2, Calendar, ChevronLeft, ChevronRight } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Search,
+  Trash2,
+  ChevronLeft,
+  ChevronRight,
+  RotateCw,
+} from "lucide-react";
 
 const ACTION_FILTER_OPTIONS = [
   { value: "Invalidated Session", label: "Invalidated Session" },
@@ -34,12 +47,11 @@ export const ActivityLogPanel = () => {
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [actionFilter, setActionFilter] = useState("");
-  const [adminFilter, setAdminFilter] = useState("");
-  const [targetFilter, setTargetFilter] = useState("");
+  const [searchFilter, setSearchFilter] = useState("");
   const [dateFrom, setDateFrom] = useState("");
   const [dateTo, setDateTo] = useState("");
   const [page, setPage] = useState(1);
-  const [pageSize] = useState(50);
+  const [pageSize] = useState(20);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleteDays, setDeleteDays] = useState("30");
 
@@ -51,8 +63,7 @@ export const ActivityLogPanel = () => {
         skip: (page - 1) * pageSize,
       };
       if (actionFilter) params.action = actionFilter;
-      if (adminFilter) params.admin = adminFilter;
-      if (targetFilter) params.target = targetFilter;
+      if (searchFilter) params.search = searchFilter;
       if (dateFrom) params.dateFrom = dateFrom;
       if (dateTo) params.dateTo = dateTo;
 
@@ -68,11 +79,11 @@ export const ActivityLogPanel = () => {
 
   useEffect(() => {
     setPage(1);
-  }, [actionFilter, adminFilter, targetFilter, dateFrom, dateTo]);
+  }, [actionFilter, searchFilter, dateFrom, dateTo]);
 
   useEffect(() => {
     fetchEntries();
-  }, [page, actionFilter, adminFilter, targetFilter, dateFrom, dateTo]);
+  }, [page, actionFilter, searchFilter, dateFrom, dateTo]);
 
   const handleDeleteOld = async () => {
     try {
@@ -104,52 +115,47 @@ export const ActivityLogPanel = () => {
   return (
     <div>
       <div className="mb-4 flex flex-wrap items-center gap-2">
-        <div className="relative flex-1 min-w-[200px]">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-[#858585]" />
+        <div className="relative min-w-[200px] flex-1">
+          <Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-[#858585]" />
           <input
             type="text"
-            placeholder="Filter by admin..."
-            value={adminFilter}
-            onChange={(e) => setAdminFilter(e.target.value)}
-            className="h-9 w-full rounded-lg border-[#ececec] bg-white pl-9 pr-3 text-sm"
+            placeholder="Search by admin or target..."
+            value={searchFilter}
+            onChange={(e) => setSearchFilter(e.target.value)}
+            className="h-9 w-full rounded-xl border border-[#c2c2c2] bg-white pr-3 pl-9 text-sm"
           />
         </div>
-        <div className="relative flex-1 min-w-[200px]">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-[#858585]" />
-          <input
-            type="text"
-            placeholder="Filter by target..."
-            value={targetFilter}
-            onChange={(e) => setTargetFilter(e.target.value)}
-            className="h-9 w-full rounded-lg border-[#ececec] bg-white pl-9 pr-3 text-sm"
-          />
-        </div>
-        <select
-          value={actionFilter}
-          onChange={(e) => setActionFilter(e.target.value)}
-          className="h-9 w-[200px] rounded-lg border-[#ececec] bg-white px-3 text-sm"
+        <Select
+          value={actionFilter || "all"}
+          onValueChange={(value) =>
+            setActionFilter(value === "all" ? "" : value)
+          }
         >
-          <option value="">All Actions</option>
-          {ACTION_FILTER_OPTIONS.map((opt) => (
-            <option key={opt.value} value={opt.value}>
-              {opt.label}
-            </option>
-          ))}
-        </select>
+          <SelectTrigger className="h-9 w-[200px] rounded-xl border-[#c2c2c2] text-sm">
+            <SelectValue placeholder="All Actions" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Actions</SelectItem>
+            {ACTION_FILTER_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
         <div className="flex items-center gap-2">
-          <Calendar className="h-4 w-4 text-[#858585]" />
           <input
             type="date"
             value={dateFrom}
             onChange={(e) => setDateFrom(e.target.value)}
-            className="h-9 rounded-lg border-[#ececec] bg-white px-3 text-sm"
+            className="h-9 rounded-xl border bg-white px-3 text-sm"
             placeholder="From"
           />
           <input
             type="date"
             value={dateTo}
             onChange={(e) => setDateTo(e.target.value)}
-            className="h-9 rounded-lg border-[#ececec] bg-white px-3 text-sm"
+            className="h-9 rounded-xl border bg-white px-3 text-sm"
             placeholder="To"
           />
         </div>
@@ -160,6 +166,7 @@ export const ActivityLogPanel = () => {
           className="rounded-full"
           onClick={fetchEntries}
         >
+          <RotateCw className="mr-1 h-4 w-4 text-green-400" />
           Refresh
         </Button>
         <Button
@@ -169,35 +176,54 @@ export const ActivityLogPanel = () => {
           className="rounded-full"
           onClick={() => setConfirmDelete(true)}
         >
-          <Trash2 className="mr-1 h-4 w-4" />
+          <Trash2 className="mr-1 h-4 w-4 text-red-400" />
           Delete Old
         </Button>
       </div>
 
       {entries.length === 0 ? (
-        <p className="py-16 text-center text-sm text-[#777]">No activity logs found.</p>
+        <p className="py-16 text-center text-sm text-[#777]">
+          No activity logs found.
+        </p>
       ) : (
         <div className="overflow-x-auto">
           <table className="w-full min-w-[1000px] table-fixed border-collapse text-sm">
             <thead>
               <tr className="rounded-md bg-[#efefef] text-[#2f2f2f]">
-                <th className="w-[15%] rounded-l-md px-2 py-2 text-left font-medium">Timestamp</th>
-                <th className="w-[15%] px-2 py-2 text-left font-medium">Admin</th>
-                <th className="w-[20%] px-2 py-2 text-left font-medium">Action</th>
-                <th className="w-[20%] px-2 py-2 text-left font-medium">Target</th>
-                <th className="w-[15%] px-2 py-2 text-left font-medium">Target Model</th>
-                <th className="w-[15%] rounded-r-md px-2 py-2 text-left font-medium">Target ID</th>
+                <th className="w-[15%] rounded-l-md px-2 py-2 text-left font-medium">
+                  Timestamp
+                </th>
+                <th className="w-[15%] px-2 py-2 text-left font-medium">
+                  Admin
+                </th>
+                <th className="w-[20%] px-2 py-2 text-left font-medium">
+                  Action
+                </th>
+                <th className="w-[20%] px-2 py-2 text-left font-medium">
+                  Target
+                </th>
+                <th className="w-[15%] px-2 py-2 text-left font-medium">
+                  Target Model
+                </th>
+                <th className="w-[15%] rounded-r-md px-2 py-2 text-left font-medium">
+                  Target ID
+                </th>
               </tr>
             </thead>
             <tbody>
               {entries.map((entry) => (
-                <tr key={entry._id} className="border-b border-[#ededed] text-[#303030]">
+                <tr
+                  key={entry._id}
+                  className="border-b border-[#ededed] text-[#303030]"
+                >
                   <td className="px-2 py-3">{formatDate(entry.timestamp)}</td>
                   <td className="truncate px-2 py-3">{entry.admin}</td>
                   <td className="px-2 py-3">{entry.action}</td>
                   <td className="truncate px-2 py-3">{entry.target || "-"}</td>
                   <td className="px-2 py-3">{entry.target_model || "-"}</td>
-                  <td className="truncate px-2 py-3">{entry.target_id || "-"}</td>
+                  <td className="truncate px-2 py-3">
+                    {entry.target_id || "-"}
+                  </td>
                 </tr>
               ))}
             </tbody>
@@ -208,7 +234,8 @@ export const ActivityLogPanel = () => {
       {totalPages > 1 && (
         <div className="mt-4 flex items-center justify-between">
           <span className="text-sm text-[#8a8a8a]">
-            Showing {(page - 1) * pageSize + 1}-{Math.min(page * pageSize, total)} of {total}
+            Showing {(page - 1) * pageSize + 1}-
+            {Math.min(page * pageSize, total)} of {total}
           </span>
           <div className="flex items-center gap-2">
             <Button
@@ -221,7 +248,9 @@ export const ActivityLogPanel = () => {
             >
               <ChevronLeft className="h-4 w-4" />
             </Button>
-            <span className="text-sm text-[#8a8a8a]">Page {page} of {totalPages}</span>
+            <span className="text-sm text-[#8a8a8a]">
+              Page {page} of {totalPages}
+            </span>
             <Button
               type="button"
               variant="outline"
@@ -246,7 +275,9 @@ export const ActivityLogPanel = () => {
             <span className="font-medium">{deleteDays} days</span>.
           </p>
           <div className="mt-4">
-            <label className="mb-2 block text-sm font-medium">Days to keep</label>
+            <label className="mb-2 block text-sm font-medium">
+              Days to keep
+            </label>
             <input
               type="number"
               min="1"

--- a/client-side-ts/src/features/admin/devtools/components/EmailQueuePanel.tsx
+++ b/client-side-ts/src/features/admin/devtools/components/EmailQueuePanel.tsx
@@ -38,7 +38,7 @@ export const EmailQueuePanel = () => {
   const [loading, setLoading] = useState(true);
   const [filter, setFilter] = useState("");
   const [page, setPage] = useState(1);
-  const [pageSize] = useState(50);
+  const [pageSize] = useState(10);
   const [resendAllConfirm, setResendAllConfirm] = useState(false);
   const [failedEmails, setFailedEmails] = useState<FailedEmail[]>([]);
   const [selectedFailed, setSelectedFailed] = useState<Set<string>>(new Set());

--- a/client-side-ts/src/features/admin/devtools/components/NoetixAIPanel.tsx
+++ b/client-side-ts/src/features/admin/devtools/components/NoetixAIPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import {
   getNoetixUsageLogs,
   getNoetixUsageStats,
@@ -12,7 +12,11 @@ import {
   getNoetixMaxIterations,
   setNoetixMaxIterations,
 } from "../api/devtools.api";
-import type { NoetixUsageLog, NoetixUsageStats, NoetixToolItem } from "../types/devtools.types";
+import type {
+  NoetixUsageLog,
+  NoetixUsageStats,
+  NoetixToolItem,
+} from "../types/devtools.types";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -25,11 +29,24 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   Search,
   Trash2,
-  Calendar,
-  ChevronLeft,
-  ChevronRight,
   Bot,
   Plus,
   X,
@@ -60,12 +77,13 @@ export const NoetixAIPanel = () => {
   const [disabledLoading, setDisabledLoading] = useState(true);
   const [tools, setTools] = useState<NoetixToolItem[]>([]);
   const [toolsLoading, setToolsLoading] = useState(true);
+  const [toolCategoryFilter, setToolCategoryFilter] = useState("");
   const [adminFilter, setAdminFilter] = useState("");
   const [successFilter, setSuccessFilter] = useState("");
   const [dateFrom, setDateFrom] = useState("");
   const [dateTo, setDateTo] = useState("");
   const [page, setPage] = useState(1);
-  const [pageSize] = useState(25);
+  const [pageSize] = useState(10);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleteDays, setDeleteDays] = useState("30");
   const [disableConfirm, setDisableConfirm] = useState<string | null>(null);
@@ -131,6 +149,22 @@ export const NoetixAIPanel = () => {
     }
   }, []);
 
+  const toolCategories = useMemo(() => {
+    const seen: string[] = [];
+    for (const t of tools) {
+      if (!seen.includes(t.category)) seen.push(t.category);
+    }
+    return seen;
+  }, [tools]);
+
+  const filteredTools = useMemo(
+    () =>
+      toolCategoryFilter
+        ? tools.filter((t) => t.category === toolCategoryFilter)
+        : tools,
+    [tools, toolCategoryFilter]
+  );
+
   const fetchMaxIterations = useCallback(async () => {
     try {
       const value = await getNoetixMaxIterations();
@@ -191,7 +225,13 @@ export const NoetixAIPanel = () => {
     fetchDisabledAdmins();
     fetchTools();
     fetchMaxIterations();
-  }, [fetchStats, fetchLogs, fetchDisabledAdmins, fetchTools, fetchMaxIterations]);
+  }, [
+    fetchStats,
+    fetchLogs,
+    fetchDisabledAdmins,
+    fetchTools,
+    fetchMaxIterations,
+  ]);
 
   useEffect(() => {
     setPage(1);
@@ -310,7 +350,10 @@ export const NoetixAIPanel = () => {
         </p>
         <div className="flex items-center gap-3">
           <span className="text-sm text-[#555]">
-            Current: <span className="font-mono font-semibold text-[#1c9dde]">{maxIterations}</span>
+            Current:{" "}
+            <span className="font-mono font-semibold text-[#1c9dde]">
+              {maxIterations}
+            </span>
           </span>
           <input
             type="number"
@@ -318,14 +361,17 @@ export const NoetixAIPanel = () => {
             max="50"
             value={maxIterationsValue}
             onChange={(e) => setMaxIterationsValue(e.target.value)}
-            className="h-9 w-20 rounded-lg border-[#ececec] bg-white px-3 text-sm font-mono"
+            className="h-9 w-20 rounded-lg border-[#ececec] bg-white px-3 font-mono text-sm"
           />
           <Button
             type="button"
             size="sm"
             className="rounded-full bg-[#1c9dde] hover:bg-[#168bc7]"
             onClick={handleSaveMaxIterations}
-            disabled={maxIterationsLoading || maxIterationsValue === String(maxIterations)}
+            disabled={
+              maxIterationsLoading ||
+              maxIterationsValue === String(maxIterations)
+            }
           >
             {maxIterationsLoading ? "Saving..." : "Save"}
           </Button>
@@ -341,31 +387,36 @@ export const NoetixAIPanel = () => {
             placeholder="Filter by admin..."
             value={adminFilter}
             onChange={(e) => setAdminFilter(e.target.value)}
-            className="h-9 w-full rounded-lg border-[#ececec] bg-white pr-3 pl-9 text-sm"
+            className="h-9 w-full rounded-xl border border-[#c2c2c2] bg-white pr-3 pl-9 text-sm"
           />
         </div>
-        <select
-          value={successFilter}
-          onChange={(e) => setSuccessFilter(e.target.value)}
-          className="h-9 rounded-lg border-[#ececec] bg-white px-3 text-sm"
+        <Select
+          value={successFilter || "all"}
+          onValueChange={(value) =>
+            setSuccessFilter(value === "all" ? "" : value)
+          }
         >
-          <option value="">All Status</option>
-          <option value="true">Success</option>
-          <option value="false">Failed</option>
-        </select>
+          <SelectTrigger className="h-9 w-[130px] rounded-xl border-[#c2c2c2] text-sm">
+            <SelectValue placeholder="All Status" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Status</SelectItem>
+            <SelectItem value="true">Success</SelectItem>
+            <SelectItem value="false">Failed</SelectItem>
+          </SelectContent>
+        </Select>
         <div className="flex items-center gap-2">
-          <Calendar className="h-4 w-4 text-[#858585]" />
           <input
             type="date"
             value={dateFrom}
             onChange={(e) => setDateFrom(e.target.value)}
-            className="h-9 rounded-lg border-[#ececec] bg-white px-3 text-sm"
+            className="h-9 rounded-xl border bg-white px-3 text-sm"
           />
           <input
             type="date"
             value={dateTo}
             onChange={(e) => setDateTo(e.target.value)}
-            className="h-9 rounded-lg border-[#ececec] bg-white px-3 text-sm"
+            className="h-9 rounded-xl border bg-white px-3 text-sm"
           />
         </div>
         <Button
@@ -375,7 +426,7 @@ export const NoetixAIPanel = () => {
           className="rounded-full"
           onClick={handleRefresh}
         >
-          <RotateCw className="mr-1 h-4 w-4" />
+          <RotateCw className="mr-1 h-4 w-4 text-green-400" />
           Refresh
         </Button>
         <Button
@@ -385,7 +436,7 @@ export const NoetixAIPanel = () => {
           className="rounded-full"
           onClick={() => setConfirmDelete(true)}
         >
-          <Trash2 className="mr-1 h-4 w-4" />
+          <Trash2 className="mr-1 h-4 w-4 text-red-400" />
           Delete Old
         </Button>
       </div>
@@ -438,16 +489,17 @@ export const NoetixAIPanel = () => {
                   className="border-b border-[#ededed] text-[#303030]"
                 >
                   <td className="truncate px-2 py-3">
-                    {log.timestamp
-                      ? formatDate(log.timestamp)
-                      : "—"}
+                    {log.timestamp ? formatDate(log.timestamp) : "—"}
                   </td>
                   <td className="truncate px-2 py-3">{log.admin}</td>
                   <td className="px-2 py-3">
                     {log.tool_names && log.tool_names.length > 0 ? (
                       <div className="flex flex-wrap gap-1">
                         {log.tool_names.map((t, i) => (
-                          <span key={i} className="font-mono text-xs bg-[#f0f0f0] rounded px-1.5 py-0.5 text-[#444]">
+                          <span
+                            key={i}
+                            className="rounded bg-[#f0f0f0] px-1.5 py-0.5 font-mono text-xs text-[#444]"
+                          >
                             {t}
                           </span>
                         ))}
@@ -482,7 +534,7 @@ export const NoetixAIPanel = () => {
                     <button
                       type="button"
                       onClick={() => setSelectedLog(log)}
-                      className="rounded-full p-1 hover:bg-[#e9f4fb] text-[#1c9dde]"
+                      className="rounded-full p-1 text-[#1c9dde] hover:bg-[#e9f4fb]"
                       title="View details"
                     >
                       <Eye className="h-4 w-4" />
@@ -495,37 +547,87 @@ export const NoetixAIPanel = () => {
         </div>
       )}
 
-      {totalPages > 1 && (
-        <div className="flex items-center justify-between">
+      {total > 0 && (
+        <div className="flex flex-wrap items-center justify-between gap-4">
           <span className="text-sm text-[#8a8a8a]">
             Showing {(page - 1) * pageSize + 1}-
             {Math.min(page * pageSize, total)} of {total}
           </span>
-          <div className="flex items-center gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="rounded-full"
-              disabled={page === 1}
-              onClick={() => setPage((p) => p - 1)}
-            >
-              <ChevronLeft className="h-4 w-4" />
-            </Button>
-            <span className="text-sm text-[#8a8a8a]">
-              Page {page} of {totalPages}
-            </span>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="rounded-full"
-              disabled={page === totalPages}
-              onClick={() => setPage((p) => p + 1)}
-            >
-              <ChevronRight className="h-4 w-4" />
-            </Button>
-          </div>
+          <Pagination className="mx-0 w-auto">
+            <PaginationContent>
+              <PaginationItem>
+                <PaginationPrevious
+                  href="#"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    if (page > 1) setPage(page - 1);
+                  }}
+                  className={page === 1 ? "pointer-events-none opacity-50" : ""}
+                />
+              </PaginationItem>
+              {Array.from({ length: Math.min(5, totalPages) }, (_, i) => {
+                let pageNum;
+                if (totalPages <= 5) {
+                  pageNum = i + 1;
+                } else if (page <= 3) {
+                  pageNum = i + 1;
+                } else if (page >= totalPages - 2) {
+                  pageNum = totalPages - 4 + i;
+                } else {
+                  pageNum = page - 2 + i;
+                }
+                return (
+                  <PaginationItem key={pageNum}>
+                    <PaginationLink
+                      href="#"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        setPage(pageNum);
+                      }}
+                      isActive={page === pageNum}
+                      className={
+                        page === pageNum
+                          ? "bg-sky-400 text-white hover:bg-sky-500"
+                          : ""
+                      }
+                    >
+                      {pageNum}
+                    </PaginationLink>
+                  </PaginationItem>
+                );
+              })}
+              {totalPages > 5 && page < totalPages - 2 && (
+                <PaginationItem>
+                  <PaginationEllipsis />
+                </PaginationItem>
+              )}
+              {totalPages > 5 && page < totalPages - 2 && (
+                <PaginationItem>
+                  <PaginationLink
+                    href="#"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      setPage(totalPages);
+                    }}
+                  >
+                    {totalPages}
+                  </PaginationLink>
+                </PaginationItem>
+              )}
+              <PaginationItem>
+                <PaginationNext
+                  href="#"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    if (page < totalPages) setPage(page + 1);
+                  }}
+                  className={
+                    page === totalPages ? "pointer-events-none opacity-50" : ""
+                  }
+                />
+              </PaginationItem>
+            </PaginationContent>
+          </Pagination>
         </div>
       )}
 
@@ -596,15 +698,35 @@ export const NoetixAIPanel = () => {
 
       {/* Tool Registry Section */}
       <div className="rounded-xl border border-[#e5e5e5] bg-white p-4">
-        <div className="mb-3 flex items-center gap-2">
-          <Bot className="h-4 w-4 text-[#1c9dde]" />
-          <p className="text-sm font-medium text-[#2b2b2b]">
-            Noetix AI Tool Registry
-          </p>
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <Bot className="h-4 w-4 text-[#1c9dde]" />
+            <p className="text-sm font-medium text-[#2b2b2b]">
+              Noetix AI Tool Registry
+            </p>
+          </div>
+          <Select
+            value={toolCategoryFilter || "all"}
+            onValueChange={(value) =>
+              setToolCategoryFilter(value === "all" ? "" : value)
+            }
+          >
+            <SelectTrigger className="h-9 w-[160px] rounded-full border-[#c2c2c2] text-sm">
+              <SelectValue placeholder="All Categories" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Categories</SelectItem>
+              {toolCategories.map((category) => (
+                <SelectItem key={category} value={category}>
+                  {category}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
         <p className="mb-3 text-xs text-[#858585]">
-          Toggle tools on or off. Disabled tools will not be available to the
-          AI agent. Permission labels indicate who can execute each tool.
+          Toggle tools on or off. Disabled tools will not be available to the AI
+          agent. Permission labels indicate who can execute each tool.
         </p>
 
         {toolsLoading ? (
@@ -613,11 +735,12 @@ export const NoetixAIPanel = () => {
               <Skeleton key={i} className="h-10 w-full" />
             ))}
           </div>
+        ) : filteredTools.length === 0 ? (
+          <p className="py-8 text-center text-sm text-[#777]">
+            No tools found for this category.
+          </p>
         ) : (
-          <ToolRegistryList
-            tools={tools}
-            onToggle={handleToggleTool}
-          />
+          <ToolRegistryList tools={filteredTools} onToggle={handleToggleTool} />
         )}
       </div>
 
@@ -703,8 +826,11 @@ export const NoetixAIPanel = () => {
         </DialogContent>
       </Dialog>
       {/* View Details Dialog */}
-      <Dialog open={Boolean(selectedLog)} onOpenChange={(open) => !open && setSelectedLog(null)}>
-        <DialogContent className="max-w-lg rounded-[20px] max-h-[85vh] overflow-y-auto">
+      <Dialog
+        open={Boolean(selectedLog)}
+        onOpenChange={(open) => !open && setSelectedLog(null)}
+      >
+        <DialogContent className="max-h-[85vh] max-w-lg overflow-y-auto rounded-[20px]">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <Eye className="h-5 w-5 text-[#1c9dde]" />
@@ -714,27 +840,54 @@ export const NoetixAIPanel = () => {
           {selectedLog && (
             <div className="space-y-3 py-2">
               <div className="grid grid-cols-2 gap-3">
-                <DetailRow icon={Clock} label="Timestamp" value={formatDate(selectedLog.timestamp)} />
-                <DetailRow icon={User} label="Admin" value={selectedLog.admin} />
+                <DetailRow
+                  icon={Clock}
+                  label="Timestamp"
+                  value={formatDate(selectedLog.timestamp)}
+                />
+                <DetailRow
+                  icon={User}
+                  label="Admin"
+                  value={selectedLog.admin}
+                />
                 <DetailRow icon={Bot} label="Mode" value={selectedLog.mode} />
                 <DetailRow
                   icon={selectedLog.success ? CheckCircle2 : XCircle}
                   label="Status"
                   value={selectedLog.success ? "Success" : "Failed"}
-                  valueClass={selectedLog.success ? "text-green-600" : "text-red-600"}
+                  valueClass={
+                    selectedLog.success ? "text-green-600" : "text-red-600"
+                  }
                 />
-                <DetailRow icon={Cpu} label="Iterations" value={String(selectedLog.iterations)} />
-                <DetailRow icon={Bot} label="Session ID" value={selectedLog.session_id} mono />
+                <DetailRow
+                  icon={Cpu}
+                  label="Iterations"
+                  value={String(selectedLog.iterations)}
+                />
+                <DetailRow
+                  icon={Bot}
+                  label="Session ID"
+                  value={selectedLog.session_id}
+                  mono
+                />
               </div>
-              <DetailRow icon={Target} label="Goal" value={selectedLog.goal} multiline />
+              <DetailRow
+                icon={Target}
+                label="Goal"
+                value={selectedLog.goal}
+                multiline
+              />
               <div className="rounded-lg bg-[#f7f7f7] p-3">
-                <p className="mb-2 text-xs font-medium text-[#858585] uppercase tracking-wide">
+                <p className="mb-2 text-xs font-medium tracking-wide text-[#858585] uppercase">
                   Tool(s) Called
                 </p>
                 {selectedLog.tool_names && selectedLog.tool_names.length > 0 ? (
                   <div className="flex flex-wrap gap-1.5">
                     {selectedLog.tool_names.map((t, i) => (
-                      <span key={i} className="font-mono text-xs bg-white border border-[#e0e0e0] rounded px-2 py-1 text-[#333]">
+                      <span
+                        key={i}
+                        className="rounded border border-[#e0e0e0] bg-white px-2 py-1 font-mono text-xs text-[#333]"
+                      >
                         {t}
                       </span>
                     ))}
@@ -744,9 +897,13 @@ export const NoetixAIPanel = () => {
                 )}
               </div>
               {selectedLog.error && (
-                <div className="rounded-lg bg-red-50 border border-red-100 p-3">
-                  <p className="mb-2 text-xs font-medium text-red-500 uppercase tracking-wide">Error</p>
-                  <p className="font-mono text-xs text-red-700 break-all">{selectedLog.error}</p>
+                <div className="rounded-lg border border-red-100 bg-red-50 p-3">
+                  <p className="mb-2 text-xs font-medium tracking-wide text-red-500 uppercase">
+                    Error
+                  </p>
+                  <p className="font-mono text-xs break-all text-red-700">
+                    {selectedLog.error}
+                  </p>
                 </div>
               )}
             </div>
@@ -783,10 +940,14 @@ const DetailRow = ({
   valueClass?: string;
 }) => (
   <div className={`${multiline ? "" : "flex items-start gap-2"}`}>
-    <Icon className={`h-4 w-4 mt-0.5 shrink-0 text-[#1c9dde]`} />
+    <Icon className={`mt-0.5 h-4 w-4 shrink-0 text-[#1c9dde]`} />
     <div className="min-w-0">
-      <p className="text-[10px] font-medium text-[#858585] uppercase tracking-wide">{label}</p>
-      <p className={`text-sm ${mono ? "font-mono break-all" : multiline ? "break-words" : "truncate"} ${valueClass ?? "text-[#2b2b2b]"}`}>
+      <p className="text-[10px] font-medium tracking-wide text-[#858585] uppercase">
+        {label}
+      </p>
+      <p
+        className={`text-sm ${mono ? "font-mono break-all" : multiline ? "break-words" : "truncate"} ${valueClass ?? "text-[#2b2b2b]"}`}
+      >
         {value}
       </p>
     </div>
@@ -816,11 +977,34 @@ const StatCard = ({
   </div>
 );
 
-const PERM_LABELS: Record<string, { label: string; cls: string; icon: React.ComponentType<{ className?: string }> }> = {
-  read: { label: "Read", cls: "bg-green-50 text-green-700 border-green-200", icon: Unlock },
-  admin_finance: { label: "Read/Write (Finance)", cls: "bg-yellow-50 text-yellow-700 border-yellow-200", icon: Shield },
-  admin_only: { label: "Admin Only", cls: "bg-red-50 text-red-700 border-red-200", icon: Lock },
-  admin_full: { label: "Full Admin", cls: "bg-purple-50 text-purple-700 border-purple-200", icon: Shield },
+const PERM_LABELS: Record<
+  string,
+  {
+    label: string;
+    cls: string;
+    icon: React.ComponentType<{ className?: string }>;
+  }
+> = {
+  read: {
+    label: "Read",
+    cls: "bg-green-50 text-green-700 border-green-200",
+    icon: Unlock,
+  },
+  admin_finance: {
+    label: "Read/Write (Finance)",
+    cls: "bg-yellow-50 text-yellow-700 border-yellow-200",
+    icon: Shield,
+  },
+  admin_only: {
+    label: "Admin Only",
+    cls: "bg-red-50 text-red-700 border-red-200",
+    icon: Lock,
+  },
+  admin_full: {
+    label: "Full Admin",
+    cls: "bg-purple-50 text-purple-700 border-purple-200",
+    icon: Shield,
+  },
 };
 
 const ToolRegistryList = ({
@@ -839,7 +1023,7 @@ const ToolRegistryList = ({
     <div className="space-y-4">
       {Object.entries(grouped).map(([category, categoryTools]) => (
         <div key={category}>
-          <p className="mb-2 text-xs font-semibold text-[#858585] uppercase tracking-wide">
+          <p className="mb-2 text-xs font-semibold tracking-wide text-[#858585] uppercase">
             {category}
           </p>
           <div className="space-y-1.5">
@@ -873,12 +1057,14 @@ const ToolRegistryList = ({
                   <button
                     type="button"
                     onClick={() => onToggle(tool)}
-                    className={`ml-3 shrink-0 flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium border transition-colors ${
+                    className={`ml-3 flex shrink-0 items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors ${
                       tool.enabled
-                        ? "bg-green-50 text-green-700 border-green-200 hover:bg-green-100"
-                        : "bg-red-50 text-red-600 border-red-200 hover:bg-red-100"
+                        ? "border-green-200 bg-green-50 text-green-700 hover:bg-green-100"
+                        : "border-red-200 bg-red-50 text-red-600 hover:bg-red-100"
                     }`}
-                    title={tool.enabled ? "Click to disable" : "Click to enable"}
+                    title={
+                      tool.enabled ? "Click to disable" : "Click to enable"
+                    }
                   >
                     {tool.enabled ? (
                       <CheckCircle2 className="h-3.5 w-3.5" />

--- a/client-side-ts/src/features/admin/devtools/types/devtools.types.ts
+++ b/client-side-ts/src/features/admin/devtools/types/devtools.types.ts
@@ -78,6 +78,7 @@ export interface LogQueryParams {
   action?: string;
   admin?: string;
   target?: string;
+  search?: string;
   dateFrom?: string;
   dateTo?: string;
   limit?: number;

--- a/client-side-ts/src/features/auth/components/ForgotPasswordForm.tsx
+++ b/client-side-ts/src/features/auth/components/ForgotPasswordForm.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useState } from "react";
 import { useForm } from "@tanstack/react-form";
 import * as z from "zod";
+import { Loader2 } from "lucide-react";
 import {
   Card,
   CardContent,
@@ -21,8 +23,25 @@ const forgotPasswordSchema = z.object({
 export type ForgotPasswordCredentials = z.infer<typeof forgotPasswordSchema>;
 
 export interface ForgotPasswordFormProps {
-  onSubmit?: (values: ForgotPasswordCredentials) => void;
+  onSubmit?: (
+    values: ForgotPasswordCredentials
+  ) => boolean | void | Promise<boolean | void>;
 }
+
+const RESEND_COOLDOWN_SECONDS = 120;
+const COOLDOWN_STORAGE_KEY = "forgotPasswordCooldownEnd";
+
+const formatCooldown = (seconds: number) => {
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${mins}:${String(secs).padStart(2, "0")}`;
+};
+
+const getStoredRemainingSeconds = () => {
+  const storedEnd = Number(sessionStorage.getItem(COOLDOWN_STORAGE_KEY));
+  if (!storedEnd) return 0;
+  return Math.max(0, Math.ceil((storedEnd - Date.now()) / 1000));
+};
 
 // Matches LoginForm.tsx / SignupForm.tsx exactly
 const inputClasses =
@@ -34,6 +53,17 @@ const floatingLabelClasses =
 export default function ForgotPasswordForm({
   onSubmit,
 }: ForgotPasswordFormProps) {
+  const [cooldown, setCooldown] = useState(getStoredRemainingSeconds);
+
+  useEffect(() => {
+    if (cooldown <= 0) {
+      sessionStorage.removeItem(COOLDOWN_STORAGE_KEY);
+      return;
+    }
+    const id = setTimeout(() => setCooldown((c) => c - 1), 1000);
+    return () => clearTimeout(id);
+  }, [cooldown]);
+
   const form = useForm({
     defaultValues: {
       id: "",
@@ -42,8 +72,17 @@ export default function ForgotPasswordForm({
     validators: {
       onSubmit: forgotPasswordSchema,
     },
-    onSubmit: async ({ value }: { value: ForgotPasswordCredentials }) =>
-      onSubmit && onSubmit(value),
+    onSubmit: async ({ value }: { value: ForgotPasswordCredentials }) => {
+      if (!onSubmit) return;
+      const result = await onSubmit(value);
+      if (result !== false) {
+        sessionStorage.setItem(
+          COOLDOWN_STORAGE_KEY,
+          String(Date.now() + RESEND_COOLDOWN_SECONDS * 1000)
+        );
+        setCooldown(RESEND_COOLDOWN_SECONDS);
+      }
+    },
   });
 
   return (
@@ -143,12 +182,26 @@ export default function ForgotPasswordForm({
             </FieldSet>
 
             <Field orientation="vertical">
-              <Button
-                type="submit"
-                className="h-11 w-full rounded-full bg-[#1C9DDE] text-base font-semibold shadow-sm hover:bg-sky-600"
-              >
-                Reset Password
-              </Button>
+              <form.Subscribe selector={(state) => state.isSubmitting}>
+                {(isSubmitting) => (
+                  <Button
+                    type="submit"
+                    disabled={isSubmitting || cooldown > 0}
+                    className="h-11 w-full rounded-full bg-[#1C9DDE] text-base font-semibold shadow-sm hover:bg-sky-600 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {isSubmitting ? (
+                      <span className="flex items-center justify-center gap-2">
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                        Sending...
+                      </span>
+                    ) : cooldown > 0 ? (
+                      `Resend in ${formatCooldown(cooldown)}`
+                    ) : (
+                      "Reset Password"
+                    )}
+                  </Button>
+                )}
+              </form.Subscribe>
               <Link to="/auth/login">
                 <Button
                   type="button"

--- a/client-side-ts/src/pages/auth/ForgotPassword.tsx
+++ b/client-side-ts/src/pages/auth/ForgotPassword.tsx
@@ -9,8 +9,8 @@ import { ArrowLeft } from "lucide-react";
 import { Link } from "react-router";
 
 export default function ForgotPassword() {
-  const handleForgotPassword = (_values: ForgotPasswordCredentials) => {
-    forgotPassword(_values.email, _values.id);
+  const handleForgotPassword = async (values: ForgotPasswordCredentials) => {
+    return await forgotPassword(values.email, values.id);
   };
 
   return (

--- a/client-side-ts/src/pages/events/sections/PastEvents.tsx
+++ b/client-side-ts/src/pages/events/sections/PastEvents.tsx
@@ -1,11 +1,26 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useMemo } from "react";
 import { MapPin, ChevronDown, Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { pastEventsData } from "@/data/sections-data";
+import { eventsData } from "@/data/sections-data";
+import { isEventPast, getManilaDateParts } from "@/data/events.utils";
 import { OptimizedImage } from "@/components/common/OptimizedImage";
 
 export const PastEvents = () => {
-  const { header, events } = pastEventsData;
+  const events = useMemo(
+    () =>
+      eventsData.events
+        .filter((event) => isEventPast(event))
+        .sort(
+          (a, b) =>
+            new Date(b.startDateTime).getTime() -
+            new Date(a.startDateTime).getTime()
+        )
+        .map((event) => ({
+          ...event,
+          ...getManilaDateParts(event.startDateTime),
+        })),
+    []
+  );
   const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set());
   const [selectedYear, setSelectedYear] = useState<number | null>(null);
   const [dropdownOpen, setDropdownOpen] = useState(false);
@@ -19,6 +34,8 @@ export const PastEvents = () => {
   const filteredEvents = selectedYear
     ? events.filter((e) => e.year === selectedYear)
     : events;
+
+  const defaultYearLabel = years[0] ?? new Date().getFullYear();
 
   const toggleExpand = (id: number) => {
     setExpandedIds((prev) => {
@@ -48,10 +65,10 @@ export const PastEvents = () => {
       <div className="mb-16 flex flex-col items-start justify-between gap-6 md:flex-row md:items-end">
         <div>
           <h2 className="text-foreground text-4xl font-black tracking-tight md:text-5xl">
-            {header.title}
+            Past Events
           </h2>
           <p className="text-primary mt-2 text-2xl font-bold">
-            {selectedYear ?? header.year}
+            {selectedYear ?? defaultYearLabel}
           </p>
         </div>
 
@@ -118,10 +135,10 @@ export const PastEvents = () => {
                 {/* Date column */}
                 <div className="flex min-w-[120px] shrink-0 flex-col items-start justify-start md:items-center">
                   <span className="text-muted-foreground/80 mb-1 text-base font-bold tracking-widest uppercase">
-                    {event.date.month}
+                    {event.month}
                   </span>
                   <span className="text-foreground text-6xl leading-[0.8] font-black md:text-7xl">
-                    {event.date.day}
+                    {event.day}
                   </span>
                 </div>
 

--- a/client-side-ts/src/pages/events/sections/UpcomingEventsSection.tsx
+++ b/client-side-ts/src/pages/events/sections/UpcomingEventsSection.tsx
@@ -5,17 +5,31 @@ import {
   CarouselItem,
 } from "@/components/ui/carousel";
 import { Calendar, MapPin } from "lucide-react";
-import { upcomingEventsData } from "@/data/sections-data";
+import { eventsData } from "@/data/sections-data";
+import { isEventPast, formatEventDateRange } from "@/data/events.utils";
 import { OptimizedImage } from "@/components/common/OptimizedImage";
 
+const currentYear = new Intl.DateTimeFormat("en-US", {
+  timeZone: "Asia/Manila",
+  year: "numeric",
+}).format(new Date());
+
 export const UpcomingEventsSection = () => {
-  const { header, events } = upcomingEventsData;
+  const events = eventsData.events
+    .filter((event) => !isEventPast(event))
+    .sort(
+      (a, b) =>
+        new Date(a.startDateTime).getTime() -
+        new Date(b.startDateTime).getTime()
+    );
 
   return (
     <section className="mx-auto max-w-7xl overflow-hidden px-4 py-12 md:px-8">
       <div className="mb-8 flex flex-col">
-        <h2 className="text-foreground text-3xl font-black">{header.title}</h2>
-        <p className="text-muted-foreground font-medium">{header.year}</p>
+        <h2 className="text-foreground text-3xl font-black">
+          Upcoming Events
+        </h2>
+        <p className="text-muted-foreground font-medium">{currentYear}</p>
       </div>
 
       <div className="relative">
@@ -53,7 +67,7 @@ export const UpcomingEventsSection = () => {
                     <div className="space-y-1.5">
                       <div className="flex items-center gap-2 text-xs text-white/80">
                         <Calendar className="text-primary h-3.5 w-3.5" />
-                        <span>{event.date}</span>
+                        <span>{formatEventDateRange(event)}</span>
                       </div>
 
                       <div className="flex items-center gap-2 text-xs text-white/80">

--- a/server-side/src/controllers/devtools.v2.controller.ts
+++ b/server-side/src/controllers/devtools.v2.controller.ts
@@ -392,11 +392,13 @@ class DevToolsController {
     if (!ALLOWED_CAMPUS.includes(req.userV2.campus)) {
       return res.status(403).json({ message: "Campus not authorized" });
     }
-    const { action, admin, target, dateFrom, dateTo, limit, skip } = req.query;
+    const { action, admin, target, search, dateFrom, dateTo, limit, skip } =
+      req.query;
     const { entries, total } = await getLogEntries({
       action: action as string,
       admin: admin as string,
       target: target as string,
+      search: search as string,
       dateFrom: dateFrom ? new Date(dateFrom as string) : undefined,
       dateTo: dateTo ? new Date(dateTo as string) : undefined,
       limit: limit ? parseInt(limit as string) : 100,

--- a/server-side/src/mail_template/mail.template.ts
+++ b/server-side/src/mail_template/mail.template.ts
@@ -159,7 +159,7 @@ const sendPsitsTemplatedEmail = async (opts: {
     logoDataUri: "cid:logo",
   });
 
-  await sendEmail({
+  return await sendEmail({
     to: opts.to,
     subject: opts.subject,
     html,
@@ -385,7 +385,7 @@ export const certificateOfParticipationEmail = async (
 
     const html = renderPsitsEmail({
       category: "Certificate",
-      title: "Congratulations! 🎉",
+      title: "Congratulations! Your Certificate of Participation",
       bodyHtml: `
         <p>Hi ${parsedData.student_name},</p>
         <p style="margin-bottom:20px;">
@@ -444,15 +444,15 @@ export const recruitmentApprovedMail = async (data: {
       "approval"
     );
 
-    await sendPsitsTemplatedEmail({
+    const id = await sendPsitsTemplatedEmail({
       to: data.applicantEmail,
-      subject: "Your PSITS Application Has Been Approved! 🎉",
+      subject: "Your PSITS Application Has Been Approved!",
       category: "Philippine Technology of Information Technology Students",
       title: "PSITS Application Approved",
       bodyHtml: `
         <p>Dear ${data.applicantName},</p>
         <p style="margin-bottom:16px;">
-          Congratulations! 🎉 We're happy to let you know that your application to join PSITS has been approved.
+          Congratulations! We're happy to let you know that your application to join PSITS has been approved.
         </p>
         <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f5f5f5; border-radius:8px; margin-bottom:20px;">
           <tr><td style="padding:16px 18px;">
@@ -467,6 +467,9 @@ export const recruitmentApprovedMail = async (data: {
       `,
     });
 
+    if (id?.id) {
+      await emailService.updateEmailIdById(String(queueEntry._id), id.id);
+    }
     await emailService.updateStatusById(String(queueEntry._id), "sent");
   } catch (err: unknown) {
     console.error(
@@ -502,7 +505,7 @@ export const recruitmentInterviewScheduledMail = async (data: {
       "interview_scheduled"
     );
 
-    await sendPsitsTemplatedEmail({
+    const id = await sendPsitsTemplatedEmail({
       to: data.applicantEmail,
       subject: "PSITS Interview Schedule Notification",
       category: "Philipine Technology of Information Technology Students",
@@ -537,6 +540,9 @@ export const recruitmentInterviewScheduledMail = async (data: {
       `,
     });
 
+    if (id?.id) {
+      await emailService.updateEmailIdById(String(queueEntry._id), id.id);
+    }
     await emailService.updateStatusById(String(queueEntry._id), "sent");
   } catch (err: unknown) {
     console.error(
@@ -567,7 +573,7 @@ export const recruitmentInterviewRescheduledMail = async (data: {
       "interview_rescheduled"
     );
 
-    await sendPsitsTemplatedEmail({
+    const id = await sendPsitsTemplatedEmail({
       to: data.applicantEmail,
       subject: "PSITS Interview Reschedule Notification",
       category: "Philipine Technology of Information Technology Students",
@@ -602,6 +608,9 @@ export const recruitmentInterviewRescheduledMail = async (data: {
       `,
     });
 
+    if (id?.id) {
+      await emailService.updateEmailIdById(String(queueEntry._id), id.id);
+    }
     await emailService.updateStatusById(String(queueEntry._id), "sent");
   } catch (err: unknown) {
     console.error(
@@ -637,7 +646,7 @@ export const recruitmentAccountCreatedMail = async (data: {
       "account_created"
     );
 
-    await sendPsitsTemplatedEmail({
+    const id = await sendPsitsTemplatedEmail({
       to: data.applicantEmail,
       subject: `${"Your PSITS " + data.role} Account Has Been Created!`,
       category: "Philippine Technology of Information Technology Students",
@@ -664,6 +673,9 @@ export const recruitmentAccountCreatedMail = async (data: {
       `,
     });
 
+    if (id?.id) {
+      await emailService.updateEmailIdById(String(queueEntry._id), id.id);
+    }
     await emailService.updateStatusById(String(queueEntry._id), "sent");
   } catch (err: unknown) {
     console.error(
@@ -695,7 +707,7 @@ export const recruitmentRejectedMail = async (data: {
       "rejection"
     );
 
-    await sendPsitsTemplatedEmail({
+    const id = await sendPsitsTemplatedEmail({
       to: data.applicantEmail,
       subject: "Update on Your PSITS Application",
       category: "Philippine Technology of Information Technology Students",
@@ -721,6 +733,9 @@ export const recruitmentRejectedMail = async (data: {
       `,
     });
 
+    if (id?.id) {
+      await emailService.updateEmailIdById(String(queueEntry._id), id.id);
+    }
     await emailService.updateStatusById(String(queueEntry._id), "sent");
   } catch (err: unknown) {
     console.error(

--- a/server-side/src/services/devtools.service.ts
+++ b/server-side/src/services/devtools.service.ts
@@ -484,6 +484,7 @@ export interface LogQueryParams {
   action?: string;
   admin?: string;
   target?: string;
+  search?: string;
   dateFrom?: Date;
   dateTo?: Date;
   limit?: number;
@@ -494,6 +495,7 @@ export const getLogEntries = async ({
   action,
   admin,
   target,
+  search,
   dateFrom,
   dateTo,
   limit = 100,
@@ -505,6 +507,12 @@ export const getLogEntries = async ({
   if (action) query.action = { $regex: action, $options: "i" };
   if (admin) query.admin = { $regex: admin, $options: "i" };
   if (target) query.target = { $regex: target, $options: "i" };
+  if (search) {
+    query.$or = [
+      { admin: { $regex: search, $options: "i" } },
+      { target: { $regex: search, $options: "i" } },
+    ];
+  }
   if (dateFrom || dateTo) {
     const timestampQuery: Record<string, Date> = {};
     if (dateFrom) timestampQuery.$gte = dateFrom;


### PR DESCRIPTION
### Events
- Replace UpcomingEvent with EventItem, swapping the display date string for startDateTime/endDateTime ISO fields that carry an explicit Asia/Manila (+08:00) offset, and rename upcomingEventsData to eventsData.
- Add events.utils.ts with helpers to detect past events, format date ranges, and extract Manila-timezone date parts, keeping event rendering consistent regardless of the viewer's timezone.
---
### Forgot Password
- Add a session-persisted resend cooldown to ForgotPasswordForm that starts after a successful submit and survives page refreshes.