### PR TITLE
feat(events): show all events to admins.

### DIFF
--- a/client-side-ts/src/layouts/AdminLayout.tsx
+++ b/client-side-ts/src/layouts/AdminLayout.tsx
@@ -89,7 +89,7 @@ export const AdminLayout = () => {
       {/* Main Content */}
       <main className="flex h-screen min-w-0 flex-1 flex-col overflow-hidden">
         {/* Page Content */}
-        <div className="flex-1 overflow-y-auto pt-14 lg:pt-0">
+        <div className="flex-1 overflow-y-auto overscroll-contain pt-14 lg:pt-0">
           <Outlet />
         </div>
       </main>

--- a/client-side-ts/src/pages/admin/EventManagement.tsx
+++ b/client-side-ts/src/pages/admin/EventManagement.tsx
@@ -600,7 +600,7 @@ const EventManagement: React.FC = () => {
       </div>
 
       {/* Content */}
-      <div className="flex-1 overflow-y-auto">
+      <div className="flex-1 overflow-y-auto overscroll-contain">
         <div className="space-y-6 px-6 py-4">
           {/* Breadcrumb */}
           <Breadcrumb>

--- a/server-side/src/controllers/eventV2.controller.ts
+++ b/server-side/src/controllers/eventV2.controller.ts
@@ -480,11 +480,16 @@ const mapPaginatedAttendees = (attendees: IAttendee[]) => {
 
 export const getAllEventsV2Controller = async (req: Request, res: Response) => {
   try {
-    const cutoffDate = getSevenDayWindowCutoffDate();
+    // Admins manage past events too (edit, statistics, certificates), so they
+    // see everything. Students only see the recent/upcoming window.
+    const isAdmin = req.userV2?.role === "admin";
+    const dateFilter = isAdmin
+      ? {}
+      : { eventDate: { $gte: getSevenDayWindowCutoffDate() } };
 
-    const events: IEvent[] = await Event.find({
-      eventDate: { $gte: cutoffDate },
-    }).select("-attendees");
+    const events: IEvent[] = await Event.find(dateFilter).select(
+      "-attendees"
+    );
 
     if (!events || events.length === 0) {
       return res.status(404).json({ message: "No events found" });


### PR DESCRIPTION
### Events
- Admins need access to past events for editing, statistics, and certificate generation, so getAllEventsV2Controller now skips the seven-day date filter for admin users. Students continue to see only recent/upcoming events within the seven-day window.
- Also add overscroll-contain to the admin layout and event management scroll containers to prevent scroll chaining when reaching scroll boundaries.