### PR TITLE
feat: add noetixDisabledTools setting and update related functionality

### DIFF
--- a/client-side-ts/src/features/admin/agent-chat/components/AgentChatPanel.tsx
+++ b/client-side-ts/src/features/admin/agent-chat/components/AgentChatPanel.tsx
@@ -18,10 +18,18 @@ const MessageBubble = ({ message }: { message: ChatMessage }) => {
   const isUser = message.role === "user";
   const isSystem = message.role === "system";
   if (isSystem) {
+    const isWarning = message.variant === "warning";
     return (
       <div className="my-3 flex items-center gap-2">
         <div className="bg-border h-px flex-1" />
-        <div className="border-border bg-muted/50 text-muted-foreground flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs">
+        <div
+          className={cn(
+            "flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs",
+            isWarning
+              ? "border-amber-300 bg-amber-50 text-amber-800"
+              : "border-border bg-muted/50 text-muted-foreground"
+          )}
+        >
           <RefreshCw className="h-3 w-3" />
           <span>{message.content}</span>
         </div>
@@ -53,6 +61,22 @@ const MessageBubble = ({ message }: { message: ChatMessage }) => {
         )}
       >
         <p className="break-words whitespace-pre-wrap">{message.content}</p>
+        {!isUser &&
+          (message.confidence ||
+            (message.sources && message.sources.length > 0)) && (
+            <div className="mt-1 flex flex-wrap items-center gap-1.5">
+              {message.confidence && (
+                <span className="rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary">
+                  {message.confidence} confidence
+                </span>
+              )}
+              {message.sources && message.sources.length > 0 && (
+                <span className="text-[10px] text-muted-foreground">
+                  Backed by: {message.sources.join(", ")}
+                </span>
+              )}
+            </div>
+          )}
         <p
           className={cn(
             "mt-1 text-xs",

--- a/client-side-ts/src/features/admin/agent-chat/hooks/useChat.ts
+++ b/client-side-ts/src/features/admin/agent-chat/hooks/useChat.ts
@@ -48,7 +48,14 @@ export const useChat = () => {
         }
 
         const {
-          data: { result, sessionId: newSessionId, history },
+          data: {
+            result,
+            sessionId: newSessionId,
+            history,
+            stuck,
+            confidence,
+            sources,
+          },
         } = response;
 
         setSessionId(newSessionId);
@@ -58,9 +65,25 @@ export const useChat = () => {
           role: "assistant",
           content: result || "Response received.",
           timestamp: new Date(),
+          ...(confidence ? { confidence } : {}),
+          ...(sources && sources.length > 0 ? { sources } : {}),
         };
 
         setMessages((prev) => [...prev, assistantMessage]);
+
+        // Noetix v3.1 loop guard fired — the answer is a clarification,
+        // surface it distinctly so the user can rephrase or refresh.
+        if (stuck) {
+          const stuckMsg: ChatMessage = {
+            id: crypto.randomUUID(),
+            role: "system",
+            content:
+              "The assistant hit a loop guard and stopped early. Rephrase with more specific details or refresh data.",
+            timestamp: new Date(),
+            variant: "warning",
+          };
+          setMessages((prev) => [...prev, stuckMsg]);
+        }
 
         // Display tool call summary as a system message if present.
         if (history) {

--- a/client-side-ts/src/features/admin/agent-chat/types/chat.types.ts
+++ b/client-side-ts/src/features/admin/agent-chat/types/chat.types.ts
@@ -7,6 +7,12 @@ export interface ChatMessage {
   role: ChatMessageRole;
   content: string;
   timestamp: Date;
+  /** Noetix v3.1 grounded-final confidence. */
+  confidence?: "high" | "medium" | "low";
+  /** Noetix v3.1: tools whose results back this answer. */
+  sources?: string[];
+  /** Renders the system pill as an amber warning instead of neutral. */
+  variant?: "default" | "warning";
 }
 
 export interface ToolCallEntry {
@@ -23,6 +29,11 @@ export interface AiAgentResponse {
     result: string;
     history: ToolCallEntry[] | string;
     iterations: number;
+    /** Noetix v3.1 loop guard fired; result is a clarification, not a full answer. */
+    stuck?: boolean;
+    stuckReason?: string;
+    confidence?: "high" | "medium" | "low";
+    sources?: string[];
   };
 }
 

--- a/client-side-ts/src/features/admin/devtools/components/NoetixAIPanel.tsx
+++ b/client-side-ts/src/features/admin/devtools/components/NoetixAIPanel.tsx
@@ -717,6 +717,12 @@ export const NoetixAIPanel = () => {
           Toggle tools on or off. Disabled tools will not be available to the AI
           agent. Permission labels indicate who can execute each tool.
         </p>
+        {tools.length > 0 && (
+          <p className="mb-3 text-xs font-medium text-[#2b2b2b]">
+            {tools.filter((t) => t.enabled).length} of {tools.length} tools
+            enabled
+          </p>
+        )}
 
         {toolsLoading ? (
           <div className="space-y-2">
@@ -1029,15 +1035,29 @@ const ToolRegistryList = ({
                       <span className="font-mono text-sm text-[#2b2b2b]">
                         {tool.name}
                       </span>
-                      <span
-                        className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-medium ${perm.cls}`}
-                        title={tool.description}
-                      >
-                        <span className="inline-flex items-center gap-1">
-                          <PermIcon className="h-3 w-3" />
-                          {perm.label}
+                        <span
+                          className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-medium ${perm.cls}`}
+                          title={tool.description}
+                        >
+                          <span className="inline-flex items-center gap-1">
+                            <PermIcon className="h-3 w-3" />
+                            {perm.label}
+                          </span>
                         </span>
-                      </span>
+                        <span
+                          className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-medium ${
+                            tool.risk === "write"
+                              ? "border-red-200 bg-red-50 text-red-700"
+                              : "border-green-200 bg-green-50 text-green-700"
+                          }`}
+                          title={
+                            tool.risk === "write"
+                              ? "This tool mutates data"
+                              : "This tool only reads data"
+                          }
+                        >
+                          {tool.risk === "write" ? "Write" : "Read"}
+                        </span>
                     </div>
                     <p className="mt-0.5 truncate text-xs text-[#858585]">
                       {tool.description}

--- a/client-side-ts/src/features/admin/devtools/types/devtools.types.ts
+++ b/client-side-ts/src/features/admin/devtools/types/devtools.types.ts
@@ -238,6 +238,7 @@ export interface NoetixToolItem {
   name: string;
   description: string;
   permission: "read" | "admin_finance" | "admin_only" | "admin_full";
+  risk?: "read" | "write";
   category: string;
   enabled: boolean;
 }

--- a/server-side/src/controllers/noetix-chat.v2.controller.ts
+++ b/server-side/src/controllers/noetix-chat.v2.controller.ts
@@ -1,7 +1,10 @@
 import { Request, Response } from "express";
 
 import { catchAsync } from "../util/catch.async.util";
-import { queryNoetixAiAgent } from "../services/noetix-chat.service";
+import {
+  queryNoetixAiAgent,
+  type NoetixLastTool,
+} from "../services/noetix-chat.service";
 import {
   isChatbotEnabled,
   isNoetixAdminDisabled,
@@ -13,9 +16,8 @@ import { logs_action } from "../enums/logs.enums";
 import {
   findToolByName,
   ToolPermissionError,
-  getToolRegistry,
   summarizeToolResult,
-  type ChatTool,
+  buildNoetixTools,
 } from "../types/chat-tool.types";
 import { createNoetixUsageLog } from "../services/noetix-usage.service";
 
@@ -44,106 +46,6 @@ const buildCleanToolHistory = (toolLog: ToolCallEntry[]): string => {
     )
     .join(" ");
 };
-
-// Extracts tool arguments from the goal message based on args definitions.
-// Noetix returns only the tool name — we parse the natural language goal to fill args.
-function extractToolArgs(
-  _toolName: string,
-  goal: string,
-  history: string,
-  args?: Array<{ name: string; description: string; pattern?: string }>
-): Record<string, string> {
-  const result: Record<string, string> = {};
-  if (!args) return result;
-
-  const source = goal + " " + history;
-
-  for (const arg of args) {
-    if (result[arg.name]) continue;
-    const keyLower = arg.name.toLowerCase();
-
-    // Check history first (Noetix may have echoed back args there).
-    // Capture the rest of the line so multi-word values like
-    // "name: John Smith" are not truncated to just "John".
-    const historyMatch = source.match(
-      new RegExp(`${keyLower}\\s*[:=]\\s*([^\\n]+)`, "i")
-    );
-    if (historyMatch) {
-      const val = historyMatch[1].trim().replace(/[.,;]+$/, "");
-      if (arg.pattern && !new RegExp(arg.pattern).test(val)) continue;
-      result[arg.name] = val;
-      continue;
-    }
-
-    // Try direct ID patterns in the goal
-    if (
-      keyLower.includes("id_number") ||
-      keyLower.includes("student_id") ||
-      keyLower.includes("id")
-    ) {
-      // Patterns: "ID 12345", "id number 12345", "ID number: 12345", "12345" (standalone alphanumeric)
-      const patterns = [
-        /(?:id\s*number?\s*[:\-]?\s*)(\w[\w\-]{5,})/i,
-        /(\w[\w\-]{5,})\s*(?:is|for|of|with)/i,
-      ];
-      for (const pat of patterns) {
-        const m = source.match(pat);
-        if (m) {
-          const val = m[1];
-          if (arg.pattern && !new RegExp(arg.pattern).test(val)) continue;
-          result[arg.name] = val;
-          break;
-        }
-      }
-    }
-
-    // Try order_id pattern (matches "order id", "order_id", "order:123...")
-    if (keyLower.includes("order_id") && !result[arg.name]) {
-      const m = source.match(/(?:order[_\s]*id\s*[:=]?\s*)([a-f0-9]{24})/i);
-      if (m) result[arg.name] = m[1];
-    }
-
-    // Try event_id pattern (matches "event id", "event_id", "eventId")
-    if (keyLower.includes("event_id") && !result[arg.name]) {
-      const m = source.match(
-        /(?:event[_\s]*id|eventId)\s*[:=]?\s*([a-f0-9]{24})/i
-      );
-      if (m) result[arg.name] = m[1];
-    }
-
-    // Generic fallback: look for values mentioned near the arg name
-    if (!result[arg.name]) {
-      const m = source.match(
-        new RegExp(`${keyLower}\\s*[:=]\\s*([^\\n]+)`, "i")
-      );
-      if (m) {
-        const val = m[1].trim().replace(/[.,;]+$/, "");
-        if (arg.pattern && !new RegExp(arg.pattern).test(val)) continue;
-        result[arg.name] = val;
-      }
-    }
-
-    // Prose extraction for free-text args (no pattern): quoted values or
-    // "called/named/titled X" phrases in the goal. Goal only — history may
-    // contain quoted JSON from prior tool results.
-    if (!result[arg.name] && !arg.pattern) {
-      const quoted = goal.match(/"([^"]{2,120})"|'([^']{2,120})'/);
-      const quotedVal = quoted?.[1] ?? quoted?.[2];
-      if (quotedVal) {
-        result[arg.name] = quotedVal.trim();
-        continue;
-      }
-      const phrase = goal.match(
-        /\b(?:called|named|titled)\s+(?:the\s+|this\s+|an?\s+)?([A-Za-z0-9][^,.!?;]{1,118})/i
-      );
-      if (phrase) {
-        result[arg.name] = phrase[1].trim();
-      }
-    }
-  }
-
-  return result;
-}
 
 export const destroySessionController = catchAsync(
   async (req: Request, res: Response) => {
@@ -215,13 +117,12 @@ export const aiAgentController = catchAsync(
     const trimmedMessage = message.trim();
     const newSessionId = crypto.randomUUID();
     let effectiveSessionId = sessionId || newSessionId;
-    let history = "";
+    let lastTool: NoetixLastTool | undefined;
     let iteration = 0;
     let sessionSuccess = false;
+    let sessionError: string | undefined;
     let finalToolName: string | undefined;
     const allToolNames: string[] = [];
-    let consecutiveFailures = 0;
-    let lastFailedTool: string | undefined;
 
     const logUsage = async () => {
       try {
@@ -232,7 +133,7 @@ export const aiAgentController = catchAsync(
           goal: trimmedMessage,
           tool_names: allToolNames,
           success: sessionSuccess,
-          error: history.includes("error:") ? history.slice(-500) : undefined,
+          error: sessionError,
           iterations: iteration,
           mode: "agent",
         });
@@ -243,15 +144,40 @@ export const aiAgentController = catchAsync(
 
     const maxIterations = await getNoetixMaxIterations();
     const disabledToolNames = new Set(await getNoetixDisabledTools());
-    const tools = getToolRegistry()
-      .filter((t) => !disabledToolNames.has(t.name))
-      .map((t) => ({
-        name: t.name,
-        description: t.description,
-        ...(t.args ? { args: t.args } : {}),
-      }));
+    // Tools are filtered by the admin's role: read-only roles (STANDARD /
+    // NO_ACCESS) get read-permission tools only; others get the tools their
+    // access level satisfies. Disabled tools are excluded.
+    const tools = buildNoetixTools(disabledToolNames, resolvedUserAccess);
+
+    if (tools.length === 0) {
+      return res.status(200).json({
+        success: true,
+        data: {
+          sessionId: effectiveSessionId,
+          persona,
+          result:
+            "No tools are available for your access level. Contact an administrator to enable tools.",
+          history: "",
+          iterations: 0,
+        },
+      });
+    }
 
     const toolLog: ToolCallEntry[] = [];
+
+    const finish = (result: string) => {
+      const cleanHistory = buildCleanToolHistory(toolLog);
+      return res.status(200).json({
+        success: true,
+        data: {
+          sessionId: effectiveSessionId,
+          persona,
+          result,
+          history: cleanHistory,
+          iterations: iteration,
+        },
+      });
+    };
 
     while (iteration < maxIterations) {
       iteration++;
@@ -263,8 +189,10 @@ export const aiAgentController = catchAsync(
           trimmedMessage,
           tools,
           effectiveSessionId,
-          history || undefined,
-          false
+          undefined,
+          false,
+          lastTool,
+          resolvedUserAccess
         );
       } catch (err) {
         if (
@@ -277,8 +205,10 @@ export const aiAgentController = catchAsync(
             trimmedMessage,
             tools,
             undefined,
-            history || undefined,
-            false
+            undefined,
+            false,
+            lastTool,
+            resolvedUserAccess
           );
         } else {
           throw err;
@@ -289,16 +219,34 @@ export const aiAgentController = catchAsync(
       finalToolName = agentResult.data.tools_used;
       if (finalToolName) allToolNames.push(finalToolName);
 
-      if (agentResult.data.isFinished) {
-        sessionSuccess = true;
-        await logUsage();
+      // Noetix v3.1 loop guard: a stuck loop is returned as 200 with a
+      // stuckReason — surface it as a failed session, not a success.
+      const stuckReason = agentResult.data.stuckReason;
+
+      if (agentResult.data.isFinished || stuckReason) {
         const cleanHistory = buildCleanToolHistory(toolLog);
+        if (stuckReason) {
+          sessionSuccess = false;
+          sessionError = `stuck: ${stuckReason}`;
+        } else {
+          sessionSuccess = true;
+        }
+        await logUsage();
+        const result =
+          agentResult.data.final_result ||
+          (stuckReason
+            ? "I could not complete this request — I hit a repeat in my tool loop. Please rephrase with more specific details."
+            : "No tool selected.");
         return res.status(200).json({
           success: true,
           data: {
             sessionId: agentResult.data.sessionId,
             persona: agentResult.data.persona,
-            result: agentResult.data.final_result,
+            result,
+            stuck: Boolean(stuckReason),
+            stuckReason: stuckReason,
+            confidence: agentResult.data.confidence,
+            sources: agentResult.data.sources,
             history: cleanHistory,
             iterations: iteration,
           },
@@ -315,6 +263,8 @@ export const aiAgentController = catchAsync(
             sessionId: agentResult.data.sessionId,
             persona: agentResult.data.persona,
             result: agentResult.data.final_result || "No tool selected.",
+            confidence: agentResult.data.confidence,
+            sources: agentResult.data.sources,
             history: cleanHistory,
             iterations: iteration,
           },
@@ -323,21 +273,84 @@ export const aiAgentController = catchAsync(
 
       const tool = findToolByName(finalToolName);
       if (!tool) {
-        history = `${history} Called ${finalToolName} — error: tool not found.\n`;
+        lastTool = {
+          tool: finalToolName,
+          args: agentResult.data.tool_args ?? {},
+          status: "error",
+          result: "Tool not found in the registry.",
+        };
+        continue;
+      }
+
+      // Disabled tools are never executed (defense in depth — Noetix does
+      // not receive them, but stale session state may still select one).
+      if (disabledToolNames.has(tool.name)) {
+        toolLog.push({
+          tool: finalToolName,
+          success: false,
+          summary: "tool is disabled by an administrator",
+        });
+        await logService.create({
+          admin: req.admin.name,
+          admin_id: req.admin._id,
+          action: `${logs_action.NOETIX_AI_ACTION}: ${tool.name} (blocked — disabled)`,
+          target: "Tool is disabled by an administrator; execution blocked.",
+        });
+        lastTool = {
+          tool: finalToolName,
+          args: agentResult.data.tool_args ?? {},
+          status: "error",
+          result:
+            "This tool is disabled by an administrator and cannot be executed. Pick a different tool or state the request cannot be fulfilled.",
+        };
+        continue;
+      }
+
+      // Noetix v3.1 B1: tool_args are validated server-side. If Noetix
+      // reports invalid args after its self-repair retry, feed the details
+      // back so it can fix them on the next turn instead of guessing.
+      const noetixArgs = agentResult.data.tool_args ?? {};
+      if (agentResult.data.tool_args_valid === false) {
+        const details =
+          (agentResult.data.validation ?? []).join("; ") ||
+          "arguments failed validation";
+        toolLog.push({
+          tool: finalToolName,
+          success: false,
+          summary: `args validation failed: ${details}`,
+        });
+        sessionError = `${finalToolName} args validation failed: ${details}`;
+        lastTool = {
+          tool: finalToolName,
+          args: noetixArgs,
+          status: "error",
+          result: `Invalid arguments: ${details}. Correct the arguments and retry.`,
+        };
+        continue;
+      }
+
+      // Noetix returned no args for a tool that requires them — ask it to
+      // populate them on the next turn.
+      const missingArgs = tool.args?.filter((a) => a.required !== false);
+      if (
+        Object.keys(noetixArgs).length === 0 &&
+        missingArgs &&
+        missingArgs.length > 0
+      ) {
+        const missing = missingArgs.map((a) => a.name).join(", ");
+        lastTool = {
+          tool: finalToolName,
+          args: noetixArgs,
+          status: "error",
+          result: `Missing required argument(s): ${missing}. Provide them and retry.`,
+        };
         continue;
       }
 
       let toolResult: unknown;
-      let resolvedArgs: Record<string, string> | undefined;
       try {
-        const noetixArgs = agentResult.data.tool_args;
-        resolvedArgs =
-          noetixArgs && Object.keys(noetixArgs).length > 0
-            ? (noetixArgs as Record<string, string>)
-            : extractToolArgs(finalToolName, trimmedMessage, history, tool.args);
-
         toolResult = await tool.execute(
-          resolvedArgs,
+          noetixArgs,
           resolvedUserAccess,
           userName
         );
@@ -347,11 +360,12 @@ export const aiAgentController = catchAsync(
           success: true,
           summary: resultSummary,
         });
-        history = `${history} Called ${finalToolName}, result: ${
-          resultSummary.length > 6000
-            ? `${resultSummary.slice(0, 6000)}... (truncated)`
-            : resultSummary
-        }.\n`;
+        lastTool = {
+          tool: finalToolName,
+          args: noetixArgs,
+          status: resultSummary === "null" ? "empty" : "ok",
+          result: resultSummary,
+        };
       } catch (err) {
         const errorMsg =
           err instanceof ToolPermissionError
@@ -364,7 +378,13 @@ export const aiAgentController = catchAsync(
           success: false,
           summary: errorMsg,
         });
-        history = `${history} Called ${finalToolName}, error: ${errorMsg}.\n`;
+        sessionError = `${finalToolName} failed: ${errorMsg}`;
+        lastTool = {
+          tool: finalToolName,
+          args: noetixArgs,
+          status: "error",
+          result: errorMsg,
+        };
 
         if (tool.permission !== "read") {
           await logService.create({
@@ -372,27 +392,6 @@ export const aiAgentController = catchAsync(
             admin_id: req.admin._id,
             action: `${logs_action.NOETIX_AI_ACTION}: ${tool.name} (failed)`,
             target: `Error: ${errorMsg}`,
-          });
-        }
-
-        if (lastFailedTool === finalToolName) {
-          consecutiveFailures++;
-        } else {
-          consecutiveFailures = 1;
-          lastFailedTool = finalToolName;
-        }
-        if (consecutiveFailures >= 2) {
-          sessionSuccess = false;
-          await logUsage();
-          return res.status(200).json({
-            success: true,
-            data: {
-              sessionId: effectiveSessionId,
-              persona,
-              result: `The tool '${finalToolName}' encountered an issue and could not complete the request. Please try again with more details.`,
-              history: buildCleanToolHistory(toolLog),
-              iterations: iteration,
-            },
           });
         }
       }
@@ -406,22 +405,17 @@ export const aiAgentController = catchAsync(
           admin: req.admin.name,
           admin_id: req.admin._id,
           action: `${logs_action.NOETIX_AI_ACTION}: ${tool.name}`,
-          target: `Args: ${JSON.stringify(resolvedArgs)} — Result: ${resultSummary.slice(0, 300)}`,
+          target: `Args: ${JSON.stringify(noetixArgs)} — Result: ${resultSummary.slice(0, 300)}`,
         });
       }
     }
 
+    sessionSuccess = false;
+    sessionError = sessionError ?? "reached max iterations";
     await logUsage();
 
-    return res.status(200).json({
-      success: true,
-      data: {
-        sessionId: effectiveSessionId,
-        persona,
-        result: "I was unable to complete this request within the available steps. Please try rephrasing your question with more specific details.",
-        history: buildCleanToolHistory(toolLog),
-        iterations: iteration,
-      },
-    });
+    return finish(
+      "I was unable to complete this request within the available steps. Please try rephrasing your question with more specific details."
+    );
   }
 );

--- a/server-side/src/models/settings.interface.ts
+++ b/server-side/src/models/settings.interface.ts
@@ -4,5 +4,6 @@ export interface ISettings {
   studentYearLastUpdated?: Date;
   chatbotEnabled?: boolean;
   noetixDisabledAdmins?: string[];
+  noetixDisabledTools?: string[];
   noetixMaxIterations?: number;
 }

--- a/server-side/src/models/settings.model.ts
+++ b/server-side/src/models/settings.model.ts
@@ -22,6 +22,10 @@ const settingsSchema = new Schema<ISettingsDocument>({
     type: [String],
     default: [],
   },
+  noetixDisabledTools: {
+    type: [String],
+    default: [],
+  },
   noetixMaxIterations: {
     type: Number,
     default: 10,

--- a/server-side/src/routes/noetix-chat.v2.route.ts
+++ b/server-side/src/routes/noetix-chat.v2.route.ts
@@ -12,17 +12,24 @@ import { psits_roles } from "../enums/role.enums";
 
 const router = Router();
 
+// All admin access levels may use the Noetix chat; tool availability is
+// filtered per role server-side (read-only roles get read-permission tools
+// only — see buildNoetixTools in chat-tool.types.ts).
+const NOETIX_ALLOWED_ACCESS = [
+  psits_roles.ADMIN,
+  psits_roles.FINANCE,
+  psits_roles.DEVELOPER,
+  psits_roles.EXECUTIVE,
+  psits_roles.HEAD_FINANCE,
+  psits_roles.STANDARD,
+  psits_roles.NO_ACCESS,
+];
+
 router.post(
   "/ai-agent",
   requireAccessTokenV2,
   roleAuthenticateV2(["admin"]),
-  adminAccessAuthenticateV2([
-    psits_roles.ADMIN,
-    psits_roles.FINANCE,
-    psits_roles.DEVELOPER,
-    psits_roles.EXECUTIVE,
-    psits_roles.HEAD_FINANCE,
-  ]),
+  adminAccessAuthenticateV2(NOETIX_ALLOWED_ACCESS),
   aiAgentController
 );
 
@@ -30,13 +37,7 @@ router.post(
   "/session/destroy",
   requireAccessTokenV2,
   roleAuthenticateV2(["admin"]),
-  adminAccessAuthenticateV2([
-    psits_roles.ADMIN,
-    psits_roles.FINANCE,
-    psits_roles.DEVELOPER,
-    psits_roles.EXECUTIVE,
-    psits_roles.HEAD_FINANCE,
-  ]),
+  adminAccessAuthenticateV2(NOETIX_ALLOWED_ACCESS),
   destroySessionController
 );
 

--- a/server-side/src/services/automation.service.ts
+++ b/server-side/src/services/automation.service.ts
@@ -334,10 +334,9 @@ const queueReportEmail = async (
     const noetixData = compressResultsForNoetix(results);
     try {
       const noetixMarkdown = await (async () => {
-        const tools = (await import("../types/chat-tool.types")).getToolRegistry().map((t) => ({
-          name: t.name,
-          description: t.description,
-        }));
+        const tools = (
+          await import("../types/chat-tool.types")
+        ).buildNoetixTools(new Set(), psits_roles.ADMIN);
         const res = await queryNoetixAiAgent(
           "EMAIL_SENDER",
           `Generate a professional daily operational report for "${job.name}". Include key metrics, highlights, and any concerns from the data below.`,

--- a/server-side/src/services/devtools.service.ts
+++ b/server-side/src/services/devtools.service.ts
@@ -760,6 +760,7 @@ export const getNoetixToolRegistry = async (): Promise<
     name: string;
     description: string;
     permission: string;
+    risk: "read" | "write";
     category: string;
   }>
 > => {
@@ -768,6 +769,7 @@ export const getNoetixToolRegistry = async (): Promise<
     name: t.name,
     description: t.description,
     permission: t.permission,
+    risk: t.permission === "read" ? "read" : "write",
     category: t.category,
   }));
 };
@@ -776,16 +778,14 @@ export const addNoetixDisabledTool = async (
   toolName: string
 ): Promise<string[]> => {
   const { Settings } = await import("../models/settings.model");
-  const existing = await Settings.find();
 
-  if (existing.length === 0) {
-    await new Settings({ noetixDisabledTools: [toolName] }).save();
-    return [toolName];
-  }
-
+  // Deterministic singleton writer: no filter so the write always targets
+  // the same first document the reader (Settings.findOne) sees, and upsert
+  // creates it when the collection is empty. $addToSet keeps it idempotent.
   await Settings.updateOne(
-    { noetixDisabledTools: { $ne: toolName } },
-    { $addToSet: { noetixDisabledTools: toolName } }
+    {},
+    { $addToSet: { noetixDisabledTools: toolName } },
+    { upsert: true }
   );
 
   const updated = await Settings.findOne().lean();

--- a/server-side/src/services/noetix-chat.service.ts
+++ b/server-side/src/services/noetix-chat.service.ts
@@ -1,24 +1,49 @@
-interface NoetixAiAgentResponse {
+import type { NoetixTool } from "../types/chat-tool.types";
+
+// Result of the tool the caller just executed (Noetix v3.1 structured
+// ledger handoff, preferred over legacy free-text `history`).
+export interface NoetixLastTool {
+  tool: string;
+  args: Record<string, unknown>;
+  status: "ok" | "error" | "empty";
+  result: string;
+}
+
+export interface NoetixAiAgentData {
+  sessionId: string;
+  persona: string;
+  isFinished: boolean;
+  final_result: string;
+  tools_used: string;
+  history: string;
+  sessionTTL: number;
+  tool_args?: Record<string, unknown>;
+  // ── v3.1 additions (all optional; older Noetix instances omit them) ──
+  plan?: Array<Record<string, unknown>>;
+  plan_revision?: Record<string, unknown>;
+  turns_used?: number;
+  tool_args_valid?: boolean;
+  validation?: string[];
+  sources?: string[];
+  confidence?: "high" | "medium" | "low";
+  stuckReason?: string;
+  tools_changed?: boolean;
+}
+
+export interface NoetixAiAgentResponse {
   success: boolean;
-  data: {
-    sessionId: string;
-    persona: string;
-    isFinished: boolean;
-    final_result: string;
-    tools_used: string;
-    history: string;
-    sessionTTL: number;
-    tool_args?: Record<string, unknown>;
-  };
+  data: NoetixAiAgentData;
 }
 
 export const queryNoetixAiAgent = async (
   persona: string,
   goal: string,
-  tools: Array<{ name: string; description: string }>,
+  tools: NoetixTool[],
   sessionId?: string,
   history?: string,
-  destroy?: boolean
+  destroy?: boolean,
+  lastTool?: NoetixLastTool,
+  adminAccess?: string
 ): Promise<NoetixAiAgentResponse> => {
   const noetixUrl = process.env.NOETIX_URL || "http://localhost:3000";
   const apiKey = process.env.NOETIX_API_KEY;
@@ -27,16 +52,22 @@ export const queryNoetixAiAgent = async (
     throw new Error("NOETIX_API_KEY is not configured");
   }
 
-  // context.tools and goal are required on EVERY call (Noetix rejects
-  // requests missing them with INVALID_REQUEST); history carries prior results.
+  // context.tools and goal are required on every call (Noetix rejects
+  // requests missing them with INVALID_REQUEST). `lastTool` carries the
+  // structured result of the previous tool execution (Noetix v3.1);
+  // `history` is the legacy free-text form, still normalized by Noetix.
   const body: Record<string, unknown> = {
     persona,
     goal,
-    context: { tools },
+    context: {
+      tools,
+      ...(adminAccess ? { adminAccess } : {}),
+    },
   };
 
   if (sessionId) body.sessionId = sessionId;
   if (history) body.history = history;
+  if (lastTool) body.lastTool = lastTool;
   if (destroy) body.destroy = true;
 
   const response = await fetch(`${noetixUrl}/api/ai-agent`, {

--- a/server-side/src/types/chat-tool.types.ts
+++ b/server-side/src/types/chat-tool.types.ts
@@ -90,13 +90,81 @@ export interface ChatTool {
   description: string;
   category: string;
   permission: ToolPermission;
-  args?: Array<{ name: string; description: string; pattern?: string }>;
+  args?: Array<{
+    name: string;
+    description: string;
+    pattern?: string;
+    /** Noetix v3.1 B1: args are required unless marked `required: false`. */
+    required?: boolean;
+  }>;
   execute: (
     args: unknown,
     userAccess: string,
     userName: string
   ) => Promise<unknown>;
 }
+
+// Noetix-contract tool payload (v3.1 B2: access + risk metadata).
+export interface NoetixTool {
+  name: string;
+  description: string;
+  access: ToolPermission;
+  risk: "read" | "write";
+  args?: Array<{
+    name: string;
+    description: string;
+    pattern?: string;
+    required?: boolean;
+  }>;
+}
+
+// Roles that may only reach read-permission tools in the Noetix chat.
+const READ_ONLY_ROLES: readonly string[] = [
+  psits_roles.STANDARD,
+  psits_roles.NO_ACCESS,
+];
+
+export const isRoleReadOnly = (access: string): boolean => {
+  const role = normalizeAccessKey(access);
+  return READ_ONLY_ROLES.includes(role);
+};
+
+export const canRoleUseTool = (
+  access: string,
+  permission: ToolPermission
+): boolean => {
+  if (permission === "read") return true;
+  const role = normalizeAccessKey(access);
+  if (READ_ONLY_ROLES.includes(role)) return false;
+  return PERMISSION_MAP[permission].includes(role);
+};
+
+const buildNoetixTool = (tool: ChatTool): NoetixTool => ({
+  name: tool.name,
+  description: tool.description,
+  access: tool.permission,
+  risk: tool.permission === "read" ? "read" : "write",
+  ...(tool.args
+    ? {
+        args: tool.args.map((arg) => ({
+          name: arg.name,
+          description: arg.description,
+          ...(arg.pattern ? { pattern: arg.pattern } : {}),
+          ...(arg.required === false ? { required: false } : {}),
+        })),
+      }
+    : {}),
+});
+
+// Tools Noetix may offer for a given admin: not disabled, and the admin's
+// role satisfies the tool's permission (read-only roles get read tools only).
+export const buildNoetixTools = (
+  disabled: Set<string>,
+  access: string
+): NoetixTool[] =>
+  TOOL_REGISTRY.filter(
+    (t) => !disabled.has(t.name) && canRoleUseTool(access, t.permission)
+  ).map(buildNoetixTool);
 
 // ─── Read Tools (50) ─────────────────────────────────────────────────────────
 
@@ -251,14 +319,14 @@ const readTools: ChatTool[] = [
   {
     name: "find_student",
     description:
-      "Searches for student by name using a partial wildcard match, so incomplete names still find results. Returns matching students with their ID number, name, course, year, and campus. And use it to other tools add_attendee, create order, approve order, and more. Note that you need to provide the partial name of the student you want to search for, and it will return a list of matching students. Do not call this tool without a name argument, as it will throw an error. Use the returned ID number to perform other actions on the student.",
+      "Searches for student by name using wildcard (substring) matching on first_name, middle_name, and last_name, so incomplete names still find results. For multi-word searches, ALL words must match one of the name fields (order-independent), e.g. 'john smi' finds 'John Smith' but not 'John Doe'. Pasting a full or partial ID number also resolves the student via an id_number prefix wildcard. Returns matching students with their ID number, name, course, year, and campus. And use it to other tools add_attendee, create order, approve order, and more. Note that you need to provide the partial name of the student you want to search for, and it will return a list of matching students. Do not call this tool without a name argument, as it will throw an error. Use the returned ID number to perform other actions on the student.",
     category: "Students",
     permission: "read",
     args: [
       {
         name: "name",
         description:
-          "Full or partial student name to search for. Supports incomplete names.",
+          "Full or partial student name to search for. For multi-word input, every word must match the name. Partial or full ID numbers also work.",
       },
     ],
     execute: async (args: unknown) => {
@@ -268,19 +336,27 @@ const readTools: ChatTool[] = [
       const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
       const projection =
         "id_number first_name middle_name last_name course year campus status -_id";
-      // Match any word against name fields so partial or multi-word
-      // queries like "john" or "john smi" still find "John Smith".
-      // id_number is included so pasting an ID also resolves the student.
+      // AND-of-clauses wildcard: every word must match at least one name
+      // field (first/middle/last), order-independent — "john smi" finds
+      // "John Smith" but not "John Doe". Numeric words additionally match
+      // id_number by prefix wildcard, so pasting a (partial) ID still
+      // resolves the student.
       const words = escaped.split(/\s+/).filter(Boolean);
+      const clauses = words.map((word) => {
+        const or: Array<Record<string, unknown>> = [
+          { first_name: new RegExp(word, "i") },
+          { middle_name: new RegExp(word, "i") },
+          { last_name: new RegExp(word, "i") },
+        ];
+        if (/^\d+$/.test(word)) {
+          or.push({ id_number: new RegExp(`^${word}`, "i") });
+        }
+        return { $or: or };
+      });
+      const filter =
+        clauses.length === 1 ? clauses[0] : ({ $and: clauses } as Record<string, unknown>);
       const students = await Student.find(
-        {
-          $or: words.flatMap((word) => [
-            { first_name: new RegExp(word, "i") },
-            { middle_name: new RegExp(word, "i") },
-            { last_name: new RegExp(word, "i") },
-            { id_number: new RegExp(`^${word}`, "i") },
-          ]),
-        },
+        filter,
         projection
       )
         .limit(25)
@@ -400,6 +476,56 @@ const readTools: ChatTool[] = [
       }
     },
   },
+  {
+    name: "get_pending_memberships_list",
+    description:
+      "Returns a paginated list of students with PENDING membership status (id_number, name, course, year, campus). Use limit (default 20, max 50) and skip (default 0) to paginate.",
+    category: "Memberships",
+    permission: "read",
+    args: [
+      {
+        name: "limit",
+        description: "Number of students to return (default 20, max 50).",
+        pattern: "^\\d+$",
+        required: false,
+      },
+      {
+        name: "skip",
+        description: "Number of students to skip for pagination (default 0).",
+        pattern: "^\\d+$",
+        required: false,
+      },
+    ],
+    execute: async (args: unknown) => {
+      const parsed = args as { limit?: string; skip?: string };
+      const limit = Math.min(parseInt(parsed.limit ?? "20", 10) || 20, 50);
+      const skip = parseInt(parsed.skip ?? "0", 10) || 0;
+      const total = await Student.countDocuments({
+        membershipStatus: membership_status.PENDING,
+      });
+      const students = await Student.find({
+        membershipStatus: membership_status.PENDING,
+      })
+        .select("id_number first_name middle_name last_name course year campus -_id")
+        .sort({ createdAt: 1 })
+        .skip(skip)
+        .limit(limit)
+        .lean();
+      return {
+        total,
+        limit,
+        skip,
+        returned: students.length,
+        students: students.map((s) => ({
+          id_number: s.id_number,
+          name: studentService.fullNameFormat(s),
+          course: s.course,
+          year: s.year,
+          campus: s.campus,
+        })),
+      };
+    },
+  },
 
   // ── Orders & Payments (10) ─────────────────────────────────────────────────
   {
@@ -436,11 +562,13 @@ const readTools: ChatTool[] = [
         name: "limit",
         description: "Number of orders to return (default 20, max 100).",
         pattern: "^\\d+$",
+        required: false,
       },
       {
         name: "skip",
         description: "Number of orders to skip for pagination (default 0).",
         pattern: "^\\d+$",
+        required: false,
       },
     ],
     execute: async (args: unknown) => {
@@ -496,6 +624,74 @@ const readTools: ChatTool[] = [
     category: "Orders",
     permission: "read",
     execute: () => Orders.countDocuments({ order_status: "Refunded" }),
+  },
+  {
+    name: "get_orders_by_status",
+    description:
+      "Returns a paginated list of orders filtered by status (Paid, Pending, or Refunded) with order_id, student name/id_number/course/year, items, total, and order_date. Use limit (default 20, max 100) and skip (default 0) to paginate. Do not return all orders at once — paginate using skip.",
+    category: "Orders",
+    permission: "read",
+    args: [
+      {
+        name: "status",
+        description: "Order status to list: Paid, Pending, or Refunded.",
+        pattern: "^(Paid|Pending|Refunded)$",
+      },
+      {
+        name: "limit",
+        description: "Number of orders to return (default 20, max 100).",
+        pattern: "^\\d+$",
+        required: false,
+      },
+      {
+        name: "skip",
+        description: "Number of orders to skip for pagination (default 0).",
+        pattern: "^\\d+$",
+        required: false,
+      },
+    ],
+    execute: async (args: unknown) => {
+      const parsed = args as { status?: string; limit?: string; skip?: string };
+      const status = parsed.status?.trim();
+      if (!status) throw new Error("status is required");
+      const limit = Math.min(parseInt(parsed.limit ?? "20", 10) || 20, 100);
+      const skip = parseInt(parsed.skip ?? "0", 10) || 0;
+      const total = await Orders.countDocuments({ order_status: status });
+      const orders = await Orders.find({ order_status: status })
+        .sort({ order_date: -1 })
+        .skip(skip)
+        .limit(limit)
+        .lean();
+      return {
+        total,
+        limit,
+        skip,
+        returned: orders.length,
+        orders: orders.map((o) => ({
+          order_id: o._id.toString(),
+          student: {
+            name: o.student_name,
+            id_number: o.id_number,
+            course: o.course,
+            year: o.year,
+          },
+          items: (
+            o.items as Array<{
+              product_name: string;
+              quantity: number;
+              sub_total: number;
+            }>
+          ).map((item) => ({
+            product_name: item.product_name,
+            quantity: item.quantity,
+            sub_total: item.sub_total,
+          })),
+          total: o.total,
+          order_date: o.order_date,
+          reference_code: o.reference_code,
+        })),
+      };
+    },
   },
   {
     name: "get_total_order_revenue",
@@ -594,6 +790,58 @@ const readTools: ChatTool[] = [
           { $sort: { totalQuantity: -1 } },
           { $limit: 5 },
           { $project: { product_name: "$_id", totalQuantity: 1, _id: 0 } },
+        ]);
+        return result ?? [];
+      } catch {
+        return [];
+      }
+    },
+  },
+  {
+    name: "get_top_sellers_by_period",
+    description:
+      "Returns the top 5 best-selling products by quantity within the last N days (default 30). Use this for recent trends instead of all-time totals.",
+    category: "Orders",
+    permission: "read",
+    args: [
+      {
+        name: "days",
+        description:
+          "Look-back period in days (default 30, max 365). Must be a whole number.",
+        pattern: "^\\d+$",
+        required: false,
+      },
+    ],
+    execute: async (args: unknown) => {
+      const parsed = args as { days?: string };
+      const days = Math.min(parseInt(parsed.days ?? "30", 10) || 30, 365);
+      const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+      try {
+        const result = await Orders.aggregate([
+          {
+            $match: {
+              order_status: "Paid",
+              transaction_date: { $gte: since },
+            },
+          },
+          { $unwind: "$items" },
+          {
+            $group: {
+              _id: "$items.product_name",
+              totalQuantity: { $sum: "$items.quantity" },
+              totalRevenue: { $sum: "$items.sub_total" },
+            },
+          },
+          { $sort: { totalQuantity: -1 } },
+          { $limit: 5 },
+          {
+            $project: {
+              product_name: "$_id",
+              totalQuantity: 1,
+              totalRevenue: 1,
+              _id: 0,
+            },
+          },
         ]);
         return result ?? [];
       } catch {
@@ -771,6 +1019,59 @@ const readTools: ChatTool[] = [
       }
     },
   },
+  {
+    name: "get_merch_on_sale_list",
+    description:
+      "Returns active merchandise products currently on sale (start_date <= now <= end_date) with product_id, name, price, stock, category, and type. Optionally filter by category. Use this to know which products can be ordered right now.",
+    category: "Merch",
+    permission: "read",
+    args: [
+      {
+        name: "category",
+        description: "Optional merch category to filter results.",
+        required: false,
+      },
+      {
+        name: "limit",
+        description: "Number of products to return (default 20, max 50).",
+        pattern: "^\\d+$",
+        required: false,
+      },
+    ],
+    execute: async (args: unknown) => {
+      const parsed = args as { category?: string; limit?: string };
+      const limit = Math.min(parseInt(parsed.limit ?? "20", 10) || 20, 50);
+      const filter: Record<string, unknown> = {
+        is_active: true,
+        start_date: { $lte: new Date() },
+        end_date: { $gte: new Date() },
+      };
+      const category = parsed.category?.trim();
+      if (category) {
+        const escaped = category.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        filter.category = new RegExp(`^${escaped}$`, "i");
+      }
+      const products = await Merch.find(
+        filter,
+        "_id name price stocks category type start_date end_date"
+      )
+        .limit(limit)
+        .lean();
+      return {
+        count: products.length,
+        products: products.map((p) => ({
+          product_id: p._id.toString(),
+          name: p.name,
+          price: p.price,
+          stocks: p.stocks,
+          category: p.category,
+          type: p.type,
+          start_date: p.start_date,
+          end_date: p.end_date,
+        })),
+      };
+    },
+  },
 
   // ── Events (5) ─────────────────────────────────────────────────────────────
   {
@@ -790,6 +1091,7 @@ const readTools: ChatTool[] = [
       {
         name: "event_name",
         description: "Optional event name to filter results.",
+        required: false,
       },
     ],
     execute: async (args: unknown) => {
@@ -883,6 +1185,45 @@ const readTools: ChatTool[] = [
       } catch {
         return 0;
       }
+    },
+  },
+  {
+    name: "get_events_by_date",
+    description:
+      "Returns all events on a given date (event name, event_id, description, status, total revenue, and attendee count). Date is YYYY-MM-DD (e.g. 2026-12-31).",
+    category: "Events",
+    permission: "read",
+    args: [
+      {
+        name: "event_date",
+        description: "Event date in YYYY-MM-DD format.",
+        pattern: "^\\d{4}-\\d{2}-\\d{2}$",
+      },
+    ],
+    execute: async (args: unknown) => {
+      const parsed = args as { event_date?: string };
+      if (!parsed.event_date) throw new Error("event_date is required");
+      const dayStart = startOfDay(new Date(parsed.event_date));
+      if (isNaN(dayStart.getTime()))
+        throw new Error("event_date is not a valid date");
+      const dayEnd = endOfDay(dayStart);
+      const events = await Event.find(
+        { eventDate: { $gte: dayStart, $lte: dayEnd } },
+        "eventId eventName eventDescription eventDate status totalRevenueAll attendees -_id"
+      ).lean();
+      return {
+        count: events.length,
+        events: events.map((e) => ({
+          event_id: e.eventId?.toString(),
+          name: e.eventName,
+          date: e.eventDate,
+          status: e.status,
+          total_revenue: e.totalRevenueAll,
+          attendees: (
+            e.attendees as unknown as Array<Record<string, unknown>>
+          ).length,
+        })),
+      };
     },
   },
 
@@ -1235,6 +1576,55 @@ const readTools: ChatTool[] = [
     },
   },
   {
+    name: "get_refund_detail_by_order",
+    description:
+      "Returns the refund record (refund_id, refund_price, refunded by, refund date) and a snapshot of the original order (total, status, student) for a given order _id. Requires ADMIN or FINANCE access.",
+    category: "Orders",
+    permission: "admin_finance",
+    args: [
+      {
+        name: "order_id",
+        description: "MongoDB ObjectId of the order.",
+        pattern: "^[a-f0-9]{24}$",
+      },
+    ],
+    execute: async (args: unknown, userAccess: string) => {
+      checkPermission("admin_finance", userAccess);
+      const parsed = args as { order_id?: string };
+      if (!parsed.order_id) throw new Error("order_id is required");
+      const oid = new Types.ObjectId(parsed.order_id);
+      const [refund, order] = await Promise.all([
+        Refund.findOne({ order_id: oid }).lean(),
+        Orders.findById(oid)
+          .select(
+            "order_status total student_name id_number order_date reference_code"
+          )
+          .lean(),
+      ]);
+      if (!refund && !order) throw new Error("Order not found");
+      return {
+        refund: refund
+          ? {
+              refund_id: refund._id.toString(),
+              refund_price: refund.refund_price,
+              refunded_by: refund.refund_admin,
+              refund_date: refund.refund_date,
+            }
+          : null,
+        order: order
+          ? {
+              order_id: order._id.toString(),
+              order_status: order.order_status,
+              total: order.total,
+              student_name: order.student_name,
+              id_number: order.id_number,
+              order_date: order.order_date,
+            }
+          : null,
+      };
+    },
+  },
+  {
     name: "get_refunds_today",
     description: "Returns the count of refunds processed today.",
     category: "Orders",
@@ -1358,11 +1748,13 @@ const readTools: ChatTool[] = [
         name: "event_id",
         description: "MongoDB ObjectId of the event.",
         pattern: "^[a-f0-9]{24}$",
+        required: false,
       },
       {
         name: "event_name",
         description:
           "Optional event name to identify the event instead of event_id.",
+        required: false,
       },
     ],
     execute: async (args: unknown) => {
@@ -1589,6 +1981,54 @@ const readTools: ChatTool[] = [
         Admin.countDocuments({ status: account_status.SUSPENDED })
       ),
   },
+  {
+    name: "get_admins_by_access",
+    description:
+      "Returns the list of active admins for a given access level (id_number, name, position, access, email). Access is one of: ADMIN, FINANCE, DEVELOPER, EXECUTIVE, HEAD_FINANCE, STANDARD, or NO_ACCESS. Requires ADMIN access.",
+    category: "Admin",
+    permission: "admin_only",
+    args: [
+      {
+        name: "access",
+        description:
+          "Access level to list admins for: ADMIN, FINANCE, DEVELOPER, EXECUTIVE, HEAD_FINANCE, STANDARD, or NO_ACCESS.",
+        pattern:
+          "^(ADMIN|FINANCE|DEVELOPER|EXECUTIVE|HEAD_FINANCE|STANDARD|NO_ACCESS)$",
+      },
+      {
+        name: "limit",
+        description: "Number of admins to return (default 20, max 50).",
+        pattern: "^\\d+$",
+        required: false,
+      },
+    ],
+    execute: async (args: unknown, userAccess: string) => {
+      checkPermission("admin_only", userAccess);
+      const parsed = args as { access?: string; limit?: string };
+      const accessKey = parsed.access?.trim().toUpperCase();
+      if (!accessKey) throw new Error("access is required");
+      const ACCESS_TO_ROLE: Record<string, string> = {
+        ADMIN: psits_roles.ADMIN,
+        FINANCE: psits_roles.FINANCE,
+        DEVELOPER: psits_roles.DEVELOPER,
+        EXECUTIVE: psits_roles.EXECUTIVE,
+        HEAD_FINANCE: psits_roles.HEAD_FINANCE,
+        STANDARD: psits_roles.STANDARD,
+        NO_ACCESS: psits_roles.NO_ACCESS,
+      };
+      const role = ACCESS_TO_ROLE[accessKey];
+      if (!role) throw new Error("Unknown access level");
+      const limit = Math.min(parseInt(parsed.limit ?? "20", 10) || 20, 50);
+      const admins = await Admin.find({
+        status: account_status.ACTIVE,
+        access: role,
+      })
+        .select("id_number name position access email -_id")
+        .limit(limit)
+        .lean();
+      return { count: admins.length, admins };
+    },
+  },
 
   // ── Membership Extra (2) ───────────────────────────────────────────────────
   {
@@ -1640,22 +2080,26 @@ const writeTools: ChatTool[] = [
         description:
           "Student ID number to create the order for. Composed of 8 digits. Required unless id_numbers is provided.",
         pattern: "^\\d{8}$",
+        required: false,
       },
       {
         name: "id_numbers",
         description:
           'Comma-separated list of student ID numbers (e.g. "20230001, 20230002") to create the same order for multiple students. Each student gets their own separate order. Required unless id_number is provided.',
+        required: false,
       },
       {
         name: "product_id",
         description:
           "MongoDB ObjectId of the product. Required unless product_name is provided.",
         pattern: "^[a-f0-9]{24}$",
+        required: false,
       },
       {
         name: "product_name",
         description:
           "Name of the product. Required unless product_id is provided.",
+        required: false,
       },
       {
         name: "quantity",
@@ -1667,11 +2111,13 @@ const writeTools: ChatTool[] = [
         name: "size",
         description:
           "Optional t-shirt size (e.g. S, M, L, XL). Only applies if the product has sizes.",
+        required: false,
       },
       {
         name: "color",
         description:
           "Optional color variation. Only applies if the product has color variations.",
+        required: false,
       },
     ],
     execute: async (args: unknown, userAccess: string) => {
@@ -1876,6 +2322,7 @@ const writeTools: ChatTool[] = [
         description:
           "Cash amount received (defaults to order total if omitted).",
         pattern: "^\\d+(\\.\\d+)?$",
+        required: false,
       },
     ],
     execute: async (args: unknown, userAccess: string, userName: string) => {
@@ -2081,11 +2528,13 @@ const writeTools: ChatTool[] = [
         name: "event_id",
         description: "Event eventId string.",
         pattern: "^[a-f0-9]{24}$",
+        required: false,
       },
       {
         name: "event_name",
         description:
           "Optional event name to identify the event instead of event_id.",
+        required: false,
       },
       {
         name: "id_number",
@@ -2119,11 +2568,13 @@ const writeTools: ChatTool[] = [
         name: "event_id",
         description: "Event eventId string.",
         pattern: "^[a-f0-9]{24}$",
+        required: false,
       },
       {
         name: "event_name",
         description:
           "Optional event name to identify the event instead of event_id.",
+        required: false,
       },
       {
         name: "id_number",
@@ -2170,11 +2621,13 @@ const writeTools: ChatTool[] = [
         name: "event_id",
         description: "Event eventId string.",
         pattern: "^[a-f0-9]{24}$",
+        required: false,
       },
       {
         name: "event_name",
         description:
           "Optional event name to identify the event instead of event_id.",
+        required: false,
       },
       {
         name: "id_number",
@@ -2186,6 +2639,7 @@ const writeTools: ChatTool[] = [
         description:
           "Session to mark: morning, afternoon, or evening. Defaults to morning.",
         pattern: "^(morning|afternoon|evening)$",
+        required: false,
       },
     ],
     execute: async (args: unknown, userAccess: string) => {
@@ -2463,10 +2917,12 @@ const writeTools: ChatTool[] = [
         name: "start_date",
         description:
           "Optional start date for sale (ISO date string). Defaults to now.",
+        required: false,
       },
       {
         name: "end_date",
         description: "Optional end date for sale (ISO date string).",
+        required: false,
       },
     ],
     execute: async (args: unknown, userAccess: string) => {
@@ -2532,18 +2988,20 @@ const writeTools: ChatTool[] = [
         description: "MongoDB ObjectId of the product to edit.",
         pattern: "^[a-f0-9]{24}$",
       },
-      { name: "name", description: "New product name." },
+      { name: "name", description: "New product name.", required: false },
       {
         name: "price",
         description: "New price as a non-negative number.",
         pattern: "^\\d+(\\.\\d+)?$",
+        required: false,
       },
       {
         name: "stocks",
         description: "New stock count.",
         pattern: "^\\d+$",
+        required: false,
       },
-      { name: "category", description: "New category." },
+      { name: "category", description: "New category.", required: false },
     ],
     execute: async (args: unknown, userAccess: string) => {
       checkPermission("admin_finance", userAccess);
@@ -2626,8 +3084,12 @@ const writeTools: ChatTool[] = [
         name: "event_date",
         description: "Event date as ISO date string (e.g. 2026-12-31).",
       },
-      { name: "event_venue", description: "Event venue location." },
-      { name: "event_theme", description: "Event theme." },
+      { name: "event_venue", description: "Event venue location.", required: false },
+      {
+        name: "event_theme",
+        description: "Event theme.",
+        required: false,
+      },
     ],
     execute: async (args: unknown, userAccess: string) => {
       checkPermission("admin_only", userAccess);
@@ -2714,8 +3176,8 @@ const writeTools: ChatTool[] = [
         name: "scheduled_at",
         description: "Interview date/time as ISO date string.",
       },
-      { name: "location", description: "Interview location." },
-      { name: "notes", description: "Optional interview notes." },
+      { name: "location", description: "Interview location.", required: false },
+      { name: "notes", description: "Optional interview notes.", required: false },
     ],
     execute: async (args: unknown, userAccess: string) => {
       checkPermission("admin_full", userAccess);
@@ -2893,11 +3355,16 @@ const writeTools: ChatTool[] = [
         description: "MongoDB ObjectId of the recruitment position.",
         pattern: "^[a-f0-9]{24}$",
       },
-      { name: "title", description: "New position title." },
-      { name: "description", description: "New position description." },
+      { name: "title", description: "New position title.", required: false },
+      {
+        name: "description",
+        description: "New position description.",
+        required: false,
+      },
       {
         name: "requirements",
         description: "Comma-separated list of requirements.",
+        required: false,
       },
     ],
     execute: async (args: unknown, userAccess: string) => {


### PR DESCRIPTION
- Added `noetixDisabledTools` property to ISettings interface and settings schema.
- Updated Noetix chat route to use a centralized access level constant for admin roles.
- Refactored automation service to build Noetix tools with role-based access.
- Enhanced devtools service to manage disabled tools with upsert functionality.
- Expanded Noetix chat service to include structured tool execution results.
- Introduced new Noetix tool interface with risk metadata and updated tool registry.
- Added multiple new read tools for fetching students, orders, events, and admins.
- Improved existing tools with pagination and filtering capabilities.