### PR TITLE
fix(admin-devtools): debounce filters and fix loading states

### DIFF
--- a/client-side-ts/src/features/admin/devtools/components/ActivityLogPanel.tsx
+++ b/client-side-ts/src/features/admin/devtools/components/ActivityLogPanel.tsx
@@ -48,6 +48,7 @@ export const ActivityLogPanel = () => {
   const [loading, setLoading] = useState(true);
   const [actionFilter, setActionFilter] = useState("");
   const [searchFilter, setSearchFilter] = useState("");
+  const [appliedSearchFilter, setAppliedSearchFilter] = useState("");
   const [dateFrom, setDateFrom] = useState("");
   const [dateTo, setDateTo] = useState("");
   const [page, setPage] = useState(1);
@@ -63,7 +64,7 @@ export const ActivityLogPanel = () => {
         skip: (page - 1) * pageSize,
       };
       if (actionFilter) params.action = actionFilter;
-      if (searchFilter) params.search = searchFilter;
+      if (appliedSearchFilter) params.search = appliedSearchFilter;
       if (dateFrom) params.dateFrom = dateFrom;
       if (dateTo) params.dateTo = dateTo;
 
@@ -78,12 +79,20 @@ export const ActivityLogPanel = () => {
   };
 
   useEffect(() => {
+    const timer = setTimeout(() => {
+      setAppliedSearchFilter(searchFilter.trim());
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [searchFilter]);
+
+  useEffect(() => {
     setPage(1);
-  }, [actionFilter, searchFilter, dateFrom, dateTo]);
+  }, [actionFilter, appliedSearchFilter, dateFrom, dateTo]);
 
   useEffect(() => {
     fetchEntries();
-  }, [page, actionFilter, searchFilter, dateFrom, dateTo]);
+  }, [page, actionFilter, appliedSearchFilter, dateFrom, dateTo]);
 
   const handleDeleteOld = async () => {
     try {
@@ -101,16 +110,6 @@ export const ActivityLogPanel = () => {
     const date = new Date(dateStr);
     return date.toLocaleString("en-PH", { timeZone: "Asia/Manila" });
   };
-
-  if (loading) {
-    return (
-      <div className="space-y-2">
-        {Array.from({ length: 5 }).map((_, i) => (
-          <Skeleton key={i} className="h-12 w-full" />
-        ))}
-      </div>
-    );
-  }
 
   return (
     <div>
@@ -181,7 +180,13 @@ export const ActivityLogPanel = () => {
         </Button>
       </div>
 
-      {entries.length === 0 ? (
+      {loading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-12 w-full" />
+          ))}
+        </div>
+      ) : entries.length === 0 ? (
         <p className="py-16 text-center text-sm text-[#777]">
           No activity logs found.
         </p>

--- a/client-side-ts/src/features/admin/devtools/components/NoetixAIPanel.tsx
+++ b/client-side-ts/src/features/admin/devtools/components/NoetixAIPanel.tsx
@@ -79,6 +79,7 @@ export const NoetixAIPanel = () => {
   const [toolsLoading, setToolsLoading] = useState(true);
   const [toolCategoryFilter, setToolCategoryFilter] = useState("");
   const [adminFilter, setAdminFilter] = useState("");
+  const [appliedAdminFilter, setAppliedAdminFilter] = useState("");
   const [successFilter, setSuccessFilter] = useState("");
   const [dateFrom, setDateFrom] = useState("");
   const [dateTo, setDateTo] = useState("");
@@ -110,7 +111,7 @@ export const NoetixAIPanel = () => {
         limit: pageSize,
         skip: (page - 1) * pageSize,
       };
-      if (adminFilter) params.admin = adminFilter;
+      if (appliedAdminFilter) params.admin = appliedAdminFilter;
       if (successFilter) params.success = successFilter;
       if (dateFrom) params.dateFrom = dateFrom;
       if (dateTo) params.dateTo = dateTo;
@@ -123,7 +124,7 @@ export const NoetixAIPanel = () => {
     } finally {
       setLogLoading(false);
     }
-  }, [page, adminFilter, successFilter, dateFrom, dateTo, pageSize]);
+  }, [page, appliedAdminFilter, successFilter, dateFrom, dateTo, pageSize]);
 
   const fetchDisabledAdmins = useCallback(async () => {
     setDisabledLoading(true);
@@ -221,21 +222,22 @@ export const NoetixAIPanel = () => {
 
   useEffect(() => {
     fetchStats();
-    fetchLogs();
     fetchDisabledAdmins();
     fetchTools();
     fetchMaxIterations();
-  }, [
-    fetchStats,
-    fetchLogs,
-    fetchDisabledAdmins,
-    fetchTools,
-    fetchMaxIterations,
-  ]);
+  }, [fetchStats, fetchDisabledAdmins, fetchTools, fetchMaxIterations]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setAppliedAdminFilter(adminFilter.trim());
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [adminFilter]);
 
   useEffect(() => {
     setPage(1);
-  }, [adminFilter, successFilter, dateFrom, dateTo]);
+  }, [appliedAdminFilter, successFilter, dateFrom, dateTo]);
 
   useEffect(() => {
     fetchLogs();
@@ -292,19 +294,6 @@ export const NoetixAIPanel = () => {
     fetchDisabledAdmins();
     fetchTools();
   };
-
-  if (logLoading) {
-    return (
-      <div className="space-y-4">
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <Skeleton key={i} className="h-20 rounded-xl" />
-          ))}
-        </div>
-        <Skeleton className="h-64 rounded-xl" />
-      </div>
-    );
-  }
 
   return (
     <div className="space-y-5">


### PR DESCRIPTION
### DevTools
- Add a 300ms debounce to the search input in ActivityLogPanel and the admin filter in NoetixAIPanel via an applied-filter state, so API requests fire only after typing pauses instead of on every keystroke
- Render the loading skeleton inline below the filter controls instead of replacing the entire panel, keeping filters visible while data loads
- Remove the duplicate fetchLogs call on mount in NoetixAIPanel to prevent double-fetching logs when the component first loads